### PR TITLE
Mass Tooltip for All BlockItems

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mass_tooltip/MixinBlockItem.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mass_tooltip/MixinBlockItem.java
@@ -25,7 +25,7 @@ public class MixinBlockItem {
             final Double mass = Objects.requireNonNull(BlockStateInfo.INSTANCE.get(item.getBlock().defaultBlockState()))
                 .getFirst();
             list.add(new TranslatableComponent("tooltip.valkyrienskies.mass").append(
-                ": " + mass).withStyle(ChatFormatting.DARK_GRAY));
+                ": " + mass + "kg").withStyle(ChatFormatting.DARK_GRAY));
         } catch (final Exception ignored) {
 
         }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mass_tooltip/MixinBlockItem.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mass_tooltip/MixinBlockItem.java
@@ -1,0 +1,33 @@
+package org.valkyrienskies.mod.mixin.feature.mass_tooltip;
+
+import java.util.List;
+import java.util.Objects;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.mod.common.BlockStateInfo;
+
+@Mixin(BlockItem.class)
+public class MixinBlockItem {
+    @Inject(method = "appendHoverText", at = @At("HEAD"))
+    private void ValkyrienSkies$addMassToTooltip(final ItemStack itemStack, final Level level,
+        final List<Component> list, final TooltipFlag tooltipFlag, final CallbackInfo ci) {
+        try {
+            final BlockItem item = (BlockItem) itemStack.getItem();
+            final Double mass = Objects.requireNonNull(BlockStateInfo.INSTANCE.get(item.getBlock().defaultBlockState()))
+                .getFirst();
+            list.add(new TranslatableComponent("tooltip.valkyrienskies.mass").append(
+                ": " + mass).withStyle(ChatFormatting.DARK_GRAY));
+        } catch (final Exception ignored) {
+
+        }
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixinducks/feature/mass_tooltip/MassTooltipVisibility.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixinducks/feature/mass_tooltip/MassTooltipVisibility.java
@@ -1,0 +1,14 @@
+package org.valkyrienskies.mod.mixinducks.feature.mass_tooltip;
+
+import net.minecraft.world.item.TooltipFlag;
+
+public enum MassTooltipVisibility {
+    ALWAYS,
+    ADVANCED,
+    DISABLED;
+
+    public boolean isVisible(final TooltipFlag flag) {
+        return this.equals(ALWAYS) ||
+            (this.equals(ADVANCED) && flag.isAdvanced());
+    }
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -1,6 +1,7 @@
 package org.valkyrienskies.mod.common.config
 
 import com.github.imifou.jsonschema.module.addon.annotation.JsonSchema
+import org.valkyrienskies.mod.mixinducks.feature.mass_tooltip.MassTooltipVisibility
 
 object VSGameConfig {
 
@@ -14,6 +15,8 @@ object VSGameConfig {
     val COMMON = Common()
 
     class Client {
+        val Tooltip = TOOLTIP()
+
         @JsonSchema(description = "Renders the VS2 debug HUD with TPS")
         var renderDebugText = false
 
@@ -21,6 +24,18 @@ object VSGameConfig {
             description = "Recommend ship slugs in mc commands where player names could be used ex. /tp ship-name wich could pollute user autocomplete"
         )
         var recommendSlugsInMcCommands = true
+
+        class TOOLTIP {
+            @JsonSchema(
+                description = "Set when the Mass Tooltip is Visible"
+            )
+            var massTooltipVisibility = MassTooltipVisibility.ADVANCED
+
+            @JsonSchema(
+                description = "Use Imperial Units to show Mass"
+            )
+            var useImperialUnits = false
+        }
     }
 
     class Server {

--- a/common/src/main/resources/assets/valkyrienskies/lang/en_us.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/en_us.json
@@ -17,5 +17,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "Can only teleport to exactly 1 ship",
   "command.valkyrienskies.get_ship.success": "Found ship with slug %s",
   "command.valkyrienskies.get_ship.fail": "No ship found",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship can only be run by entities!"
+  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship can only be run by entities!",
+  "tooltip.valkyrienskies.mass": "Mass"
 }

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -30,6 +30,7 @@
     "feature.fluid_escaping_ship_config.MixinFlowingFluid",
     "feature.get_entities.MixinLevel",
     "feature.ladders.MixinLivingEntity",
+    "feature.mass_tooltip.MixinBlockItem",
     "feature.mob_spawning.NaturalSpawnerMixin",
     "feature.render_pathfinding.MixinDebugPackets",
     "feature.screen_distance_check.MixinScreenHandler",


### PR DESCRIPTION
Utilizing a Mixin, I have added a tooltip to all BlockItems to display the masses of their associated blocks

This tooltip's visibililty is changeable via the client config where it can be set to always on, only when advanced tooltips are enabled, or disabled

There is also a config option to use Imperial Units when displaying mass

I also added a translation key for "Mass"