### PR TITLE
Fix #486 - when you log off on a ship and it moves, you should log on still in the ship, not in the middle of nowhere

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/teleport_reconnected_player_to_ship/MixinServerPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/teleport_reconnected_player_to_ship/MixinServerPlayer.java
@@ -1,0 +1,89 @@
+package org.valkyrienskies.mod.mixin.feature.teleport_reconnected_player_to_ship;
+
+import com.mojang.authlib.GameProfile;
+import javax.annotation.Nullable;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import org.joml.Vector3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.util.EntityDraggingInformation;
+import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider;
+
+@Mixin(ServerPlayer.class)
+public abstract class MixinServerPlayer extends Player {
+
+    @Shadow
+    public abstract ServerLevel serverLevel();
+
+    public MixinServerPlayer(final Level level, final BlockPos blockPos, final float f,
+        final GameProfile gameProfile) {
+        super(level, blockPos, f, gameProfile);
+        throw new IllegalStateException("Unreachable");
+    }
+
+    @Inject(method = "readAdditionalSaveData", at = @At("RETURN"))
+    void teleportToShip(final CompoundTag compoundTag, final CallbackInfo ci) {
+        if (!compoundTag.contains("LastShipId"))
+            return; // Player did not disconnect off of any ship
+
+        final long lastShipId = compoundTag.getLong("LastShipId");
+        System.out.println("Last ship id is: " + lastShipId);
+
+        final Ship ship = VSGameUtilsKt.getShipObjectWorld(serverLevel()).getAllShips().getById(lastShipId);
+        System.out.println("Should teleport to: " + ship);
+
+        // If ship doesn't exist, don't bother
+        if (ship == null)
+            return;
+
+        // Translate ship coords to world coords
+        final double x = compoundTag.getDouble("RelativeShipX");
+        final double y = compoundTag.getDouble("RelativeShipY");
+        final double z = compoundTag.getDouble("RelativeShipZ");
+
+        final Vector3d playerShipPosition = new Vector3d(x, y, z);
+        final Vector3d playerWorldPosition = ship.getShipToWorld().transformPosition(playerShipPosition);
+
+        setPos(playerWorldPosition.x, playerWorldPosition.y, playerWorldPosition.z);
+    }
+
+    @Inject(method = "addAdditionalSaveData", at = @At("RETURN"))
+    void rememberLastShip(final CompoundTag compoundTag, final CallbackInfo ci) {
+        final EntityDraggingInformation draggingInformation = ((IEntityDraggingInformationProvider) this).getDraggingInformation();
+
+        if (draggingInformation.getTicksSinceStoodOnShip() > 4)
+            return;
+
+        @Nullable final Long lastShipId = draggingInformation.getLastShipStoodOn();
+
+        if (lastShipId == null)
+            return;
+
+        compoundTag.putLong("LastShipId", lastShipId);
+        System.out.println("Saved as: " + lastShipId);
+
+        final Ship ship = VSGameUtilsKt.getShipObjectWorld(serverLevel()).getAllShips().getById(lastShipId);
+
+        if (ship == null)
+            return;
+
+        // Get position relative to ship
+        // (Technically, this grabs the position in the shipyard, but it works well enough...)
+        final Vector3d playerWorldPosition = new Vector3d(getX(), getY(), getZ());
+        final Vector3d playerShipPosition = ship.getWorldToShip().transformPosition(playerWorldPosition);
+
+        compoundTag.putDouble("RelativeShipX", playerShipPosition.x);
+        compoundTag.putDouble("RelativeShipY", playerShipPosition.y);
+        compoundTag.putDouble("RelativeShipZ", playerShipPosition.z);
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/teleport_reconnected_player_to_ship/MixinServerPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/teleport_reconnected_player_to_ship/MixinServerPlayer.java
@@ -37,11 +37,8 @@ public abstract class MixinServerPlayer extends Player {
             return; // Player did not disconnect off of any ship
 
         final long lastShipId = compoundTag.getLong("LastShipId");
-        System.out.println("Last ship id is: " + lastShipId);
 
         final Ship ship = VSGameUtilsKt.getShipObjectWorld(serverLevel()).getAllShips().getById(lastShipId);
-        System.out.println("Should teleport to: " + ship);
-
         // If ship doesn't exist, don't bother
         if (ship == null)
             return;
@@ -65,15 +62,12 @@ public abstract class MixinServerPlayer extends Player {
             return;
 
         @Nullable final Long lastShipId = draggingInformation.getLastShipStoodOn();
-
         if (lastShipId == null)
             return;
 
         compoundTag.putLong("LastShipId", lastShipId);
-        System.out.println("Saved as: " + lastShipId);
 
         final Ship ship = VSGameUtilsKt.getShipObjectWorld(serverLevel()).getAllShips().getById(lastShipId);
-
         if (ship == null)
             return;
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -96,6 +96,20 @@ object VSGameConfig {
         var enableMovementChecks = false
 
         @JsonSchema(
+            description = "If true, when a player disconnects, their position on the ship is saved such that " +
+                "if the ship is moved, when they reconnect they will be teleported to the same position in the ship " +
+                "as they left, instead of being left behind."
+        )
+        var teleportReconnectedPlayers = true
+
+        @JsonSchema(
+            description = "Determines how many airborne ticks after a player leaves the ground of a" +
+                "ship that they are still considered part of it when they disconnect, such that they will" +
+                "be teleported back to it after reconnecnting."
+        )
+        var maxAirborneTicksForReconnectedPlayerTeleport = 4
+
+        @JsonSchema(
             description = "If true, prevents water and other fluids from flowing out of the ship's bounding box."
         )
         var preventFluidEscapingShip = true

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -48,6 +48,7 @@
     "feature.shipyard_entities.MixinServerLevel",
     "feature.shipyard_entities.MixinTransientEntitySectionManager",
     "feature.spawn_player_on_ship.MixinServerGamePacketListenerImpl",
+    "feature.teleport_reconnected_player_to_ship.MixinServerPlayer",
     "feature.tick_ship_chunks.MixinChunkMap",
     "feature.world_border.MixinLevel",
     "feature.world_border.MixinWorldBorder",


### PR DESCRIPTION
Fixes #486 

When you log off on top of a ship, or in mid-air within 4 ticks of jumping off a ship (can be changed), the id of the last ship you stood on, as well as your position in the ship's chunk claim is saved as nbt. When you reconnect, and you have the `LastShipId` tag, and it points to a valid ship, then the chunk claim position is translated to the world position and you are teleported to that position.

Please let me know of any errors/considerations. Thank you.