### PR TITLE
Make shipyard entities not get dragged by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,17 @@
 Valkyrien Skies 2
 </h1>
 <p align="center">
-<a href="https://www.valkyrienskies.org/">Website</a> - <a href="https://www.curseforge.com/minecraft/mc-mods/valkyrien-skies">CurseForge</a> - 
-<a href="https://modrinth.com/mod/valkyrien-skies">Modrinth</a> - <a href="https://wiki.valkyrienskies.org/wiki/Main_Page">Wiki</a> - <a href="https://discord.gg/rG3QNDV">Discord</a>
+<a href="https://www.valkyrienskies.org/"><img src="https://img.shields.io/badge/Website-white?style=for-the-badge&logo=html5&logoColor=black" alt="Website"></a>
+<a href="https://www.curseforge.com/minecraft/mc-mods/valkyrien-skies"><img src="https://img.shields.io/badge/CurseForge-white?style=for-the-badge&logo=curseforge" alt="CurseForge"></a>
+<a href="https://modrinth.com/mod/valkyrien-skies"><img src="https://img.shields.io/badge/Modrinth-white?style=for-the-badge&logo=modrinth" alt="Modrinth"></a>
+<a href="https://wiki.valkyrienskies.org/wiki/Main_Page"><img src="https://img.shields.io/badge/Wiki-white?style=for-the-badge&logo=wikipedia&logoColor=black" alt="Wiki"></a>
+<a href="https://discord.gg/rG3QNDV"><img src="https://img.shields.io/badge/Discord-white?style=for-the-badge&logo=discord" alt="Discord"></a>
 </p>
 
 *The physics mod to end all other physics mods. Better compatibility,
 performance, collisions, interactions and physics than anything prior!*
 
 ![2022-11-01_21 58 07](https://user-images.githubusercontent.com/26909616/199406363-38e1d032-9c18-4aef-a74a-23f4b268e6ad.png)
-
 
 ## Installation
 

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/client/renderer/MixinGameRenderer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/client/renderer/MixinGameRenderer.java
@@ -33,7 +33,7 @@ import org.valkyrienskies.mod.client.IVSCamera;
 import org.valkyrienskies.mod.common.IShipObjectWorldClientProvider;
 import org.valkyrienskies.mod.common.entity.ShipMountedToData;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
-import org.valkyrienskies.mod.common.entity.handling.VSEntityManager;
+import org.valkyrienskies.mod.common.util.EntityDragger;
 import org.valkyrienskies.mod.common.util.EntityDraggingInformation;
 import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
@@ -129,7 +129,7 @@ public abstract class MixinGameRenderer {
 
             // Also update entity last tick positions, so that they interpolate correctly
             for (final Entity entity : clientWorld.entitiesForRendering()) {
-                if (!((IEntityDraggingInformationProvider) entity).vs$shouldDrag() || VSEntityManager.isShipyardEntity(entity)) {
+                if (EntityDragger.INSTANCE.isDraggable(entity)) {
                     continue;
                 }
                 // The position we want to render [entity] at for this frame

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/client/renderer/MixinGameRenderer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/client/renderer/MixinGameRenderer.java
@@ -33,6 +33,7 @@ import org.valkyrienskies.mod.client.IVSCamera;
 import org.valkyrienskies.mod.common.IShipObjectWorldClientProvider;
 import org.valkyrienskies.mod.common.entity.ShipMountedToData;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.entity.handling.VSEntityManager;
 import org.valkyrienskies.mod.common.util.EntityDraggingInformation;
 import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
@@ -128,7 +129,7 @@ public abstract class MixinGameRenderer {
 
             // Also update entity last tick positions, so that they interpolate correctly
             for (final Entity entity : clientWorld.entitiesForRendering()) {
-                if (!((IEntityDraggingInformationProvider) entity).vs$shouldDrag()) {
+                if (!((IEntityDraggingInformationProvider) entity).vs$shouldDrag() || VSEntityManager.isShipyardEntity(entity)) {
                     continue;
                 }
                 // The position we want to render [entity] at for this frame

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/client/renderer/MixinGameRenderer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/client/renderer/MixinGameRenderer.java
@@ -129,7 +129,7 @@ public abstract class MixinGameRenderer {
 
             // Also update entity last tick positions, so that they interpolate correctly
             for (final Entity entity : clientWorld.entitiesForRendering()) {
-                if (EntityDragger.INSTANCE.isDraggable(entity)) {
+                if (EntityDragger.isDraggable(entity)) {
                     continue;
                 }
                 // The position we want to render [entity] at for this frame

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_movement_packets/MixinServerEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_movement_packets/MixinServerEntity.java
@@ -19,9 +19,9 @@ import org.valkyrienskies.core.api.ships.ServerShip;
 import org.valkyrienskies.core.impl.networking.simple.SimplePacket;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.ValkyrienSkiesMod;
-import org.valkyrienskies.mod.common.entity.handling.VSEntityManager;
 import org.valkyrienskies.mod.common.networking.PacketEntityShipMotion;
 import org.valkyrienskies.mod.common.networking.PacketMobShipRotation;
+import org.valkyrienskies.mod.common.util.EntityDragger;
 import org.valkyrienskies.mod.common.util.EntityDraggingInformation;
 import org.valkyrienskies.mod.common.util.EntityLerper;
 import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider;
@@ -49,7 +49,8 @@ public class MixinServerEntity {
     )
     private void wrapBroadcastAccept(Consumer instance, Object t, Operation<Void> original) {
         if (t instanceof ClientboundSetEntityMotionPacket || t instanceof ClientboundTeleportEntityPacket || t instanceof ClientboundMoveEntityPacket || t instanceof ClientboundRotateHeadPacket) {
-            if (entity instanceof IEntityDraggingInformationProvider draggedEntity && draggedEntity.vs$shouldDrag() && !VSEntityManager.isShipyardEntity(entity)) {
+            if (EntityDragger.INSTANCE.isDraggable(entity)) {
+                IEntityDraggingInformationProvider draggedEntity = (IEntityDraggingInformationProvider) entity;
                 EntityDraggingInformation dragInfo = draggedEntity.getDraggingInformation();
 
                 if (dragInfo != null && dragInfo.isEntityBeingDraggedByAShip() && dragInfo.getLastShipStoodOn() != null) {

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_movement_packets/MixinServerEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_movement_packets/MixinServerEntity.java
@@ -19,6 +19,7 @@ import org.valkyrienskies.core.api.ships.ServerShip;
 import org.valkyrienskies.core.impl.networking.simple.SimplePacket;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.ValkyrienSkiesMod;
+import org.valkyrienskies.mod.common.entity.handling.VSEntityManager;
 import org.valkyrienskies.mod.common.networking.PacketEntityShipMotion;
 import org.valkyrienskies.mod.common.networking.PacketMobShipRotation;
 import org.valkyrienskies.mod.common.util.EntityDraggingInformation;
@@ -48,7 +49,7 @@ public class MixinServerEntity {
     )
     private void wrapBroadcastAccept(Consumer instance, Object t, Operation<Void> original) {
         if (t instanceof ClientboundSetEntityMotionPacket || t instanceof ClientboundTeleportEntityPacket || t instanceof ClientboundMoveEntityPacket || t instanceof ClientboundRotateHeadPacket) {
-            if (entity instanceof IEntityDraggingInformationProvider draggedEntity && draggedEntity.vs$shouldDrag()) {
+            if (entity instanceof IEntityDraggingInformationProvider draggedEntity && draggedEntity.vs$shouldDrag() && !VSEntityManager.isShipyardEntity(entity)) {
                 EntityDraggingInformation dragInfo = draggedEntity.getDraggingInformation();
 
                 if (dragInfo != null && dragInfo.isEntityBeingDraggedByAShip() && dragInfo.getLastShipStoodOn() != null) {

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_movement_packets/MixinServerEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_movement_packets/MixinServerEntity.java
@@ -49,7 +49,7 @@ public class MixinServerEntity {
     )
     private void wrapBroadcastAccept(Consumer instance, Object t, Operation<Void> original) {
         if (t instanceof ClientboundSetEntityMotionPacket || t instanceof ClientboundTeleportEntityPacket || t instanceof ClientboundMoveEntityPacket || t instanceof ClientboundRotateHeadPacket) {
-            if (EntityDragger.INSTANCE.isDraggable(entity)) {
+            if (EntityDragger.isDraggable(entity)) {
                 IEntityDraggingInformationProvider draggedEntity = (IEntityDraggingInformationProvider) entity;
                 EntityDraggingInformation dragInfo = draggedEntity.getDraggingInformation();
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/VSEntityManager.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/VSEntityManager.kt
@@ -102,4 +102,9 @@ object VSEntityManager {
             PacketSyncVSEntityTypes(entityTypes).sendToClient(player)
         }
     }
+
+    @JvmStatic
+    fun isShipyardEntity(entity: Entity): Boolean {
+        return getHandler(entity) == DefaultShipyardEntityHandler
+    }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
@@ -1,16 +1,13 @@
 package org.valkyrienskies.mod.common.util
 
-import net.minecraft.client.Minecraft
 import net.minecraft.client.player.LocalPlayer
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.util.Mth
 import net.minecraft.world.entity.Entity
-import net.minecraft.world.entity.player.Player
 import net.minecraft.world.phys.Vec3
 import org.joml.Vector3d
 import org.joml.Vector3dc
 import org.valkyrienskies.core.api.ships.ClientShip
-import org.valkyrienskies.core.api.ships.ServerShip
 import org.valkyrienskies.core.api.ships.Ship
 import org.valkyrienskies.mod.common.entity.handling.VSEntityManager
 import org.valkyrienskies.mod.common.shipObjectWorld
@@ -23,6 +20,7 @@ import kotlin.math.sin
 object EntityDragger {
     // How much we decay the addedMovement each tick after player hasn't collided with a ship for at least 10 ticks.
     private const val ADDED_MOVEMENT_DECAY = 0.9
+
 
     /**
      * Drag these entities with the ship they're standing on.
@@ -39,7 +37,7 @@ object EntityDragger {
 
 
             // Only drag entities that aren't mounted to vehicles
-            if (shipDraggingEntity != null && entity.vehicle == null && !VSEntityManager.isShipyardEntity(entity) && (entity as IEntityDraggingInformationProvider).`vs$shouldDrag`()) {
+            if (shipDraggingEntity != null && entity.vehicle == null && isDraggable(entity)) {
                 if (entityDraggingInformation.isEntityBeingDraggedByAShip()) {
                     // Compute how much we should drag the entity
                     val shipData = entity.level.shipObjectWorld.allShips.getById(shipDraggingEntity)
@@ -202,5 +200,12 @@ object EntityDragger {
             }
         }
         return default
+    }
+
+    /**
+     * Check if the given entity should be dragged. Shipyard entities and ones marked as non-draggable return false.
+     */
+    fun isDraggable(entity: Entity): Boolean {
+        return  !VSEntityManager.isShipyardEntity(entity) && entity is IEntityDraggingInformationProvider && (entity as IEntityDraggingInformationProvider).`vs$shouldDrag`()
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
@@ -37,7 +37,7 @@ object EntityDragger {
             val shipDraggingEntity = entityDraggingInformation.lastShipStoodOn
 
             // Only drag entities that aren't mounted to vehicles
-            if (shipDraggingEntity != null && entity.vehicle == null) {
+            if (shipDraggingEntity != null && entity.vehicle == null && (entity as IEntityDraggingInformationProvider).`vs$shouldDrag`()) {
                 if (entityDraggingInformation.isEntityBeingDraggedByAShip()) {
                     // Compute how much we should drag the entity
                     val shipData = entity.level.shipObjectWorld.allShips.getById(shipDraggingEntity)

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
@@ -205,7 +205,8 @@ object EntityDragger {
     /**
      * Check if the given entity should be dragged. Shipyard entities and ones marked as non-draggable return false.
      */
+    @JvmStatic
     fun isDraggable(entity: Entity): Boolean {
-        return  !VSEntityManager.isShipyardEntity(entity) && entity is IEntityDraggingInformationProvider && (entity as IEntityDraggingInformationProvider).`vs$shouldDrag`()
+        return !VSEntityManager.isShipyardEntity(entity) && entity is IEntityDraggingInformationProvider && (entity as IEntityDraggingInformationProvider).`vs$shouldDrag`()
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
@@ -12,6 +12,7 @@ import org.joml.Vector3dc
 import org.valkyrienskies.core.api.ships.ClientShip
 import org.valkyrienskies.core.api.ships.ServerShip
 import org.valkyrienskies.core.api.ships.Ship
+import org.valkyrienskies.mod.common.entity.handling.VSEntityManager
 import org.valkyrienskies.mod.common.shipObjectWorld
 import org.valkyrienskies.mod.common.util.EntityLerper.yawToWorld
 import kotlin.math.asin
@@ -36,8 +37,9 @@ object EntityDragger {
 
             val shipDraggingEntity = entityDraggingInformation.lastShipStoodOn
 
+
             // Only drag entities that aren't mounted to vehicles
-            if (shipDraggingEntity != null && entity.vehicle == null && (entity as IEntityDraggingInformationProvider).`vs$shouldDrag`()) {
+            if (shipDraggingEntity != null && entity.vehicle == null && !VSEntityManager.isShipyardEntity(entity) && (entity as IEntityDraggingInformationProvider).`vs$shouldDrag`()) {
                 if (entityDraggingInformation.isEntityBeingDraggedByAShip()) {
                     // Compute how much we should drag the entity
                     val shipData = entity.level.shipObjectWorld.allShips.getById(shipDraggingEntity)


### PR DESCRIPTION
Since shipyard entities are in the shipyard, they don't need to be dragged. VS2 dragging code doesn't check for shipyard entities anywhere, only for if an entity is marked as draggable.