### PR TITLE
[1.18] World-aware rain/snowfall on ships

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
@@ -27,6 +27,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.progress.ChunkProgressListener;
 import net.minecraft.world.entity.ai.village.poi.PoiManager;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ChunkGenerator;
@@ -45,9 +46,11 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.core.api.ships.LoadedServerShip;
+import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.core.api.ships.Wing;
 import org.valkyrienskies.core.api.ships.WingManager;
 import org.valkyrienskies.core.apigame.world.ServerShipWorldCore;
@@ -282,9 +285,26 @@ public abstract class MixinServerLevel implements IShipObjectWorldServerProvider
 
     }
 
+
     @Override
     public void removeChunk(final int chunkX, final int chunkZ) {
         final ChunkPos chunkPos = new ChunkPos(chunkX, chunkZ);
         vs$knownChunks.remove(chunkPos);
+    }
+
+
+
+    //Replace the biome check in tick chunk for one that transforms ship positions to world-space.
+    @Redirect(method = "tickChunk", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;getBiome(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/Holder;"))
+    private Holder<Biome> adjustForWorldPosition(final ServerLevel instance,final BlockPos blockPos) {
+        final ServerLevel level = ServerLevel.class.cast(this);
+        final Ship ship = VSGameUtilsKt.getShipManagingPos(level, blockPos);
+        if (ship != null) {
+            final Vector3d vPosWorld = ship.getShipToWorld().transformPosition(VectorConversionsMCKt.toJOMLD(blockPos));
+            final BlockPos blockPosWorld = new BlockPos(vPosWorld.x, vPosWorld.y, vPosWorld.z);
+            return level.getBiome(blockPosWorld);
+        }
+
+        return level.getBiome(blockPos);
     }
 }


### PR DESCRIPTION
Replaces the biome checker in `tickChunk()` for one that transform shipyard positions to world-space. This fixes issues such as snowfall for ships in non-cold chunks. 