### PR TITLE
Fix compatibility with Pehkui player scale

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
@@ -103,16 +103,18 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
 
         // Remove the component of [movementAdjustedForCollisions] that is parallel to [collisionResponseHorizontal]
         if (collisionResponseHorizontal.lengthSquared() > 1e-6) {
+            final Vec3 deltaMovement = getDeltaMovement();
+
             final Vector3dc collisionResponseHorizontalNormal = collisionResponseHorizontal.normalize(new Vector3d());
             final double parallelHorizontalVelocityComponent =
                 collisionResponseHorizontalNormal
-                    .dot(movementAdjustedForCollisions.x, 0.0, movementAdjustedForCollisions.z);
+                    .dot(deltaMovement.x, 0.0, deltaMovement.z);
 
             setDeltaMovement(
-                movementAdjustedForCollisions.x
+                deltaMovement.x
                     - collisionResponseHorizontalNormal.x() * parallelHorizontalVelocityComponent,
-                movementAdjustedForCollisions.y,
-                movementAdjustedForCollisions.z
+                deltaMovement.y,
+                deltaMovement.z
                     - collisionResponseHorizontalNormal.z() * parallelHorizontalVelocityComponent
             );
         }


### PR DESCRIPTION
When a player is scaled by Pehkui, the "movement" and "movementAdjustedForCollisions" parameters of the `redirectSetVelocity` inject are scaled too, but the `deltaMovement` property of Entities is not adjusted. Since the inject uses `setDeltaMovement` with a parameter that has been scaled, this results in the player slowing down (when small), or speeding up (when large) while moving against a block. (Specifically while moving against a block since the function inject overrides is only called when performing a horizontal collision).