### PR TITLE
Implementing the full Ship API

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/world/MixinLevel.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/world/MixinLevel.java
@@ -1,0 +1,25 @@
+package org.valkyrienskies.mod.mixin.world;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.core.game.ships.ShipDataCommon;
+import org.valkyrienskies.mod.api.BlockEntityShipProvider;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Mixin(Level.class)
+public class MixinLevel {
+
+    @Inject(method = "setBlockEntity", at = @At("HEAD"))
+    public void onSetBlockEntity(final BlockPos blockPos, final BlockEntity blockEntity, final CallbackInfo ci) {
+        final ShipDataCommon data = VSGameUtilsKt.getShipManagingPos((Level) (Object) this, blockPos);
+        if (data != null && blockEntity instanceof BlockEntityShipProvider) {
+            ((BlockEntityShipProvider) blockEntity).setShip(data);
+        }
+    }
+
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/api/BlockEntityShipProvider.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/api/BlockEntityShipProvider.kt
@@ -1,22 +1,11 @@
 package org.valkyrienskies.mod.api
 
-import net.minecraft.core.BlockPos
-import net.minecraft.world.level.Level
-import net.minecraft.world.level.block.entity.BlockEntity
 import org.valkyrienskies.core.api.Ship
 import org.valkyrienskies.core.api.ShipProvider
-import org.valkyrienskies.core.game.ships.ShipObject
 
 interface BlockEntityShipProvider : ShipProvider {
-    override var ship: Ship?
-
     /**
-     * Gets called on block entity creation and relocation
-     *  the actual new [BlockPos], [Ship] and [Level] shall be assigned
-     *  on this [BlockEntity] after this call
-     * @param newPos
-     * @param newLevel
-     * @param newShip
+     * Ship for the block entity, it will be set on creation
      */
-    fun onShipChange(newPos: BlockPos, newLevel: Level, newShip: ShipObject) {}
+    override var ship: Ship?
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/item/ShipCreatorItem.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/item/ShipCreatorItem.kt
@@ -31,7 +31,7 @@ class ShipCreatorItem(properties: Properties, private val scale: Double) : Item(
                 val centerPos = shipData.chunkClaim.getCenterBlockCoordinates(Vector3i()).toBlockPos()
 
                 // Move the block from the world to a ship
-                level.relocateBlock(blockPos, centerPos)
+                level.relocateBlock(blockPos, centerPos, shipData)
             }
         }
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/RelocationUtil.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/RelocationUtil.kt
@@ -7,11 +7,13 @@ import net.minecraft.world.level.Level
 import net.minecraft.world.level.block.Blocks
 import net.minecraft.world.level.chunk.LevelChunk
 import net.minecraft.world.level.chunk.LevelChunk.EntityCreationType.CHECK
+import org.valkyrienskies.core.api.Ship
+import org.valkyrienskies.mod.api.BlockEntityShipProvider
 
 private val AIR = Blocks.AIR.defaultBlockState()
 
 // the from and the to can be local or global
-fun relocateBlock(fromChunk: LevelChunk, from: BlockPos, toChunk: LevelChunk, to: BlockPos) {
+fun relocateBlock(fromChunk: LevelChunk, from: BlockPos, toChunk: LevelChunk, to: BlockPos, toShip: Ship) {
     val state = fromChunk.getBlockState(from)
     val entity = fromChunk.getBlockEntity(from)
 
@@ -34,9 +36,13 @@ fun relocateBlock(fromChunk: LevelChunk, from: BlockPos, toChunk: LevelChunk, to
     toChunk.setBlockState(to, state, false) // TODO should isMoving be false?
 
     tag?.let {
-        toChunk.getBlockEntity(to, CHECK)!!.load(state, tag)
+        val be = toChunk.getBlockEntity(to, CHECK)!!
+        if (be is BlockEntityShipProvider)
+            be.ship = toShip
+
+        be.load(state, it)
     }
 }
 
-fun Level.relocateBlock(from: BlockPos, to: BlockPos) =
-    relocateBlock(getChunkAt(from), from, getChunkAt(to), to)
+fun Level.relocateBlock(from: BlockPos, to: BlockPos, toShip: Ship) =
+    relocateBlock(getChunkAt(from), from, getChunkAt(to), to, toShip)


### PR DESCRIPTION
So in my PR I made the ship API and implemented the obvious things.
But I also had in that PR BlockEntityShipProvider, and this was not implmented yet.
The idea of that API was so that BlockEntities can hook easily on ships and are automatically set on changes.
So this PR is for that

_and implementing Ship interface in ShipCommon 👀 _