### PR TITLE
Allow ship chunks to tick properly

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinChunkMap.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinChunkMap.java
@@ -14,6 +14,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.chunk.ChunkBiomeContainer;
@@ -26,6 +27,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.valkyrienskies.core.api.ServerShip;
 import org.valkyrienskies.core.game.ChunkAllocator;
 import org.valkyrienskies.core.game.IPlayer;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
@@ -48,6 +50,9 @@ public abstract class MixinChunkMap {
     @Shadow
     @Final
     private Supplier<DimensionDataStorage> overworldDataStorage;
+
+    @Shadow
+    abstract boolean noPlayersCloseForSpawning(ChunkPos chunkPos);
 
     /**
      * Force the game to generate empty chunks in the shipyard.
@@ -115,4 +120,28 @@ public abstract class MixinChunkMap {
         final Stream<ServerPlayer> newReturnValue = watchingPlayers.stream();
         cir.setReturnValue(newReturnValue);
     }
+
+    @Inject(method = "euclideanDistanceSquared", at = @At("HEAD"), cancellable = true)
+    private static void preDistanceToSqr(final ChunkPos chunkPos, final Entity entity,
+        final CallbackInfoReturnable<Double> cir) {
+        final double retValue =
+            VSGameUtilsKt.squaredDistanceBetweenInclShips(entity.level, entity.getX(), 0, entity.getZ(), chunkPos.x,
+                0,
+                chunkPos.z);
+        cir.setReturnValue(retValue);
+    }
+
+    @Inject(method = "noPlayersCloseForSpawning", at = @At("RETURN"), cancellable = true)
+    void noPlayersCloseForSpawning(final ChunkPos chunkPos, final CallbackInfoReturnable<Boolean> cir) {
+        if (ChunkAllocator.isChunkInShipyard(chunkPos.x, chunkPos.z)) {
+            if (cir.getReturnValue()) {
+                final ServerShip ship = VSGameUtilsKt.getShipObjectWorld(level).getLoadedShips()
+                    .getShipDataFromChunkPos(chunkPos.x, chunkPos.z, VSGameUtilsKt.getDimensionId(level));
+                if (ship != null) {
+                    cir.setReturnValue(false);
+                }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #185 

Allows ship chunks to be included in tickChunks, which allows for random ticks and weather effects.