### PR TITLE
teleport mobs to ship when loading back in

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/entity/MixinMob.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/entity/MixinMob.java
@@ -1,0 +1,66 @@
+package org.valkyrienskies.mod.mixin.entity;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.Mob;
+import org.joml.Vector3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.mod.common.entity.ShipyardPosSavable;
+
+@Mixin(Mob.class)
+public class MixinMob implements ShipyardPosSavable {
+
+    @Unique
+    public Vector3d valkyrienskies$unloadedShipyardPos = null;
+
+    @Override
+    public Vector3d valkyrienskies$getUnloadedShipyardPos() {
+        return valkyrienskies$unloadedShipyardPos;
+    }
+
+    @Override
+    public void valkyrienskies$setUnloadedShipyardPos(Vector3d vector3d) {
+        this.valkyrienskies$unloadedShipyardPos = vector3d;
+    }
+
+
+    /**
+     * Save mob's shipyard position to nbt, or clear it if null
+     *
+     * @author G_Mungus
+     */
+    @Inject(method = "addAdditionalSaveData", at = @At("RETURN"))
+    public void addAdditionalSaveDataMixin(CompoundTag nbt, CallbackInfo info) {
+        Vector3d position = this.valkyrienskies$getUnloadedShipyardPos();
+        if (position != null) {
+            nbt.putDouble("valkyrienskies$unloadedX",position.x);
+            nbt.putDouble("valkyrienskies$unloadedY",position.y);
+            nbt.putDouble("valkyrienskies$unloadedZ", position.z);
+        } else {
+            nbt.remove("valkyrienskies$unloadedX");
+            nbt.remove("valkyrienskies$unloadedY");
+            nbt.remove("valkyrienskies$unloadedZ");
+        }
+    }
+
+
+    /**
+     * Read mob's shipyard position from nbt
+     *
+     * @author G_Mungus
+     */
+    @Inject(method = "readAdditionalSaveData", at = @At("RETURN"))
+    public void readAdditionalSaveData(CompoundTag nbt, CallbackInfo info) {
+        if (nbt.contains("valkyrienskies$unloadedX") && nbt.contains("valkyrienskies$unloadedY") && nbt.contains("valkyrienskies$unloadedZ")) {
+            double[] xyz = {nbt.getDouble("valkyrienskies$unloadedX"), nbt.getDouble("valkyrienskies$unloadedY"), nbt.getDouble("valkyrienskies$unloadedZ")};
+            this.valkyrienskies$setUnloadedShipyardPos(new Vector3d(xyz));
+        }
+    }
+
+
+
+}
+

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinChunkMap.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinChunkMap.java
@@ -9,17 +9,25 @@ import java.util.function.Supplier;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.Mob;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.storage.DimensionDataStorage;
+import org.joml.Vector3d;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.core.apigame.world.IPlayer;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.entity.ShipyardPosSavable;
 import org.valkyrienskies.mod.common.util.MinecraftPlayer;
+import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
+
 
 @Mixin(ChunkMap.class)
 public abstract class MixinChunkMap {
@@ -100,6 +108,65 @@ public abstract class MixinChunkMap {
         );
 
         cir.setReturnValue(new ArrayList<>(watchingPlayers));
+    }
+
+    /**
+     * Save mob's shipyard position when it gets unloaded
+     *
+     * @author G_Mungus
+     */
+
+    @Inject(method = "removeEntity", at = @At("HEAD"))
+    protected void unloadEntityMixin(Entity entity, CallbackInfo info) {
+        if (entity instanceof Mob mob) {
+            Vector3d shipyardPos = valkyrienskies$getPosInShipyard(mob);
+            if (shipyardPos != null &&
+                VSGameUtilsKt.getShipManagingPos(this.level, shipyardPos) != null &&
+                ((ShipyardPosSavable)mob).valkyrienskies$getUnloadedShipyardPos() == null) {
+
+                ((ShipyardPosSavable)mob).valkyrienskies$setUnloadedShipyardPos(shipyardPos);
+            }
+        }
+    }
+
+    /**
+     * Teleport mob to correct position on ship when loaded back in
+     *
+     * @author G_Mungus
+     */
+
+    @Inject(method = "addEntity", at = @At("RETURN"))
+    protected void loadEntityMixin(Entity entity, CallbackInfo info) {
+        if (entity instanceof Mob mob) {
+            Vector3d shipyardPos = ((ShipyardPosSavable)mob).valkyrienskies$getUnloadedShipyardPos();
+            if(shipyardPos != null) {
+                mob.teleportTo(shipyardPos.x,
+                    shipyardPos.y,
+                    shipyardPos.z);
+
+                ((ShipyardPosSavable) mob).valkyrienskies$setUnloadedShipyardPos(null);
+            }
+        }
+    }
+
+
+    /**
+     * Helper method to get shipyard pos of mob on a ship
+     * <p>
+     * Implementation might look wierd but the way I originally had it didn't work while in the middle of chunk unloading
+     *
+     * @author G_Mungus
+     */
+    @Unique
+    private Vector3d valkyrienskies$getPosInShipyard(final Entity entity) {
+        List<Vector3d> vectors = VSGameUtilsKt.transformToNearbyShipsAndWorld(entity.level(), entity.getX(), entity.getY(), entity.getZ(), 1.0);
+
+        for (Vector3d vec : vectors) {
+            if (VSGameUtilsKt.isBlockInShipyard(entity.level(), VectorConversionsMCKt.toMinecraft(vec))) {
+                return vec;
+            }
+        }
+        return null;
     }
 
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/ShipyardPosSavable.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/ShipyardPosSavable.kt
@@ -1,0 +1,8 @@
+package org.valkyrienskies.mod.common.entity
+
+import org.joml.Vector3d
+
+interface ShipyardPosSavable {
+    fun `valkyrienskies$getUnloadedShipyardPos`(): Vector3d?
+    fun `valkyrienskies$setUnloadedShipyardPos`(vector3d: Vector3d?)
+}

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -16,6 +16,7 @@
     "accessors.world.level.pathfinder.PathAccessor",
     "commands.argument.selector.MixinEntitySelectorParser",
     "entity.MixinEntity",
+    "entity.MixinMob",
     "feature.ai.node_evaluator.PathNavigationRegionAccessor",
     "feature.ai.node_evaluator.SwimNodeEvaluatorMixin",
     "feature.ai.node_evaluator.WalkNodeEvaluatorMixin",


### PR DESCRIPTION
Saves Mob's shipyard location when unloading and saves it to NBT, then teleports mob back onto the ship when loading back in. This makes it so that mobs no longer fall off of a moving ship when the player moves away and comes back.