### PR TITLE
Fixes randomTick (crops) on ships for 1.18.x

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/tick_ship_chunks/MixinChunkMap.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/tick_ship_chunks/MixinChunkMap.java
@@ -39,7 +39,7 @@ public abstract class MixinChunkMap {
     @Inject(method = "anyPlayerCloseEnoughForSpawning", at = @At("RETURN"), cancellable = true)
     void noPlayersCloseForSpawning(final ChunkPos chunkPos, final CallbackInfoReturnable<Boolean> cir) {
         if (VSGameUtilsKt.isChunkInShipyard(level, chunkPos.x, chunkPos.z)) {
-            if (cir.getReturnValue()) {
+            if (!cir.getReturnValue()) {
                 final ServerShip ship = VSGameUtilsKt.getShipObjectWorld(level).getLoadedShips()
                     .getByChunkPos(chunkPos.x, chunkPos.z, VSGameUtilsKt.getDimensionId(level));
                 if (ship != null) {


### PR DESCRIPTION
It looks like the logic flipped from "No-one here?" to "Anyone here?" from 1.16.x to 1.18.x but a ! was missed

I've tested this locally and it fixes crops for me.