### PR TITLE
Prevent shading of commons-lang3

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -126,6 +126,7 @@ shadowJar {
     duplicatesStrategy DuplicatesStrategy.EXCLUDE // Ignore duplicate valkyrienskies-common.accesswidener files
     dependencies {
         exclude(dependency("org.jetbrains.kotlin:.*:.*")) // Don't shade kotlin!
+        exclude(dependency("org.apache.commons:commons-lang3:.*")) // Don't apache-commons, see #617
     }
     // Exclude dummy Optifine classes
     exclude "net/optifine/**"


### PR DESCRIPTION
I didn't found anything regarding contribution guidelines so I hope this is fine 😄 

---

commons-lang3 is always provided at runtime,
don't shade it to prevent incompatibilities.

Closes #617, #616