### PR TITLE
[1.20.1] Fixing Epic Fights Crash

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -81,6 +81,9 @@ dependencies {
     // Modular Routers
     modCompileOnly("curse.maven:mr-250294:4696089")
 
+    // Epic Fight
+    modCompileOnly("maven.modrinth:epic-fight:20.9.6")
+
     // Add Kotlin for Forge (3.12.0)
     forgeRuntimeLibrary("maven.modrinth:kotlin-for-forge:${kotlin_version}")
 

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/compat/epicfight/FracturedBlockStateInfoProvider.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/compat/epicfight/FracturedBlockStateInfoProvider.java
@@ -1,0 +1,41 @@
+package org.valkyrienskies.mod.forge.compat.epicfight;
+
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.valkyrienskies.core.apigame.world.chunks.BlockType;
+import org.valkyrienskies.mod.common.BlockStateInfo;
+import org.valkyrienskies.mod.common.BlockStateInfoProvider;
+import org.valkyrienskies.mod.common.ValkyrienSkiesMod;
+import yesman.epicfight.main.EpicFightMod;
+import yesman.epicfight.world.level.block.FractureBlockState;
+
+public class FracturedBlockStateInfoProvider implements BlockStateInfoProvider {
+    public static void register() {
+        Registry.register(BlockStateInfo.INSTANCE.getREGISTRY(),
+            new ResourceLocation(EpicFightMod.MODID, "fractured"), new FracturedBlockStateInfoProvider());
+    }
+
+    @Override
+    public int getPriority() {
+        return 101;
+    }
+
+    @Nullable
+    @Override
+    public Double getBlockStateMass(@NotNull BlockState blockState) {
+        if (blockState instanceof FractureBlockState)
+            return 0.0;
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public BlockType getBlockStateType(@NotNull BlockState blockState) {
+        if (blockState instanceof FractureBlockState)
+            return ValkyrienSkiesMod.vsCore.getBlockTypes().getSolid();
+        return null;
+    }
+}

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/compat/epicfight/README.md
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/compat/epicfight/README.md
@@ -1,0 +1,4 @@
+EpicFight Compat Class
+
+- FracturedBlockStateInfoProvider
+  - Epic Fight adds its own custom BlockState called FracturedBlockState that only exists on the Client and cannot be handled by MassDatapackResolver

--- a/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ValkyrienSkiesModForge.kt
+++ b/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ValkyrienSkiesModForge.kt
@@ -17,6 +17,7 @@ import net.minecraftforge.client.event.RegisterKeyMappingsEvent
 import net.minecraftforge.event.AddReloadListenerEvent
 import net.minecraftforge.event.RegisterCommandsEvent
 import net.minecraftforge.event.TagsUpdatedEvent
+import net.minecraftforge.fml.ModList
 import net.minecraftforge.fml.ModLoadingContext
 import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus
@@ -51,6 +52,7 @@ import org.valkyrienskies.mod.common.item.PhysicsEntityCreatorItem
 import org.valkyrienskies.mod.common.item.ShipAssemblerItem
 import org.valkyrienskies.mod.common.item.ShipCreatorItem
 import org.valkyrienskies.mod.compat.clothconfig.VSClothConfig
+import org.valkyrienskies.mod.forge.compat.epicfight.FracturedBlockStateInfoProvider
 
 @Mod(MOD_ID)
 class ValkyrienSkiesModForge {
@@ -167,6 +169,11 @@ class ValkyrienSkiesModForge {
             ValkyrienSkiesMod.createCreativeTab()
         }
         deferredRegister.register(modBus)
+
+
+        if (ModList.get().isLoaded("epicfight")) {
+            FracturedBlockStateInfoProvider.register()
+        }
     }
 
     private fun registerResourceManagers(event: AddReloadListenerEvent) {


### PR DESCRIPTION
I added a new `FracturedBlockStateInfoProvider` for handling Epic Fight's custom `FracturedBlockState` which is only used on the client and is the reason for the crash