### PR TITLE
Change Sodium maven source to jitpack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ subprojects {
             maven { url = "https://maven.tterrag.com/" } // Registrate, Forge Create and Flywheel
             maven { url = "https://maven.cafeteria.dev/releases" } // Fake Player API
             maven { url = "https://maven.jamieswhiteshirt.com/libs-release" } // Reach Entity Attributes
+            maven { url 'https://jitpack.io' }
         }
     }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     modApi("me.shedaniel.cloth:cloth-config:4.14.64")
 
-    modCompileOnly("curse.maven:sodium-394468:3669187")
+    modCompileOnly("com.github.CaffeineMC:sodium-fabric:mc1.18.2-0.4.1")
 
     // vs-core
     implementation("org.valkyrienskies.core:impl:${rootProject.vs_core_version}") {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     include(modImplementation("net.fabricmc:fabric-language-kotlin:1.8.5+kotlin.1.7.20"))
     include(modImplementation("me.shedaniel.cloth:cloth-config-fabric:6.3.81"))
 
-    modImplementation("curse.maven:sodium-394468:3669187")
+    modImplementation("com.github.CaffeineMC:sodium-fabric:mc1.18.2-0.4.1")
     modImplementation("com.terraformersmc:modmenu:3.2.3")
 
     // Depend on the fabric API


### PR DESCRIPTION
Currently, Curse Maven is returning 403 for Sodium. This may only be related to the recent malware troubles, but Sodium is no longer uploading new versions to CurseForge, so it may be worth changing the source anyways.