### PR TITLE
Fix injection point for new shipyard entitiy

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinPersistentEntitySectionManager.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinPersistentEntitySectionManager.java
@@ -83,11 +83,11 @@ public abstract class MixinPersistentEntitySectionManager implements OfLevel {
     @Inject(
         method = "addEntity",
         at = @At(
-            value = "RETURN"
+            value = "HEAD"
         )
     )
     <T extends EntityAccess> void preAddEntity(T entityAccess, boolean bl, CallbackInfoReturnable<Boolean> cir) {
-        if (cir.getReturnValue() && entityAccess instanceof final Entity entity) {
+        if (entityAccess instanceof final Entity entity) {
             final LoadedShip ship =
                 VSGameUtilsKt.getShipObjectManagingPos(entity.level(), VectorConversionsMCKt.toJOML(entity.position()));
             if (ship != null) {

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinServerLevel.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinServerLevel.java
@@ -9,11 +9,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.valkyrienskies.core.api.ships.LoadedShip;
-import org.valkyrienskies.mod.common.VSGameUtilsKt;
-import org.valkyrienskies.mod.common.entity.handling.VSEntityManager;
-import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 import org.valkyrienskies.mod.mixinducks.world.OfLevel;
 
 @Mixin(ServerLevel.class)
@@ -27,19 +22,4 @@ public class MixinServerLevel {
     void configureEntitySections(final CallbackInfo ci) {
         ((OfLevel) entityManager).setLevel(ServerLevel.class.cast(this));
     }
-
-    @Inject(
-        method = "addEntity",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/entity/PersistentEntitySectionManager;addNewEntity(Lnet/minecraft/world/level/entity/EntityAccess;)Z"
-        )
-    )
-    void preAddEntity(final Entity entity, final CallbackInfoReturnable<Boolean> cir) {
-        final LoadedShip ship = VSGameUtilsKt.getShipObjectManagingPos(entity.level(), VectorConversionsMCKt.toJOML(entity.position()));
-        if (ship != null) {
-            VSEntityManager.INSTANCE.getHandler(entity).freshEntityInShipyard(entity, ship);
-        }
-    }
-
 }


### PR DESCRIPTION
# Issue
* Contraption wings do not work after world reload unless re-assembled.

This is due to the injection point for new shipyard entity only catching entities **added to the level**, so entities loaded from chunk savedata do not get intercepted. 
This results in the wing initializing code not being run.

# Solution
Move the injection point into `PersistentEntitySectionManager:addEntity`, where all newly loaded entities can be intercepted.

Unknown how this will effect other shipyard entities logic, but so far no issues in regular gameplay usage.