### PR TITLE
Update MixinEntity.java For Pekhui compatibility

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
@@ -137,16 +137,18 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
 
         // Remove the component of [movementAdjustedForCollisions] that is parallel to [collisionResponseHorizontal]
         if (collisionResponseHorizontal.lengthSquared() > 1e-6) {
+            final Vec3 deltaMovement = getDeltaMovement();
+
             final Vector3dc collisionResponseHorizontalNormal = collisionResponseHorizontal.normalize(new Vector3d());
             final double parallelHorizontalVelocityComponent =
                 collisionResponseHorizontalNormal
-                    .dot(movementAdjustedForCollisions.x, 0.0, movementAdjustedForCollisions.z);
+                    .dot(deltaMovement.x, 0.0, deltaMovement.z);
 
             setDeltaMovement(
-                movementAdjustedForCollisions.x
+                deltaMovement.x
                     - collisionResponseHorizontalNormal.x() * parallelHorizontalVelocityComponent,
-                movementAdjustedForCollisions.y,
-                movementAdjustedForCollisions.z
+                deltaMovement.y,
+                deltaMovement.z
                     - collisionResponseHorizontalNormal.z() * parallelHorizontalVelocityComponent
             );
         }


### PR DESCRIPTION
Delta movement change to allow for proper scaling of momentum for scaled players. Similar changes have been merged into 1.20/main. 