### PR TITLE
Fix beds

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/bed_fix/MixinServerPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/bed_fix/MixinServerPlayer.java
@@ -1,0 +1,42 @@
+package org.valkyrienskies.mod.mixin.feature.bed_fix;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Mixin(ServerPlayer.class)
+public abstract class MixinServerPlayer extends Entity {
+
+    public MixinServerPlayer(final EntityType<?> entityType, final Level level) {
+        super(entityType, level);
+    }
+
+    @Inject(
+        at = @At("TAIL"),
+        method = "isReachableBedBlock",
+        cancellable = true
+    )
+    private void isReachableBedBlock(final BlockPos blockPos, final CallbackInfoReturnable<Boolean> cir) {
+        if (!cir.getReturnValue()) {
+            final Vec3 vec3 = Vec3.atBottomCenterOf(blockPos);
+
+            final double origX = vec3.x;
+            final double origY = vec3.y;
+            final double origZ = vec3.z;
+
+            VSGameUtilsKt.transformToNearbyShipsAndWorld(this.level, origX, origY, origZ, 1, (x, y, z) -> {
+                cir.setReturnValue(Math.abs(this.getX() - x) <= 3.0 && Math.abs(this.getY() - y) <= 2.0 &&
+                    Math.abs(this.getZ() - z) <= 3.0);
+            });
+        }
+    }
+
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/bed_fix/MixinServerPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/bed_fix/MixinServerPlayer.java
@@ -33,8 +33,8 @@ public abstract class MixinServerPlayer extends Entity {
             final double origZ = vec3.z;
 
             VSGameUtilsKt.transformToNearbyShipsAndWorld(this.level, origX, origY, origZ, 1, (x, y, z) -> {
-                cir.setReturnValue(Math.abs(this.getX() - x) <= 3.0 && Math.abs(this.getY() - y) <= 2.0 &&
-                    Math.abs(this.getZ() - z) <= 3.0);
+                cir.setReturnValue(Math.abs(this.getX() - x) <= 3.0 && Math.abs(this.getY() - y) <= 2.0
+                    && Math.abs(this.getZ() - z) <= 3.0);
             });
         }
     }

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -9,6 +9,7 @@
     "accessors.server.world.ChunkMapAccessor",
     "accessors.util.math.Matrix4fAccessor",
     "entity.MixinEntity",
+    "feature.bed_fix.MixinServerPlayer",
     "feature.block_placement_orientation.MixinBlockItem",
     "feature.block_placement_orientation.MixinBlockPlaceContext",
     "feature.container_distance_check.MixinRandomizableContainerBlockEntity",


### PR DESCRIPTION
Bed distance check has been fixed so that players can use beds on ships. The lie down animation is untouched, as that's part of player rendering, so the player will not properly lie down on the bed, but the bed is now usable for sleeping and setting spawn.