### PR TITLE
[1.20] World-aware rain/snowfall on ships

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
@@ -250,7 +250,7 @@ public abstract class MixinServerLevel implements IShipObjectWorldServerProvider
 
     //Replace the biome check in tick chunk for one that transforms ship positions to world-space.
     @Redirect(method = "tickChunk", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;getBiome(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/Holder;"))
-    private Holder<Biome> adjustForWorldPosition(final ServerLevel instance,final BlockPos blockPos) {
+    private Holder<Biome> adjustForWorldPosition(final ServerLevel instance, final BlockPos blockPos) {
         final ServerLevel level = ServerLevel.class.cast(this);
         final Ship ship = VSGameUtilsKt.getShipManagingPos(level, blockPos);
         if (ship != null) {

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
@@ -255,7 +255,7 @@ public abstract class MixinServerLevel implements IShipObjectWorldServerProvider
         final Ship ship = VSGameUtilsKt.getShipManagingPos(level, blockPos);
         if (ship != null) {
             final Vector3d vPosWorld = ship.getShipToWorld().transformPosition(VectorConversionsMCKt.toJOMLD(blockPos));
-            final BlockPos blockPosWorld = new BlockPos(vPosWorld.x, vPosWorld.y, vPosWorld.z);
+            final BlockPos blockPosWorld = BlockPos.containing(vPosWorld.x, vPosWorld.y, vPosWorld.z);
             return level.getBiome(blockPosWorld);
         }
 

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
@@ -15,12 +15,14 @@ import java.util.Optional;
 import java.util.function.BooleanSupplier;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.BlockPos.MutableBlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.core.Position;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -36,8 +38,10 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.valkyrienskies.core.api.ships.LoadedServerShip;
+import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.core.api.ships.Wing;
 import org.valkyrienskies.core.api.ships.WingManager;
 import org.valkyrienskies.core.apigame.world.ServerShipWorldCore;
@@ -242,5 +246,19 @@ public abstract class MixinServerLevel implements IShipObjectWorldServerProvider
     public void removeChunk(final int chunkX, final int chunkZ) {
         final ChunkPos chunkPos = new ChunkPos(chunkX, chunkZ);
         vs$knownChunks.remove(chunkPos);
+    }
+
+    //Replace the biome check in tick chunk for one that transforms ship positions to world-space.
+    @Redirect(method = "tickChunk", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;getBiome(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/Holder;"))
+    private Holder<Biome> adjustForWorldPosition(final ServerLevel instance,final BlockPos blockPos) {
+        final ServerLevel level = ServerLevel.class.cast(this);
+        final Ship ship = VSGameUtilsKt.getShipManagingPos(level, blockPos);
+        if (ship != null) {
+            final Vector3d vPosWorld = ship.getShipToWorld().transformPosition(VectorConversionsMCKt.toJOMLD(blockPos));
+            final BlockPos blockPosWorld = new BlockPos(vPosWorld.x, vPosWorld.y, vPosWorld.z);
+            return level.getBiome(blockPosWorld);
+        }
+
+        return level.getBiome(blockPos);
     }
 }


### PR DESCRIPTION
Replaces the biome checker in `tickChunk()` for one that transform shipyard positions to world-space. This fixes issues such as snowfall for ships in non-cold chunks. 

1.20 version of https://github.com/ValkyrienSkies/Valkyrien-Skies-2/pull/1156