### PR TITLE
superglue bandaid fix

### DIFF
--- a/common/src/main/resources/data/create/vs_entities/super_glue.json
+++ b/common/src/main/resources/data/create/vs_entities/super_glue.json
@@ -1,0 +1,3 @@
+{
+  "handler": "valkyrienskies:shipyard"
+}


### PR DESCRIPTION
Literally just adding superglue to the list of vs shipyard entities. Does not fix latest create yet, and glue doesn't seem to want to render, but it does stick.