### PR TITLE
Unfloored position components in getOnPos related parts of the entity_collsion mixin

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
@@ -133,7 +133,7 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
         final Iterable<Ship> intersectingShips = VSGameUtilsKt.getShipsIntersecting(level, testAABB);
         for (final Ship ship : intersectingShips) {
             final Vector3dc blockPosInLocal =
-                ship.getShipTransform().getWorldToShipMatrix().transformPosition(blockPosInGlobal, new Vector3d());
+                ship.getTransform().getWorldToShip().transformPosition(blockPosInGlobal, new Vector3d());
             final BlockPos blockPos = new BlockPos(
                 Math.floor(blockPosInLocal.x()), Math.floor(blockPosInLocal.y()), Math.floor(blockPosInLocal.z())
             );
@@ -142,7 +142,7 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
                 return blockPos;
             } else {
                 // Check the block below as well, in the cases of fences
-                final Vector3dc blockPosInLocal2 = ship.getShipTransform().getWorldToShipMatrix()
+                final Vector3dc blockPosInLocal2 = ship.getTransform().getWorldToShip()
                     .transformPosition(
                         new Vector3d(blockPosInGlobal.x(), blockPosInGlobal.y() - 1.0, blockPosInGlobal.z()));
                 final BlockPos blockPos2 = new BlockPos(
@@ -160,9 +160,9 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
     @Inject(method = "getBlockPosBelowThatAffectsMyMovement", at = @At("HEAD"), cancellable = true)
     private void preGetBlockPosBelowThatAffectsMyMovement(final CallbackInfoReturnable<BlockPos> cir) {
         final Vector3dc blockPosInGlobal = new Vector3d(
-            Math.floor(position.x) + 0.5,
-            Math.floor(getBoundingBox().minY - 0.5) + 0.5,
-            Math.floor(position.z) + 0.5
+            position.x,
+            getBoundingBox().minY - 0.5,
+            position.z
         );
         final BlockPos blockPosStandingOnFromShip = getPosStandingOnFromShips(blockPosInGlobal);
         if (blockPosStandingOnFromShip != null) {
@@ -177,9 +177,9 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
     @Inject(method = "getOnPos", at = @At("HEAD"), cancellable = true)
     private void preGetOnPos(final CallbackInfoReturnable<BlockPos> cir) {
         final Vector3dc blockPosInGlobal = new Vector3d(
-            Math.floor(position.x) + 0.5,
-            Math.floor(position.y - 0.2) + 0.5,
-            Math.floor(position.z) + 0.5
+            position.x,
+            position.y - 0.2,
+            position.z
         );
         final BlockPos blockPosStandingOnFromShip = getPosStandingOnFromShips(blockPosInGlobal);
         if (blockPosStandingOnFromShip != null) {
@@ -190,9 +190,9 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
     @Inject(method = "spawnSprintParticle", at = @At("HEAD"), cancellable = true)
     private void preSpawnSprintParticle(final CallbackInfo ci) {
         final Vector3dc blockPosInGlobal = new Vector3d(
-            Math.floor(position.x) + 0.5,
-            Math.floor(position.y - 0.2) + 0.5,
-            Math.floor(position.z) + 0.5
+            position.x,
+            position.y - 0.2,
+            position.z
         );
         final BlockPos blockPosStandingOnFromShip = getPosStandingOnFromShips(blockPosInGlobal);
         if (blockPosStandingOnFromShip != null) {


### PR DESCRIPTION
This fixes the getOnPos mixins where it was doing Math.floor on position components and then +.5 to get the 'block center' before the position had been transformed into ship space