### PR TITLE
Fixed changed tag

### DIFF
--- a/common/src/main/resources/data/valkyrienskies/vs_mass/misc.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/misc.json
@@ -375,7 +375,7 @@
     "elasticity": 0.5
   },
   {
-    "tag": "minecraft:carpets",
+    "tag": "minecraft:wool_carpets",
     "mass": 2.0,
     "friction": 0.6,
     "elasticity": 0.05


### PR DESCRIPTION
in 1.19 22w13a carpets block and item tag were renamed to wool_carpets.