### PR TITLE
Use seated pos when checking entity distance

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/entity/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/entity/MixinEntity.java
@@ -125,6 +125,29 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
         cir.setReturnValue(newEyePos);
     }
 
+    @Inject(method = "getEyePosition()Lnet/minecraft/world/phys/Vec3;", at = @At("HEAD"), cancellable = true)
+    private void preGetEyePosition2(final CallbackInfoReturnable<Vec3> cir) {
+        final ShipMountedToData shipMountedToData = VSGameUtilsKt.getShipMountedToData(Entity.class.cast(this), null);
+        if (shipMountedToData == null) {
+            return;
+        }
+        final LoadedShip shipMountedTo = shipMountedToData.getShipMountedTo();
+
+        final ShipTransform shipTransform;
+        if (shipMountedTo instanceof ShipObjectClient) {
+            shipTransform = ((ShipObjectClient) shipMountedTo).getRenderTransform();
+        } else {
+            shipTransform = shipMountedTo.getShipTransform();
+        }
+        final Vector3dc basePos = shipTransform.getShipToWorldMatrix()
+            .transformPosition(shipMountedToData.getMountPosInShip(), new Vector3d());
+        final Vector3dc eyeRelativePos = shipTransform.getShipCoordinatesToWorldCoordinatesRotation().transform(
+            new Vector3d(0.0, getEyeHeight(), 0.0)
+        );
+        final Vec3 newEyePos = VectorConversionsMCKt.toMinecraft(basePos.add(eyeRelativePos, new Vector3d()));
+        cir.setReturnValue(newEyePos);
+    }
+
     /**
      * @reason Needed for players to pick blocks correctly when mounted to a ship
      */

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
@@ -117,8 +117,11 @@ val Player.playerWrapper get() = (this as PlayerDuck).vs_getPlayer()
 /**
  * Like [Entity.squaredDistanceTo] except the destination is transformed into world coordinates if it is a ship
  */
-fun Entity.squaredDistanceToInclShips(x: Double, y: Double, z: Double) =
-    level.squaredDistanceBetweenInclShips(x, y, z, this.x, this.y, this.z)
+fun Entity.squaredDistanceToInclShips(x: Double, y: Double, z: Double): Double {
+    var p = this.position()
+    getShipMountedToData(this, null)?.mountPosInShip?.toMinecraft()?.let{ p = it }
+    return level().squaredDistanceBetweenInclShips(x, y, z, p.x, p.y, p.z)
+}
 
 /**
  * Calculates the squared distance between to points.


### PR DESCRIPTION
**CHANGE, REASON**
- Use the seat position where valid in entity distance checks 
   -  Utilise the seat position in ship for distance checks which is guaranteed to be accurate _for checks on the same ship_
- `Entity::getEyePosition` without partial tick uses VS2 modification as well
   -  pick does not use entity distance checks instead it uses `IForgePlayer::canReach`, which uses `Entity::getEyePosition()`, which is not mixin'ed by VS2 (only `Entity::getEyePosition(F)` is)

**KNOWN EFFECTS**
- Interacting with a moving ship while seated on it is significantly more reliable, up to 1km/s (tested)

**CAVEATS**
### **NOT TESTED ON FABRIC**
- ~~no guarantees when player is not seated~~ See: #1027
- not tested to work between ships, I have no clue when that'd ever apply in normal gameplay