### PR TITLE
fix: terrain update performance

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
@@ -6,11 +6,8 @@ import com.google.common.collect.Lists;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.function.BooleanSupplier;
 import net.minecraft.core.BlockPos;
@@ -45,6 +42,7 @@ import org.valkyrienskies.core.api.ships.Wing;
 import org.valkyrienskies.core.api.ships.WingManager;
 import org.valkyrienskies.core.apigame.world.ServerShipWorldCore;
 import org.valkyrienskies.core.apigame.world.chunks.TerrainUpdate;
+import org.valkyrienskies.core.impl.datastructures.DenseBlockPosSet;
 import org.valkyrienskies.mod.common.IShipObjectWorldServerProvider;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.block.WingBlock;
@@ -62,7 +60,7 @@ public abstract class MixinServerLevel implements IShipObjectWorldServerProvider
     @NotNull
     public abstract MinecraftServer getServer();
 
-    private final Set<Vector3ic> knownChunkRegions = new HashSet<>();
+    private final DenseBlockPosSet knownChunkRegions = new DenseBlockPosSet();
 
     @Nullable
     @Override
@@ -125,7 +123,7 @@ public abstract class MixinServerLevel implements IShipObjectWorldServerProvider
         // Create DenseVoxelShapeUpdate for new loaded chunks
         // Also mark the chunks as loaded in the ship objects
         final List<TerrainUpdate> voxelShapeUpdates = new ArrayList<>();
-        final Set<Vector3ic> currentTickChunkRegions = new HashSet<>();
+        final DenseBlockPosSet currentTickChunkRegions = new DenseBlockPosSet();
 
         for (final ChunkHolder chunkHolder : loadedChunksList) {
             final Optional<LevelChunk> worldChunkOptional =
@@ -192,17 +190,16 @@ public abstract class MixinServerLevel implements IShipObjectWorldServerProvider
             }
         }
 
-        final Iterator<Vector3ic> knownChunkPosIterator = knownChunkRegions.iterator();
-        while (knownChunkPosIterator.hasNext()) {
-            final Vector3ic knownChunkPos = knownChunkPosIterator.next();
-            if (!currentTickChunkRegions.contains(knownChunkPos)) {
+        knownChunkRegions.forEach((x, y, z) -> {
+            if (!currentTickChunkRegions.contains(x, y, z)) {
                 // Delete this chunk
-                final TerrainUpdate deleteVoxelShapeUpdate =
-                    getVsCore().newDeleteTerrainUpdate(knownChunkPos.x(), knownChunkPos.y(), knownChunkPos.z());
+                final TerrainUpdate deleteVoxelShapeUpdate = getVsCore().newDeleteTerrainUpdate(x, y, z);
                 voxelShapeUpdates.add(deleteVoxelShapeUpdate);
-                knownChunkPosIterator.remove();
+
+                // DenseBlockPosSet doesn't throw ConcurrentModificationException
+                knownChunkRegions.remove(x, y, z);
             }
-        }
+        });
 
         // Send new loaded chunks updates to the ship world
         shipObjectWorld.addTerrainUpdates(

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/BlockStateInfoProvider.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/BlockStateInfoProvider.kt
@@ -17,6 +17,7 @@ import org.valkyrienskies.core.apigame.world.chunks.BlockType
 import org.valkyrienskies.mod.common.block.WingBlock
 import org.valkyrienskies.mod.common.config.MassDatapackResolver
 import org.valkyrienskies.mod.common.hooks.VSGameEvents
+import java.util.function.IntFunction
 
 // Other mods can then provide weights and types based on their added content
 // NOTE: if we have block's in vs-core we should ask getVSBlock(blockstate: BlockStat): VSBlock since thatd be more handy
@@ -53,20 +54,33 @@ object BlockStateInfo {
 
     // This is [ThreadLocal] because in single-player games the Client thread and Server thread will read/write to
     // [CACHE] simultaneously. This creates a data race that can crash the game (See https://github.com/ValkyrienSkies/Valkyrien-Skies-2/issues/126).
-    val CACHE: ThreadLocal<Int2ObjectOpenHashMap<Pair<Double, BlockType>>> =
-        ThreadLocal.withInitial { Int2ObjectOpenHashMap<Pair<Double, BlockType>>() }
+
+    class Cache {
+        // Use a load factor of 0.5f because this map is hit very often
+        private val blockStateCache: Int2ObjectOpenHashMap<Pair<Double, BlockType>> =
+            Int2ObjectOpenHashMap<Pair<Double, BlockType>>(2048, 0.5f)
+
+        fun get(blockState: BlockState): Pair<Double, BlockType>? {
+            val blockId = Block.getId(blockState)
+
+            if (blockId == -1) {
+                return null
+            }
+
+            return blockStateCache.computeIfAbsent(blockId, IntFunction { iterateRegistry(blockState) })
+        }
+    }
+
+    private val _cache = ThreadLocal.withInitial { Cache() }
+    val cache: Cache get() = _cache.get()
+
     // NOTE: this caching can get allot better, ex. default just returns constants so it might be more faster
     //  if we store that these values do not need to be cached by double and blocktype but just that they use default impl
 
     // this gets the weight and type provided by providers; or it gets it out of the cache
 
-    fun get(blockState: BlockState): Pair<Double, BlockType>? =
-        getId(blockState)?.let { CACHE.get().getOrPut(it) { iterateRegistry(blockState) } }
-
-    fun getId(blockState: BlockState): Int? {
-        val r = Block.getId(blockState)
-        if (r == -1) return null
-        return r
+    fun get(blockState: BlockState): Pair<Double, BlockType>? {
+        return cache.get(blockState)
     }
 
     private fun iterateRegistry(blockState: BlockState): Pair<Double, BlockType> =

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
@@ -375,10 +375,11 @@ fun Ship.toWorldCoordinates(x: Double, y: Double, z: Double, dest: Vector3d = Ve
 
 fun LevelChunkSection.toDenseVoxelUpdate(chunkPos: Vector3ic): TerrainUpdate {
     val update = vsCore.newDenseTerrainUpdateBuilder(chunkPos.x(), chunkPos.y(), chunkPos.z())
+    val info = BlockStateInfo.cache
     for (x in 0..15) {
         for (y in 0..15) {
             for (z in 0..15) {
-                update.addBlock(x, y, z, BlockStateInfo.get(getBlockState(x, y, z))?.second ?: vsCore.blockTypes.air)
+                update.addBlock(x, y, z, info.get(getBlockState(x, y, z))?.second ?: vsCore.blockTypes.air)
             }
         }
     }


### PR DESCRIPTION
Terrain update is taking up a lot of tick time doing hashtable lookups. This is a tentative fix, needs to be tested before merging

see spark profiles:
https://spark.lucko.me/V1QB339Y6V
https://spark.lucko.me/JDGEW88gM3
https://spark.lucko.me/uK9b6Amvj1