### PR TITLE
[1.18.2] FTB Chunks Compatibility

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,12 +1,3 @@
-repositories {
-    maven {
-        url "https://cursemaven.com"
-        content {
-            includeGroup "curse.maven"
-        }
-    }
-}
-
 dependencies {
     annotationProcessor(implementation("com.github.LlamaLad7:MixinExtras:0.1.1"))
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,3 +1,12 @@
+repositories {
+    maven {
+        url "https://cursemaven.com"
+        content {
+            includeGroup "curse.maven"
+        }
+    }
+}
+
 dependencies {
     annotationProcessor(implementation("com.github.LlamaLad7:MixinExtras:0.1.1"))
 
@@ -15,6 +24,11 @@ dependencies {
         exclude module: "netty-buffer"
         exclude module: "fastutil"
     }
+
+    // FTB Stuffs
+    modCompileOnly("curse.maven:ftb-util-404465:4210935")
+    modCompileOnly("curse.maven:ftb-teams-404468:4229138")
+    modCompileOnly("curse.maven:ftb-chunks-314906:4229120")
 }
 
 architectury {

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/ftb_chunks/MixinClaimedChunkManager.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/ftb_chunks/MixinClaimedChunkManager.java
@@ -3,6 +3,7 @@ package org.valkyrienskies.mod.mixin.mod_compat.ftb_chunks;
 import dev.ftb.mods.ftbchunks.data.ClaimedChunkManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
 import org.joml.Vector3d;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
@@ -38,12 +39,20 @@ public abstract class MixinClaimedChunkManager {
             return pos;
         }
 
-        final Ship ship = VSGameUtilsKt.getShipManagingPos(entity.level, pos);
+        Level level = entity.level;
+
+        final Ship ship = VSGameUtilsKt.getShipManagingPos(level, pos);
         if (ship == null) {
             return pos;
         }
 
         final Vector3d vec = ship.getShipToWorld().transformPosition(new Vector3d(pos.getX(), pos.getY(), pos.getZ()));
-        return new BlockPos(VectorConversionsMCKt.toMinecraft(vec));
+        BlockPos newPos = new BlockPos(VectorConversionsMCKt.toMinecraft(vec));
+
+        if (newPos.getY() > level.getMaxBuildHeight() || newPos.getY() < level.getMinBuildHeight()) {
+            return pos;
+        }
+        
+        return newPos;
     }
 }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/ftb_chunks/MixinClaimedChunkManager.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/ftb_chunks/MixinClaimedChunkManager.java
@@ -1,40 +1,24 @@
 package org.valkyrienskies.mod.mixin.mod_compat.ftb_chunks;
 
-import dev.ftb.mods.ftbchunks.data.ClaimedChunk;
 import dev.ftb.mods.ftbchunks.data.ClaimedChunkManager;
-import dev.ftb.mods.ftblibrary.math.ChunkDimPos;
-import java.util.Map;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.Level;
-import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3d;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 
 @Pseudo
 @Mixin(ClaimedChunkManager.class)
 public abstract class MixinClaimedChunkManager {
     @Unique
     private Entity entity = null;
-    @Unique
-    private BlockPos pos = null;
-
-    @Shadow
-    public abstract @Nullable ClaimedChunk getChunk(ChunkDimPos pos);
-
-    @Shadow
-    @Final
-    private Map<ChunkDimPos, ClaimedChunk> claimedChunks;
 
     @ModifyVariable(method = "protect", at = @At("HEAD"), name = "entity", remap = false)
     private Entity ValkyrienSkies$entity(final Entity entity) {
@@ -42,22 +26,24 @@ public abstract class MixinClaimedChunkManager {
         return entity;
     }
 
-    @ModifyVariable(method = "protect", at = @At("HEAD"), name = "pos", remap = false)
-    private BlockPos ValkyrienSkies$entity(final BlockPos instance) {
-        this.pos = instance;
-        return pos;
-    }
-
-    @Inject(method = "getChunk", at = @At("RETURN"), cancellable = true, remap = false)
-    public void ValkyrienSkies$getChunk(final ChunkDimPos dimPos, final CallbackInfoReturnable<ClaimedChunk> cir) {
-        if (entity != null) {
-            final Level level = entity.level;
-            final Ship ship = VSGameUtilsKt.getShipManagingPos(level, pos);
-            if (ship != null && pos.getY() < level.getMaxBuildHeight() && pos.getY() > level.getMinBuildHeight()) {
-                final Vector3d vec =
-                    ship.getShipToWorld().transformPosition(new Vector3d(pos.getX(), pos.getY(), pos.getZ()));
-                cir.setReturnValue(getChunk(new ChunkDimPos(level, new BlockPos(vec.x, vec.y, vec.z))));
-            }
+    @ModifyArg(
+        method = "protect",
+        at = @At(
+            value = "INVOKE",
+            target = "Ldev/ftb/mods/ftblibrary/math/ChunkDimPos;<init>(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)V"
+        )
+    )
+    private BlockPos ValkyrienSkies$newChunkDimPos(final BlockPos pos) {
+        if (entity == null) {
+            return pos;
         }
+
+        final Ship ship = VSGameUtilsKt.getShipManagingPos(entity.level, pos);
+        if (ship == null) {
+            return pos;
+        }
+
+        final Vector3d vec = ship.getShipToWorld().transformPosition(new Vector3d(pos.getX(), pos.getY(), pos.getZ()));
+        return new BlockPos(VectorConversionsMCKt.toMinecraft(vec));
     }
 }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/ftb_chunks/MixinClaimedChunkManager.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/ftb_chunks/MixinClaimedChunkManager.java
@@ -13,6 +13,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.config.VSGameConfig;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 
 @Pseudo
@@ -35,11 +36,11 @@ public abstract class MixinClaimedChunkManager {
         )
     )
     private BlockPos ValkyrienSkies$newChunkDimPos(final BlockPos pos) {
-        if (entity == null) {
+        if (entity == null && !VSGameConfig.SERVER.getFTBChunks().getShipsProtectedByClaims()) {
             return pos;
         }
 
-        Level level = entity.level;
+        final Level level = entity.level;
 
         final Ship ship = VSGameUtilsKt.getShipManagingPos(level, pos);
         if (ship == null) {
@@ -47,12 +48,15 @@ public abstract class MixinClaimedChunkManager {
         }
 
         final Vector3d vec = ship.getShipToWorld().transformPosition(new Vector3d(pos.getX(), pos.getY(), pos.getZ()));
-        BlockPos newPos = new BlockPos(VectorConversionsMCKt.toMinecraft(vec));
+        final BlockPos newPos = new BlockPos(VectorConversionsMCKt.toMinecraft(vec));
 
-        if (newPos.getY() > level.getMaxBuildHeight() || newPos.getY() < level.getMinBuildHeight()) {
+        if (
+            (newPos.getY() > level.getMaxBuildHeight() || newPos.getY() < level.getMinBuildHeight()) &&
+                !VSGameConfig.SERVER.getFTBChunks().getShipsProtectionOutOfBuildHeight()
+        ) {
             return pos;
         }
-        
+
         return newPos;
     }
 }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/ftb_chunks/MixinClaimedChunkManager.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/ftb_chunks/MixinClaimedChunkManager.java
@@ -6,7 +6,6 @@ import dev.ftb.mods.ftblibrary.math.ChunkDimPos;
 import java.util.Map;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3d;
@@ -27,6 +26,8 @@ import org.valkyrienskies.mod.common.VSGameUtilsKt;
 public abstract class MixinClaimedChunkManager {
     @Unique
     private Entity entity = null;
+    @Unique
+    private BlockPos pos = null;
 
     @Shadow
     public abstract @Nullable ClaimedChunk getChunk(ChunkDimPos pos);
@@ -41,12 +42,15 @@ public abstract class MixinClaimedChunkManager {
         return entity;
     }
 
+    @ModifyVariable(method = "protect", at = @At("HEAD"), name = "pos", remap = false)
+    private BlockPos ValkyrienSkies$entity(final BlockPos instance) {
+        this.pos = instance;
+        return pos;
+    }
+
     @Inject(method = "getChunk", at = @At("RETURN"), cancellable = true, remap = false)
     public void ValkyrienSkies$getChunk(final ChunkDimPos dimPos, final CallbackInfoReturnable<ClaimedChunk> cir) {
         if (entity != null) {
-            final ChunkPos chunk = dimPos.getChunkPos();
-            final BlockPos pos =
-                new BlockPos(chunk.getMiddleBlockX(), chunk.getWorldPosition().getY(), chunk.getMiddleBlockZ());
             final Level level = entity.level;
             final Ship ship = VSGameUtilsKt.getShipManagingPos(level, pos);
             if (ship != null && pos.getY() < level.getMaxBuildHeight() && pos.getY() > level.getMinBuildHeight()) {

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/ftb_chunks/MixinClaimedChunkManager.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/ftb_chunks/MixinClaimedChunkManager.java
@@ -1,0 +1,57 @@
+package org.valkyrienskies.mod.mixin.mod_compat.ftb_chunks;
+
+import dev.ftb.mods.ftbchunks.data.ClaimedChunk;
+import dev.ftb.mods.ftbchunks.data.ClaimedChunkManager;
+import dev.ftb.mods.ftblibrary.math.ChunkDimPos;
+import java.util.Map;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.ChunkPos;
+import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3d;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Pseudo
+@Mixin(ClaimedChunkManager.class)
+public abstract class MixinClaimedChunkManager {
+    @Unique
+    private Entity entity = null;
+
+    @Shadow
+    public abstract @Nullable ClaimedChunk getChunk(ChunkDimPos pos);
+
+    @Shadow
+    @Final
+    private Map<ChunkDimPos, ClaimedChunk> claimedChunks;
+
+    @ModifyVariable(method = "protect", at = @At("HEAD"), name = "entity", remap = false)
+    private Entity ValkyrienSkies$entity(final Entity entity) {
+        this.entity = entity;
+        return entity;
+    }
+
+    @Inject(method = "getChunk", at = @At("RETURN"), cancellable = true, remap = false)
+    public void ValkyrienSkies$getChunk(final ChunkDimPos dimPos, final CallbackInfoReturnable<ClaimedChunk> cir) {
+        if (entity != null) {
+            final ChunkPos chunk = dimPos.getChunkPos();
+            final BlockPos pos =
+                new BlockPos(chunk.getMiddleBlockX(), chunk.getWorldPosition().getY(), chunk.getMiddleBlockZ());
+            final Ship ship = VSGameUtilsKt.getShipManagingPos(entity.level, pos);
+            if (ship != null) {
+                final Vector3d vec =
+                    ship.getShipToWorld().transformPosition(new Vector3d(pos.getX(), pos.getY(), pos.getZ()));
+                cir.setReturnValue(getChunk(new ChunkDimPos(entity.level, new BlockPos(vec.x, vec.y, vec.z))));
+            }
+        }
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/ftb_chunks/MixinClaimedChunkManager.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/ftb_chunks/MixinClaimedChunkManager.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3d;
 import org.spongepowered.asm.mixin.Final;
@@ -46,11 +47,12 @@ public abstract class MixinClaimedChunkManager {
             final ChunkPos chunk = dimPos.getChunkPos();
             final BlockPos pos =
                 new BlockPos(chunk.getMiddleBlockX(), chunk.getWorldPosition().getY(), chunk.getMiddleBlockZ());
-            final Ship ship = VSGameUtilsKt.getShipManagingPos(entity.level, pos);
-            if (ship != null) {
+            final Level level = entity.level;
+            final Ship ship = VSGameUtilsKt.getShipManagingPos(level, pos);
+            if (ship != null && pos.getY() < level.getMaxBuildHeight() && pos.getY() > level.getMinBuildHeight()) {
                 final Vector3d vec =
                     ship.getShipToWorld().transformPosition(new Vector3d(pos.getX(), pos.getY(), pos.getZ()));
-                cir.setReturnValue(getChunk(new ChunkDimPos(entity.level, new BlockPos(vec.x, vec.y, vec.z))));
+                cir.setReturnValue(getChunk(new ChunkDimPos(level, new BlockPos(vec.x, vec.y, vec.z))));
             }
         }
     }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -19,6 +19,20 @@ object VSGameConfig {
     }
 
     class Server {
+        val FTBChunks = FTBCHUNKS()
+
+        class FTBCHUNKS {
+            @JsonSchema(
+                description = "Are Ships protected by FTB Chunk Claims?"
+            )
+            var shipsProtectedByClaims = true
+            
+            @JsonSchema(
+                description = "Are ships protected outside of build height (max and min)?"
+            )
+            var shipsProtectionOutOfBuildHeight = false
+        }
+
         val ComputerCraft = COMPUTERCRAFT()
 
         class COMPUTERCRAFT {

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -41,6 +41,7 @@
     "feature.water_in_ships_entity.MixinEntity",
     "feature.world_border.MixinLevel",
     "feature.world_border.MixinWorldBorder",
+    "mod_compat.ftb_chunks.MixinClaimedChunkManager",
     "mod_compat.sodium.MixinChunkTracker",
     "mod_compat.sodium.MixinRegionChunkRenderer",
     "mod_compat.sodium.MixinRenderSectionManager",


### PR DESCRIPTION
Allows Ships to fall under the protection of FTB Chunks if the blocks are in said chunk!

- Added MixinClaimedChunkManager to pass Shipyard positions to worldspace to be tested against
- Edited build.gradle:common to add FTB Chunks, Utilities, and Teams, as well as the CurseMaven repository
- Edited valkyrienskies-common.mixins.json to add MixinClaimedChunkManager