### PR TITLE
Fix Create, CBC contraption seats

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/entity/MixinAbstractContraptionEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/entity/MixinAbstractContraptionEntity.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix3d;
 import org.joml.Matrix4d;
 import org.joml.Matrix4dc;
@@ -43,10 +44,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.core.api.ships.ContraptionWingProvider;
 import org.valkyrienskies.core.api.ships.LoadedServerShip;
+import org.valkyrienskies.core.api.ships.LoadedShip;
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.core.api.ships.WingManager;
 import org.valkyrienskies.mod.common.CompatUtil;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.entity.ShipMountedToData;
+import org.valkyrienskies.mod.common.entity.ShipMountedToDataProvider;
 import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 import org.valkyrienskies.mod.compat.CreateConversionsKt;
@@ -54,7 +58,7 @@ import org.valkyrienskies.mod.mixinducks.mod_compat.create.MixinAbstractContrapt
 
 @Mixin(AbstractContraptionEntity.class)
 public abstract class MixinAbstractContraptionEntity extends Entity implements MixinAbstractContraptionEntityDuck,
-    ContraptionWingProvider, IEntityDraggingInformationProvider {
+    ContraptionWingProvider, IEntityDraggingInformationProvider, ShipMountedToDataProvider {
 
     public MixinAbstractContraptionEntity(EntityType<?> entityType, Level level) {
         super(entityType, level);
@@ -80,6 +84,16 @@ public abstract class MixinAbstractContraptionEntity extends Entity implements M
 
     @Shadow
     public abstract Vec3 getPrevAnchorVec();
+
+    @Nullable
+    @Override
+    public ShipMountedToData provideShipMountedToData(@NotNull final Entity passenger, @Nullable final Float partialTicks) {
+        final LoadedShip shipObjectEntityMountedTo = VSGameUtilsKt.getShipObjectManagingPos(passenger.level, toJOML(this.position()));
+        if (shipObjectEntityMountedTo == null) return null;
+
+        final Vector3dc mountedPosInShip = toJOML(this.getPassengerPosition(passenger, partialTicks == null ? 1 : partialTicks));
+        return new ShipMountedToData(shipObjectEntityMountedTo, mountedPosInShip);
+    }
 
     //Region start - fix being sent to the  ̶s̶h̶a̶d̶o̶w̶r̶e̶a̶l̶m̶ shipyard on ship contraption disassembly
     @Redirect(method = "moveCollidedEntitiesOnDisassembly", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setPos(DDD)V"))

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create_big_cannons/MixinPitchOrientedContraptionEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create_big_cannons/MixinPitchOrientedContraptionEntity.java
@@ -1,5 +1,7 @@
 package org.valkyrienskies.mod.mixin.mod_compat.create_big_cannons;
 
+import static org.valkyrienskies.mod.common.util.VectorConversionsMCKt.toJOML;
+
 import com.simibubi.create.content.contraptions.OrientedContraptionEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
@@ -46,6 +48,13 @@ public abstract class MixinPitchOrientedContraptionEntity extends OrientedContra
                     .subtract(0, passenger.getEyeHeight(), 0);
                 ci.setReturnValue(original);
             }
+        }
+    }
+
+    @Inject(method="getPassengerPosition", at = @At("RETURN"), cancellable = true, remap = false)
+    protected void vsGetPassengerPosition(Entity passenger, float partialTicks, CallbackInfoReturnable<Vec3> cir) {
+        if (VSGameUtilsKt.getShipObjectManagingPos(passenger.level, toJOML(this.position())) != null) {
+            cir.setReturnValue(cir.getReturnValue().add(0,0.1,0));
         }
     }
 }


### PR DESCRIPTION
Made rendering respect the passenger offset of Create contraptions, and by extension CBC contraptions.
Added a small offset to CBC cause the ship transform messes with it slightly, a thorough fix can wait. 