### PR TITLE
Fix for #1152, compat with Create: Stuff & Additions ("Grapplin Whisk" item)

### DIFF
--- a/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/create_stuff_additions/MixinGrapplinWhiskChainsLineProcedure.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/create_stuff_additions/MixinGrapplinWhiskChainsLineProcedure.java
@@ -8,11 +8,13 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import org.joml.Vector3d;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
-@Mixin(targets = {"net.mcreator.createstuffadditions.procedures.GrapplinWhiskChainsLineProcedure"})
+@Pseudo
+@Mixin(targets = {"net.mcreator.createstuffadditions.procedures.GrapplinWhiskChainsLineProcedure"}, remap = false)
 public abstract class MixinGrapplinWhiskChainsLineProcedure {
     /**
      * There's no harm in skipping this check, it shouldn't happen client side anyway.
@@ -22,7 +24,8 @@ public abstract class MixinGrapplinWhiskChainsLineProcedure {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/LevelAccessor;isEmptyBlock(Lnet/minecraft/core/BlockPos;)Z"
-        )
+        ),
+        require = 0
     )
     private static boolean skipAnnoyingEmptyBlockCheck(LevelAccessor instance, BlockPos blockPos) {
         return false;

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/create_stuff_additions/MixinGrapplinWhiskChainsLineProcedure.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/create_stuff_additions/MixinGrapplinWhiskChainsLineProcedure.java
@@ -1,0 +1,62 @@
+package org.valkyrienskies.mod.forge.mixin.compat.create_stuff_additions;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import org.joml.Vector3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Mixin(targets = {"net.mcreator.createstuffadditions.procedures.GrapplinWhiskChainsLineProcedure"})
+public abstract class MixinGrapplinWhiskChainsLineProcedure {
+    /**
+     * There's no harm in skipping this check, it shouldn't happen client side anyway.
+     */
+    @Redirect(
+        method = "execute(Lnet/minecraftforge/eventbus/api/Event;Lnet/minecraft/world/level/LevelAccessor;D)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/LevelAccessor;isEmptyBlock(Lnet/minecraft/core/BlockPos;)Z"
+        )
+    )
+    private static boolean skipAnnoyingEmptyBlockCheck(LevelAccessor instance, BlockPos blockPos) {
+        return false;
+    }
+
+    /**
+     * This mixin prevents the mod from crashing on rendering an absurdly long chain. Unfortunately, all instances of
+     * "hey what's the position targeted by grappling hook, again?" happen through accessing NBT tags. This looks
+     * suboptimal but for an MCreator mod that's a drop in the ocean.
+     */
+    @WrapOperation(
+        method = "execute(Lnet/minecraftforge/eventbus/api/Event;Lnet/minecraft/world/level/LevelAccessor;D)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/nbt/CompoundTag;getDouble(Ljava/lang/String;)D"
+        )
+    )
+    private static double replacePosition(CompoundTag instance, String string, Operation<Double> original,
+        @Local(argsOnly = true) LevelAccessor world) {
+        boolean x = string.equals("xPostion");
+        boolean y = string.equals("yPostion");
+        boolean z = string.equals("zPostion");
+        if (x || y || z) {
+            Vector3d truePos = new Vector3d(
+                original.call(instance, "xPostion"),
+                original.call(instance, "yPostion"),
+                original.call(instance, "zPostion")
+            );
+            Vector3d worldPos = VSGameUtilsKt.getWorldCoordinates((Level)world, BlockPos.containing(truePos.x, truePos.y, truePos.z), truePos);
+            if (x) return worldPos.x;
+            if (y) return worldPos.y;
+            return worldPos.z;
+        } else {
+            return original.call(instance, string);
+        }
+    }
+}

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/create_stuff_additions/MixinGrapplinWhiskItemInHandTickProcedure.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/create_stuff_additions/MixinGrapplinWhiskItemInHandTickProcedure.java
@@ -1,0 +1,50 @@
+package org.valkyrienskies.mod.forge.mixin.compat.create_stuff_additions;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import org.joml.Vector3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Mixin(targets = {"net.mcreator.createstuffadditions.procedures.GrapplinWhiskItemInHandTickProcedure"})
+public abstract class MixinGrapplinWhiskItemInHandTickProcedure {
+    /**
+     * This mixin repeats {@link MixinGrapplinWhiskChainsLineProcedure} but is responsible for game logic, namely players
+     * being tethered by the grappling hook around its correct coordinates. We should not break the checks related to
+     * blockstates on the grappling hook position. These are already in the shipyard as ensured by raycast mixins of VS,
+     * and should not be transformed to world.
+     */
+    @WrapOperation(
+        method = "execute",
+        slice = @Slice(
+            // getDouble is called 12 times in this method, we need all but the first three. Slicing should be more reliable than spamming ordinals.
+            from = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/LevelAccessor;isEmptyBlock(Lnet/minecraft/core/BlockPos;)Z")
+        ),
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/CompoundTag;getDouble(Ljava/lang/String;)D")
+    )
+    private static double replacePosition(CompoundTag instance, String string, Operation<Double> original,
+        @Local(argsOnly = true) LevelAccessor world) {
+        boolean x = string.equals("xPostion");
+        boolean y = string.equals("yPostion");
+        boolean z = string.equals("zPostion");
+        if (x || y || z) {
+            Vector3d truePos = new Vector3d(
+                original.call(instance, "xPostion"),
+                original.call(instance, "yPostion"),
+                original.call(instance, "zPostion")
+            );
+            Vector3d worldPos = VSGameUtilsKt.getWorldCoordinates((Level)world, BlockPos.containing(truePos.x, truePos.y, truePos.z), truePos);
+            if (x) return worldPos.x;
+            if (y) return worldPos.y;
+            return worldPos.z;
+        } else {
+            return original.call(instance, string);
+        }
+    }
+}

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/create_stuff_additions/MixinGrapplinWhiskItemInHandTickProcedure.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/create_stuff_additions/MixinGrapplinWhiskItemInHandTickProcedure.java
@@ -8,11 +8,13 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import org.joml.Vector3d;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Slice;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
-@Mixin(targets = {"net.mcreator.createstuffadditions.procedures.GrapplinWhiskItemInHandTickProcedure"})
+@Pseudo
+@Mixin(targets = {"net.mcreator.createstuffadditions.procedures.GrapplinWhiskItemInHandTickProcedure"}, remap = false)
 public abstract class MixinGrapplinWhiskItemInHandTickProcedure {
     /**
      * This mixin repeats {@link MixinGrapplinWhiskChainsLineProcedure} but is responsible for game logic, namely players
@@ -26,7 +28,8 @@ public abstract class MixinGrapplinWhiskItemInHandTickProcedure {
             // getDouble is called 12 times in this method, we need all but the first three. Slicing should be more reliable than spamming ordinals.
             from = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/LevelAccessor;isEmptyBlock(Lnet/minecraft/core/BlockPos;)Z")
         ),
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/CompoundTag;getDouble(Ljava/lang/String;)D")
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/CompoundTag;getDouble(Ljava/lang/String;)D"),
+        require = 0
     )
     private static double replacePosition(CompoundTag instance, String string, Operation<Double> original,
         @Local(argsOnly = true) LevelAccessor world) {

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/create_stuff_additions/MixinGrapplinWhiskRightclickedProcedure.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/create_stuff_additions/MixinGrapplinWhiskRightclickedProcedure.java
@@ -1,0 +1,38 @@
+package org.valkyrienskies.mod.forge.mixin.compat.create_stuff_additions;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Pseudo
+@Mixin(targets = {"net.mcreator.createstuffadditions.procedures.GrapplinWhiskRightclickedProcedure"}, remap = false)
+public abstract class MixinGrapplinWhiskRightclickedProcedure {
+    /**
+     * For some reason ship-aware view vectors clash with raycasting in this mod, so when a player is standing on a ship
+     * the raycast goes into a completely different direction. Replacing it with original-ish MC behavior.
+     */
+    @WrapOperation(
+        method = "execute(Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/item/ItemStack;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/entity/Entity;getViewVector(F)Lnet/minecraft/world/phys/Vec3;"
+        ),
+        require = 0
+    )
+    private static Vec3 dumbViewVector(Entity instance, float scale, Operation<Vec3> original) {
+        float f = instance.getViewXRot(scale);
+        float g = instance.getViewYRot(scale);
+        // Original MC code.
+        float h = f * ((float)Math.PI / 180);
+        float i = -g * ((float)Math.PI / 180);
+        float j = Mth.cos(i);
+        float k = Mth.sin(i);
+        float l = Mth.cos(h);
+        float m = Mth.sin(h);
+        return new Vec3(k * l, -m, j * l);
+    }
+}

--- a/forge/src/main/resources/valkyrienskies-forge.mixins.json
+++ b/forge/src/main/resources/valkyrienskies-forge.mixins.json
@@ -12,6 +12,8 @@
     "compat.common_create.MixinBlocks",
     "compat.common_create.MixinChuteBlockEntity",
     "compat.common_create.MixinControlledContraptionEntity",
+    "compat.create_stuff_additions.MixinGrapplinWhiskChainsLineProcedure",
+    "compat.create_stuff_additions.MixinGrapplinWhiskItemInHandTickProcedure",
     "compat.immersivengineering.MixinBlockEntityInventory",
     "compat.integrateddynamics.MixinVoxelShapeComponents",
     "compat.mekanism.MixinRadiationManager",

--- a/forge/src/main/resources/valkyrienskies-forge.mixins.json
+++ b/forge/src/main/resources/valkyrienskies-forge.mixins.json
@@ -14,6 +14,7 @@
     "compat.common_create.MixinControlledContraptionEntity",
     "compat.create_stuff_additions.MixinGrapplinWhiskChainsLineProcedure",
     "compat.create_stuff_additions.MixinGrapplinWhiskItemInHandTickProcedure",
+    "compat.create_stuff_additions.MixinGrapplinWhiskRightclickedProcedure",
     "compat.immersivengineering.MixinBlockEntityInventory",
     "compat.integrateddynamics.MixinVoxelShapeComponents",
     "compat.mekanism.MixinRadiationManager",


### PR DESCRIPTION
https://github.com/user-attachments/assets/9f3cfed8-e28f-4b38-9247-d1428c91bd18

No more crash when trying to use the whisk on a ship, as described in #1152. Looks like grappling works as it would on regular world blocks. TODO: contact the dev of this addon to discuss whether they approve compat for their mod in VS2.