### PR TITLE
Change Deprecated Libraries

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
   "depends": {
     "fabricloader": ">=0.14.6",
     "minecraft": ">=1.18.2",
-    "fabric": "*"
+    "fabric-api": "*"
   },
   "breaks": {
   }


### PR DESCRIPTION
This commit changes "fabric" to "fabric-api" since "fabric" is deprecated.