### PR TITLE
Make mob spawns on ships configurable

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/NaturalSpawnerMixin.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/NaturalSpawnerMixin.java
@@ -1,0 +1,27 @@
+package org.valkyrienskies.mod.mixin.feature.mob_spawning;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.NaturalSpawner;
+import net.minecraft.world.level.NaturalSpawner.SpawnState;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.core.game.ChunkAllocator;
+import org.valkyrienskies.mod.common.config.VSGameConfig;
+
+@Mixin(NaturalSpawner.class)
+public class NaturalSpawnerMixin {
+
+    @Inject(method = "spawnForChunk", at = @At("HEAD"), cancellable = true)
+    private static void determineSpawningOnShips(final ServerLevel level, final LevelChunk chunk,
+        final SpawnState spawnState,
+        final boolean spawnFriendlies, final boolean spawnMonsters, final boolean bl, final CallbackInfo ci) {
+        if (ChunkAllocator.isChunkInShipyard(chunk.getPos().x, chunk.getPos().z)) {
+            if (!VSGameConfig.SERVER.getAllowMobSpawns()) {
+                ci.cancel();
+            }
+        }
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/tick_ship_chunks/MixinChunkMap.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/tick_ship_chunks/MixinChunkMap.java
@@ -1,0 +1,47 @@
+package org.valkyrienskies.mod.mixin.feature.tick_ship_chunks;
+
+import net.minecraft.server.level.ChunkMap;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.ChunkPos;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.valkyrienskies.core.api.ServerShip;
+import org.valkyrienskies.core.game.ChunkAllocator;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Mixin(ChunkMap.class)
+public abstract class MixinChunkMap {
+
+    @Shadow
+    @Final
+    private ServerLevel level;
+
+    @Inject(method = "euclideanDistanceSquared", at = @At("HEAD"), cancellable = true)
+    private static void preDistanceToSqr(final ChunkPos chunkPos, final Entity entity,
+        final CallbackInfoReturnable<Double> cir) {
+        final double retValue =
+            VSGameUtilsKt.squaredDistanceBetweenInclShips(entity.level, entity.getX(), 0, entity.getZ(), chunkPos.x,
+                0,
+                chunkPos.z);
+        cir.setReturnValue(retValue);
+    }
+
+    @Inject(method = "noPlayersCloseForSpawning", at = @At("RETURN"), cancellable = true)
+    void noPlayersCloseForSpawning(final ChunkPos chunkPos, final CallbackInfoReturnable<Boolean> cir) {
+        if (ChunkAllocator.isChunkInShipyard(chunkPos.x, chunkPos.z)) {
+            if (cir.getReturnValue()) {
+                final ServerShip ship = VSGameUtilsKt.getShipObjectWorld(level).getLoadedShips()
+                    .getShipDataFromChunkPos(chunkPos.x, chunkPos.z, VSGameUtilsKt.getDimensionId(level));
+                if (ship != null) {
+                    cir.setReturnValue(false);
+                }
+            }
+        }
+    }
+
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/tick_ship_chunks/MixinChunkMap.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/tick_ship_chunks/MixinChunkMap.java
@@ -14,6 +14,9 @@ import org.valkyrienskies.core.api.ServerShip;
 import org.valkyrienskies.core.game.ChunkAllocator;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
+/**
+ * These methods fix random ticking on ship chunks
+ */
 @Mixin(ChunkMap.class)
 public abstract class MixinChunkMap {
 

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinChunkMap.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinChunkMap.java
@@ -14,7 +14,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.chunk.ChunkBiomeContainer;
@@ -27,7 +26,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.valkyrienskies.core.api.ServerShip;
 import org.valkyrienskies.core.game.ChunkAllocator;
 import org.valkyrienskies.core.game.IPlayer;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
@@ -119,29 +117,6 @@ public abstract class MixinChunkMap {
 
         final Stream<ServerPlayer> newReturnValue = watchingPlayers.stream();
         cir.setReturnValue(newReturnValue);
-    }
-
-    @Inject(method = "euclideanDistanceSquared", at = @At("HEAD"), cancellable = true)
-    private static void preDistanceToSqr(final ChunkPos chunkPos, final Entity entity,
-        final CallbackInfoReturnable<Double> cir) {
-        final double retValue =
-            VSGameUtilsKt.squaredDistanceBetweenInclShips(entity.level, entity.getX(), 0, entity.getZ(), chunkPos.x,
-                0,
-                chunkPos.z);
-        cir.setReturnValue(retValue);
-    }
-
-    @Inject(method = "noPlayersCloseForSpawning", at = @At("RETURN"), cancellable = true)
-    void noPlayersCloseForSpawning(final ChunkPos chunkPos, final CallbackInfoReturnable<Boolean> cir) {
-        if (ChunkAllocator.isChunkInShipyard(chunkPos.x, chunkPos.z)) {
-            if (cir.getReturnValue()) {
-                final ServerShip ship = VSGameUtilsKt.getShipObjectWorld(level).getLoadedShips()
-                    .getShipDataFromChunkPos(chunkPos.x, chunkPos.z, VSGameUtilsKt.getDimensionId(level));
-                if (ship != null) {
-                    cir.setReturnValue(false);
-                }
-            }
-        }
     }
 
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -48,5 +48,10 @@ object VSGameConfig {
             description = "Blast force in newtons of a TNT explosion at the center of the explosion."
         )
         var explosionBlastForce = 500000.0
+
+        @JsonSchema(
+            description = "Allow natural mob spawning on ships"
+        )
+        var allowMobSpawns = false
     }
 }

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -29,6 +29,7 @@
     "feature.mob_spawning.NaturalSpawnerMixin",
     "feature.move_block_items_drops.MixinBlock",
     "feature.screen_distance_check.MixinScreenHandler",
+    "feature.tick_ship_chunks.MixinChunkMap",
     "mod_compat.sodium.MixinChunkRenderContainer",
     "mod_compat.sodium.MixinChunkRenderManager",
     "mod_compat.sodium.MixinSodiumWorldRenderer",

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -26,6 +26,7 @@
     "feature.fire_between_ship_and_world.LavaFluidMixin",
     "feature.fluid_escaping_ship_config.MixinFlowingFluid",
     "feature.ladders.MixinLivingEntity",
+    "feature.mob_spawning.NaturalSpawnerMixin",
     "feature.move_block_items_drops.MixinBlock",
     "feature.screen_distance_check.MixinScreenHandler",
     "mod_compat.sodium.MixinChunkRenderContainer",


### PR DESCRIPTION
Due to the previous chunk fixes, mobs started spawning on ships. Added a config to toggle that, defaulting to off because most mob AI does not work on ships. Should change default to true when AI is working.