### PR TITLE
Changes to relocation utils

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembly.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembly.kt
@@ -16,6 +16,7 @@ import org.valkyrienskies.mod.common.playerWrapper
 import org.valkyrienskies.mod.common.shipObjectWorld
 import org.valkyrienskies.mod.common.util.toJOML
 import org.valkyrienskies.mod.util.relocateBlock
+import org.valkyrienskies.mod.util.updateBlock
 
 fun createNewShipWithBlocks(
     centerBlock: BlockPos, blocks: DenseBlockPosSet, level: ServerLevel
@@ -56,7 +57,20 @@ fun createNewShipWithBlocks(
             val fromPos = BlockPos((sourceChunk.pos.x shl 4) + x, (chunkY shl 4) + y, (sourceChunk.pos.z shl 4) + z)
             val toPos = BlockPos((destChunk.pos.x shl 4) + x, (chunkY shl 4) + y, (destChunk.pos.z shl 4) + z)
 
-            relocateBlock(sourceChunk, fromPos, destChunk, toPos, ship)
+            relocateBlock(sourceChunk, fromPos, destChunk, toPos, false, ship)
+        }
+    }
+
+    // Use updateBlock to update blocks after copying
+    blocks.forEachChunk { chunkX, chunkY, chunkZ, chunk ->
+        val sourceChunk = level.getChunk(chunkX, chunkZ)
+        val destChunk = level.getChunk(chunkX - deltaX, chunkZ - deltaZ)
+
+        chunk.forEach { x, y, z ->
+            val fromPos = BlockPos((sourceChunk.pos.x shl 4) + x, (chunkY shl 4) + y, (sourceChunk.pos.z shl 4) + z)
+            val toPos = BlockPos((destChunk.pos.x shl 4) + x, (chunkY shl 4) + y, (destChunk.pos.z shl 4) + z)
+
+            updateBlock(destChunk.level, fromPos, toPos, destChunk.getBlockState(toPos))
         }
     }
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/VSEntityManager.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/VSEntityManager.kt
@@ -52,9 +52,11 @@ object VSEntityManager {
 
     // Sends a packet with all the entity -> handler pairs to the client
     fun syncHandlers(player: MinecraftPlayer) {
-        PacketSyncVSEntityTypes(Array(Registry.ENTITY_TYPE.count()) {
-            val handler = getHandler(Registry.ENTITY_TYPE.byId(it))
-            namedEntityHandlers[handler].toString()
-        }).sendToClient(player)
+        PacketSyncVSEntityTypes(
+            Array(Registry.ENTITY_TYPE.count()) {
+                val handler = getHandler(Registry.ENTITY_TYPE.byId(it))
+                namedEntityHandlers[handler].toString()
+            }
+        ).sendToClient(player)
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/item/ShipCreatorItem.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/item/ShipCreatorItem.kt
@@ -1,13 +1,13 @@
 package org.valkyrienskies.mod.common.item
 
 import net.minecraft.Util
-import net.minecraft.core.Direction.NORTH
 import net.minecraft.network.chat.TextComponent
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.InteractionResult
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.context.UseOnContext
+import net.minecraft.world.level.block.Rotation.NONE
 import net.minecraft.world.level.block.state.BlockState
 import org.joml.Vector3i
 import org.valkyrienskies.core.game.ChunkAllocator
@@ -38,7 +38,7 @@ class ShipCreatorItem(properties: Properties, private val scale: Double) : Item(
                 val centerPos = shipData.chunkClaim.getCenterBlockCoordinates(Vector3i()).toBlockPos()
 
                 // Move the block from the world to a ship
-                level.relocateBlock(blockPos, centerPos, shipData, NORTH)
+                level.relocateBlock(blockPos, centerPos, true, shipData, NONE)
 
                 ctx.player?.sendMessage(TextComponent("SHIPIFIED!"), Util.NIL_UUID)
             }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/VSGamePackets.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/VSGamePackets.kt
@@ -33,7 +33,6 @@ object VSGamePackets {
                 val attachment: SeatedControllingPlayer = ship.getAttachment()
                     ?: SeatedControllingPlayer(seat.direction.opposite).apply { ship.setAttachment(this) }
 
-
                 attachment.forwardImpulse = driving.impulse.z
                 attachment.leftImpulse = driving.impulse.x
                 attachment.upImpulse = driving.impulse.y

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/world/RaycastUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/world/RaycastUtils.kt
@@ -238,7 +238,8 @@ fun Level.raytraceEntities(
 }
 
 fun BlockGetter.vanillaClip(context: ClipContext): BlockHitResult =
-    BlockGetter.traverseBlocks(context,
+    BlockGetter.traverseBlocks(
+        context,
         { clipContext: ClipContext, blockPos: BlockPos ->
             val blockState = getBlockState(blockPos)
             val fluidState = getFluidState(blockPos)
@@ -264,9 +265,10 @@ fun BlockGetter.vanillaClip(context: ClipContext): BlockHitResult =
             else
                 blockHitResult2
         }, { ctx ->
-            val vec3 = ctx.from.subtract(ctx.to)
-            BlockHitResult.miss(
-                ctx.to, Direction.getNearest(vec3.x, vec3.y, vec3.z),
-                BlockPos(ctx.to)
-            )
-        })
+        val vec3 = ctx.from.subtract(ctx.to)
+        BlockHitResult.miss(
+            ctx.to, Direction.getNearest(vec3.x, vec3.y, vec3.z),
+            BlockPos(ctx.to)
+        )
+    }
+    )

--- a/common/src/main/kotlin/org/valkyrienskies/mod/util/RelocationUtil.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/util/RelocationUtil.kt
@@ -9,7 +9,6 @@ import net.minecraft.world.level.block.Rotation
 import net.minecraft.world.level.block.Rotation.NONE
 import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.level.chunk.LevelChunk
-import net.minecraft.world.level.chunk.LevelChunk.EntityCreationType.CHECK
 import org.valkyrienskies.core.api.ServerShip
 import org.valkyrienskies.mod.api.ShipBlockEntity
 
@@ -60,7 +59,7 @@ fun relocateBlock(
     }
 
     tag?.let {
-        val be = toChunk.getBlockEntity(to, CHECK)!!
+        val be = level.getBlockEntity(to)!!
         if (be is ShipBlockEntity) be.ship = toShip
 
         be.load(state, it)

--- a/common/src/main/kotlin/org/valkyrienskies/mod/util/RelocationUtil.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/util/RelocationUtil.kt
@@ -76,26 +76,26 @@ fun relocateBlock(
  */
 fun updateBlock(level: Level, fromPos: BlockPos, toPos: BlockPos, toState: BlockState) {
 
-    //75 = flag 1 (block update) & flag 2 (send to clients) + flag 8 (force rerenders) + flag 64 (block is moving)
+    // 75 = flag 1 (block update) & flag 2 (send to clients) + flag 8 (force rerenders) + flag 64 (block is moving)
     val flags = 75
 
-    //updateNeighbourShapes recurses through nearby blocks, recursionLeft is the limit
+    // updateNeighbourShapes recurses through nearby blocks, recursionLeft is the limit
     val recursionLeft = 511
 
     level.setBlocksDirty(fromPos, toState, AIR)
     level.sendBlockUpdated(fromPos, toState, AIR, flags)
-    //This handles the update for neighboring blocks in worldspace
+    // This handles the update for neighboring blocks in worldspace
     AIR.updateNeighbourShapes(level, fromPos, flags, recursionLeft)
     AIR.updateIndirectNeighbourShapes(level, fromPos, flags, recursionLeft)
-    //This updates lighting for blocks in worldspace
+    // This updates lighting for blocks in worldspace
     level.chunkSource.lightEngine.checkBlock(fromPos)
 
     level.setBlocksDirty(toPos, AIR, toState)
     level.sendBlockUpdated(toPos, AIR, toState, flags)
-    //This handles the update for neighboring blocks in shipspace (ladders, redstone)
+    // This handles the update for neighboring blocks in shipspace (ladders, redstone)
     toState.updateNeighbourShapes(level, toPos, flags, recursionLeft)
     toState.updateIndirectNeighbourShapes(level, toPos, flags, recursionLeft)
-    //This updates lighting for blocks in shipspace
+    // This updates lighting for blocks in shipspace
     level.chunkSource.lightEngine.checkBlock(toPos)
 }
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/util/RelocationUtil.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/util/RelocationUtil.kt
@@ -76,19 +76,25 @@ fun relocateBlock(
  */
 fun updateBlock(level: Level, fromPos: BlockPos, toPos: BlockPos, toState: BlockState) {
 
+    //75 = flag 1 (block update) & flag 2 (send to clients) + flag 8 (force rerenders) + flag 64 (block is moving)
+    val flags = 75
+
+    //updateNeighbourShapes recurses through nearby blocks, recursionLeft is the limit
+    val recursionLeft = 511
+
     level.setBlocksDirty(fromPos, toState, AIR)
-    level.sendBlockUpdated(fromPos, toState, AIR, 75)
+    level.sendBlockUpdated(fromPos, toState, AIR, flags)
     //This handles the update for neighboring blocks in worldspace
-    AIR.updateNeighbourShapes(level, fromPos, 75 and -0x22, 512 - 1)
-    AIR.updateIndirectNeighbourShapes(level, fromPos, 75 and -0x22, 512 - 1)
+    AIR.updateNeighbourShapes(level, fromPos, flags, recursionLeft)
+    AIR.updateIndirectNeighbourShapes(level, fromPos, flags, recursionLeft)
     //This updates lighting for blocks in worldspace
     level.chunkSource.lightEngine.checkBlock(fromPos)
 
     level.setBlocksDirty(toPos, AIR, toState)
-    level.sendBlockUpdated(toPos, AIR, toState, 75)
+    level.sendBlockUpdated(toPos, AIR, toState, flags)
     //This handles the update for neighboring blocks in shipspace (ladders, redstone)
-    toState.updateNeighbourShapes(level, toPos, 75 and -0x22, 512 - 1)
-    toState.updateIndirectNeighbourShapes(level, toPos, 75 and -0x22, 512 - 1)
+    toState.updateNeighbourShapes(level, toPos, flags, recursionLeft)
+    toState.updateIndirectNeighbourShapes(level, toPos, flags, recursionLeft)
     //This updates lighting for blocks in shipspace
     level.chunkSource.lightEngine.checkBlock(toPos)
 }


### PR DESCRIPTION
relocateBlock uses vanilla BlockState.rotate() for compatibility, and so we don't reinvent the wheel
relocateBlock has the option to update blocks around it or not
updateBlock method, which more thoroughly updates blocks copied from world to shipyard
Assembly updates blocks separately after copying all of them