### PR TITLE
Only move ship entities into world once they're spawned in

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntity.java
@@ -13,7 +13,6 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.entity.handling.VSEntityManager;
 
@@ -64,33 +63,6 @@ public abstract class MixinEntity {
             .getTeleportPos(Entity.class.cast(this), new Vector3d(d, e, f));
         teleportTo(pos.x, pos.y, pos.z);
         isModifyingTeleport = false;
-    }
-
-    @Unique
-    private boolean isModifyingSetPos = false;
-
-    /**
-     * @author ewoudje
-     * @reason use vs2 entity handler to handle this method
-     */
-    @Inject(method = "setPosRaw", at = @At(value = "HEAD"), cancellable = true)
-    private void handlePosSet(final double x, final double y, final double z, final CallbackInfo ci) {
-        if (isModifyingSetPos) {
-            return;
-        }
-
-        final Vector3d pos = new Vector3d(x, y, z);
-        final Ship ship;
-
-        if ((ship = VSGameUtilsKt.getShipObjectManagingPos(level, pos)) != null) {
-            final var result = VSEntityManager.INSTANCE.getHandler(Entity.class.cast(this))
-                .onEntityMove(Entity.class.cast(this), ship, pos);
-
-            isModifyingSetPos = true;
-            setPosRaw(result.x(), result.y(), result.z());
-            isModifyingSetPos = false;
-            ci.cancel();
-        }
     }
 
     /**

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinServerLevel.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinServerLevel.java
@@ -9,6 +9,10 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.entity.handling.VSEntityManager;
 import org.valkyrienskies.mod.mixinducks.world.OfLevel;
 
 @Mixin(ServerLevel.class)
@@ -21,6 +25,20 @@ public class MixinServerLevel {
     @Inject(method = "<init>", at = @At("RETURN"))
     void configureEntitySections(final CallbackInfo ci) {
         ((OfLevel) entityManager).setLevel(ServerLevel.class.cast(this));
+    }
+
+    @Inject(
+        method = "addEntity",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/entity/PersistentEntitySectionManager;addNewEntity(Lnet/minecraft/world/level/entity/EntityAccess;)Z"
+        )
+    )
+    void preAddEntity(final Entity entity, final CallbackInfoReturnable<Boolean> cir) {
+        final Ship ship = VSGameUtilsKt.getShipManaging(entity);
+        if (ship != null) {
+            VSEntityManager.INSTANCE.getHandler(entity).freshEntityInShipyard(entity, ship);
+        }
     }
 
 }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
@@ -22,7 +22,6 @@ import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.progress.ChunkProgressListener;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.LevelChunkSection;
@@ -38,14 +37,11 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.core.api.ships.LoadedServerShip;
-import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.core.apigame.world.ServerShipWorldCore;
 import org.valkyrienskies.core.apigame.world.chunks.TerrainUpdate;
 import org.valkyrienskies.mod.common.IShipObjectWorldServerProvider;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
-import org.valkyrienskies.mod.common.entity.handling.VSEntityManager;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 import org.valkyrienskies.mod.mixin.accessors.server.world.ChunkMapAccessor;
 
@@ -177,18 +173,5 @@ public abstract class MixinServerLevel implements IShipObjectWorldServerProvider
             voxelShapeUpdates
         );
     }
-
-    /**
-     * @author ewoudje
-     * @reason send updates to relevant VSEntityHandler
-     */
-    @Inject(method = "addEntity", at = @At(value = "HEAD"))
-    private void updateHandler(final Entity entity, final CallbackInfoReturnable<Boolean> cir) {
-        final Vector3d pos = new Vector3d(entity.getX(), entity.getY(), entity.getZ());
-        final Ship ship = VSGameUtilsKt.getShipObjectManagingPos(entity.level, pos);
-        if (ship != null) {
-            VSEntityManager.INSTANCE.getHandler(entity)
-                .freshEntityInShipyard(entity, ship, pos);
-        }
-    }
+    
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/ShipyardEntityHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/ShipyardEntityHandler.kt
@@ -5,14 +5,15 @@ import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.client.renderer.entity.EntityRenderer
 import net.minecraft.world.entity.Entity
 import org.joml.Vector3d
-import org.joml.Vector3dc
 import org.valkyrienskies.core.api.ships.ClientShip
 import org.valkyrienskies.core.api.ships.Ship
 import org.valkyrienskies.mod.common.util.toJOML
 import org.valkyrienskies.mod.common.util.toMinecraft
 
 object ShipyardEntityHandler : VSEntityHandler {
-    override fun freshEntityInShipyard(entity: Entity, ship: Ship, position: Vector3dc) {}
+    override fun freshEntityInShipyard(entity: Entity, ship: Ship) {
+        // do nothing
+    }
 
     override fun <T : Entity> applyRenderTransform(
         ship: ClientShip, entity: T, entityRenderer: EntityRenderer<T>, x: Double, y: Double, z: Double,
@@ -50,6 +51,4 @@ object ShipyardEntityHandler : VSEntityHandler {
         // EW: i think it was in entity dragging logic
         matrixStack.mulPose(ship.renderTransform.shipToWorldRotation.toMinecraft())
     }
-
-    override fun onEntityMove(self: Entity, ship: Ship, position: Vector3dc): Vector3dc = position
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/VSEntityHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/VSEntityHandler.kt
@@ -5,7 +5,6 @@ import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.client.renderer.entity.EntityRenderer
 import net.minecraft.world.entity.Entity
 import org.joml.Vector3d
-import org.joml.Vector3dc
 import org.valkyrienskies.core.api.ships.ClientShip
 import org.valkyrienskies.core.api.ships.Ship
 
@@ -16,7 +15,7 @@ interface VSEntityHandler {
      *
      * Gets called when a new entity gets made in the shipyard
      */
-    fun freshEntityInShipyard(entity: Entity, ship: Ship, position: Vector3dc)
+    fun freshEntityInShipyard(entity: Entity, ship: Ship)
 
     /**
      * ApplyRenderTransform
@@ -52,11 +51,4 @@ interface VSEntityHandler {
     fun applyRenderOnMountedEntity(
         ship: ClientShip, self: Entity, passenger: Entity, partialTicks: Float, matrixStack: PoseStack
     )
-
-    /**
-     * Gets called every move of a entity that lives in the shipyard
-     *
-     * Should call self.setPosRaw(x, y, z)
-     */
-    fun onEntityMove(self: Entity, ship: Ship, position: Vector3dc): Vector3dc
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/WorldEntityHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/WorldEntityHandler.kt
@@ -19,8 +19,8 @@ import kotlin.math.atan2
 import kotlin.math.sqrt
 
 object WorldEntityHandler : VSEntityHandler {
-    override fun freshEntityInShipyard(entity: Entity, ship: Ship, position: Vector3dc) {
-        moveEntityFromShipyardToWorld(entity, ship, position)
+    override fun freshEntityInShipyard(entity: Entity, ship: Ship) {
+        moveEntityFromShipyardToWorld(entity, ship)
     }
 
     override fun <T : Entity> applyRenderTransform(
@@ -47,11 +47,8 @@ object WorldEntityHandler : VSEntityHandler {
     ) {
     }
 
-    override fun onEntityMove(self: Entity, ship: Ship, position: Vector3dc) =
-        moveEntityFromShipyardToWorld(self, ship, position)
-
-    fun moveEntityFromShipyardToWorld(entity: Entity, ship: Ship, position: Vector3dc): Vector3dc {
-        val newPos = ship.shipToWorld.transformPosition(Vector3d(position))
+    private fun moveEntityFromShipyardToWorld(entity: Entity, ship: Ship): Vector3dc {
+        val newPos = ship.shipToWorld.transformPosition(entity.position().toJOML())
         entity.setPos(newPos.x, newPos.y, newPos.z)
         entity.xo = entity.x
         entity.yo = entity.y


### PR DESCRIPTION
setPosRaw might be called before the velocity of the entity is updated, causing the velocity of entities that were spawned in the shipyard and teleported to the world to remain untransformed.

If it turns out to that entities are often teleported into the shipyard AFTER being spawned we may want to teleport all entities out of the shipyard at the end of the tick. 

But for now, let's see if this works.

Closes #303