### PR TITLE
Stop Flywheel BatchingEngine crash

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/flywheel/MixinBlockEntityInstanceManager.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/flywheel/MixinBlockEntityInstanceManager.java
@@ -48,6 +48,7 @@ public abstract class MixinBlockEntityInstanceManager extends InstanceManager<Bl
         cancellable = true
     )
     void preCreateRaw(final BlockEntity blockEntity, final CallbackInfoReturnable<Instance> cir) {
+        
         final Level nullableLevel = blockEntity.getLevel();
         if (nullableLevel instanceof final ClientLevel level) {
             final ClientShip ship = VSGameUtilsKt.getShipObjectManagingPos(
@@ -57,7 +58,8 @@ public abstract class MixinBlockEntityInstanceManager extends InstanceManager<Bl
                     vs$shipMaterialManagers.computeIfAbsent(ship, k -> vs$createMaterialManager());
                 final Vector3i c =
                     ship.getChunkClaim().getCenterBlockCoordinates(VSGameUtilsKt.getYRange(nullableLevel), new Vector3i());
-                ((InstancingEngineAccessor) manager).setOriginCoordinate(new BlockPos(c.x, c.y, c.z));
+                if (manager instanceof InstancingEngineAccessor)
+                    ((InstancingEngineAccessor) manager).setOriginCoordinate(new BlockPos(c.x, c.y, c.z));
 
                 cir.setReturnValue(InstancedRenderRegistry.createInstance(manager, blockEntity));
             }


### PR DESCRIPTION
Check if Flywheel is using the instancing engine before asserting that it is.  Since the Batching engine doesn't use an origin coordinate, I assume not having one shouldn't break anything, but you'll want to double-check.

Currently, attempting to use batching mode will crash the game immediately until the config is changed.

This patch also needs to be applied to the other branches as well.

Fixes #739 and #816.