### PR TITLE
Fix for #1161 (encased fan, broken bulk processing on ships)

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/common_create/MixinAirCurrent.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/common_create/MixinAirCurrent.java
@@ -1,8 +1,10 @@
 package org.valkyrienskies.mod.mixin.mod_compat.common_create;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import com.simibubi.create.content.kinetics.fan.AirCurrent;
 import com.simibubi.create.content.kinetics.fan.IAirCurrentSource;
-import java.util.Iterator;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
@@ -21,29 +23,21 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 import org.valkyrienskies.mod.common.world.RaycastUtilsKt;
-import org.valkyrienskies.mod.compat.CreateCompat;
 import org.valkyrienskies.mod.mixinducks.mod_compat.create.IExtendedAirCurrentSource;
 
 @Mixin(AirCurrent.class)
 public abstract class MixinAirCurrent {
 
-    @Unique
-    private final float maxAcceleration = 5;
     @Shadow
     @Final
     public IAirCurrentSource source;
-    @Unique
-    private Vec3 transformedFlow = Vec3.ZERO;
-    @Unique
-    private float acceleration;
 
     @Unique
     private Ship getShip() {
@@ -55,8 +49,11 @@ public abstract class MixinAirCurrent {
             return null;
     }
 
-    @Inject(method = "getFlowLimit", at = @At("HEAD"), cancellable = true, remap = false)
-    private static void clipFlowLimit(Level level, BlockPos start, float max, Direction facing, CallbackInfoReturnable<Float> cir) {
+    @Inject(method = "getFlowLimit", at = @At("RETURN"), cancellable = true, remap = false)
+    private static void clipFlowLimit(Level level, BlockPos start, float originalMax, Direction facing, CallbackInfoReturnable<Float> cir) {
+        // First let Create do its job at finding block obstructions that will cap max length, then use this value as ship search range.
+        float max = cir.getReturnValue();
+
         Ship ship = VSGameUtilsKt.getShipManagingPos(level, start);
         if (ship != null) {
             Vector3d startVec = ship.getTransform().getShipToWorld().transformPosition(new Vector3d(start.getX() + 0.5, start.getY() + 0.5, start.getZ() + 0.5));
@@ -70,7 +67,12 @@ public abstract class MixinAirCurrent {
                             VectorConversionsMCKt.toMinecraft(startVec.add(direction.x, direction.y, direction.z)),
                             ClipContext.Block.OUTLINE,
                             ClipContext.Fluid.NONE,
-                            null));
+                            null), true,
+                            // Skipping own ship as block obstructions were already calculated by Create. Besides,
+                            // solid blocks like blaze burners or fan catalysts (from addons) can be used for processing
+                            // instead of obstructing airflow. Not accounting for this used to cause this bug:
+                            // https://github.com/ValkyrienSkies/Valkyrien-Skies-2/issues/1161
+                            ship.getId());
 
             // Distance from start to end but, its not squared so, slow -_-
             cir.setReturnValue((float) result.getLocation().distanceTo(mcStart));
@@ -94,7 +96,6 @@ public abstract class MixinAirCurrent {
         }
     }
 
-    // Require 0 because this mixin doesn't work in create 0.5.1f
     @Redirect(method = "tickAffectedEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/AABB;intersects(Lnet/minecraft/world/phys/AABB;)Z"), require = 0)
     private boolean redirectIntersects(AABB instance, AABB other) {
         Ship ship = getShip();
@@ -105,55 +106,41 @@ public abstract class MixinAirCurrent {
         } else return instance.intersects(other);
     }
 
-    // Require 0 because this mixin doesn't work in create 0.5.1f
-    // it doesn't exactly work in v6 either so this should probably get fixed
-    @Inject(
-        method = "tickAffectedEntities",
-        at = @At(
-                value = "INVOKE",
-                target = "Lnet/minecraft/world/entity/Entity;getDeltaMovement()Lnet/minecraft/world/phys/Vec3;"
-        ),
-        locals = LocalCapture.CAPTURE_FAILSOFT,
-        require = 0
+    // While getCenter is unstable between versions, it is only used as an argument of distanceTo which is only called once.
+    @ModifyArg(method = "tickAffectedEntities",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;distanceTo(Lnet/minecraft/world/phys/Vec3;)D", ordinal = 0),
+        index = 0
     )
-    private void harvester(Level world, CallbackInfo ci, Iterator iterator, Entity entity, Vec3i flow, float speed,
-        float sneakModifier, double entityDistance, double entityDistanceOld, float acceleration) {
+    private Vec3 transformCenter(Vec3 center) {
+        Ship ship = getShip();
+        if (ship != null && this.source.getAirCurrentWorld() != null) {
+            Vector3d tempVec = new Vector3d();
+            ship.getTransform().getShipToWorld().transformPosition(center.x, center.y, center.z, tempVec);
+            center = VectorConversionsMCKt.toMinecraft(tempVec);
+        }
+        return center;
+    }
+
+    // Ordinals used here are correct both for v0.5.1 and v6 and in fact are stable all the way from Create v0.3.
+    @WrapOperation(method = "tickAffectedEntities",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V")
+    )
+    private void redirectSetDeltaMovement(Entity instance, Vec3 motion,
+        Operation<Void> original,
+        @Local(ordinal = 2) float acceleration, @Local(ordinal = 3) float maxAcceleration, @Local(ordinal = 0) Vec3i flow
+    ) {
         Ship ship = getShip();
         if (ship != null) {
             Vector3d tempVec = new Vector3d();
             ship.getTransform().getShipToWorld().transformDirection(flow.getX(), flow.getY(), flow.getZ(), tempVec);
-            transformedFlow = VectorConversionsMCKt.toMinecraft(tempVec);
-        }
-        this.acceleration = acceleration;
-    }
+            Vec3 transformedFlow = VectorConversionsMCKt.toMinecraft(tempVec);
 
-    // Require 0 because this mixin doesn't work in create 0.5.1f
-    @Redirect(method = "tickAffectedEntities",
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V"), require = 0
-    )
-    private void redirectSetDeltaMovement(Entity instance, Vec3 motion) {
-        Ship ship = getShip();
-        if (ship != null) {
             Vec3 previousMotion = instance.getDeltaMovement();
             double xIn = Mth.clamp(transformedFlow.x * acceleration - previousMotion.x, -maxAcceleration, maxAcceleration);
             double yIn = Mth.clamp(transformedFlow.y * acceleration - previousMotion.y, -maxAcceleration, maxAcceleration);
             double zIn = Mth.clamp(transformedFlow.z * acceleration - previousMotion.z, -maxAcceleration, maxAcceleration);
-            instance.setDeltaMovement(previousMotion.add(new Vec3(xIn, yIn, zIn).scale(1 / 8f)));
-        } else {
-            instance.setDeltaMovement(motion);
+            motion = previousMotion.add(new Vec3(xIn, yIn, zIn).scale(1 / 8f));
         }
-    }
-
-    // Require 0 because this mixin doesn't work in create 0.5.1f
-    @Redirect(method = "tickAffectedEntities", at = @At(value = "INVOKE", target = "Lnet/createmod/catnip/math/VecHelper;getCenterOf(Lnet/minecraft/core/Vec3i;)Lnet/minecraft/world/phys/Vec3;"), allow = 1, require = 0, remap = false)
-    private Vec3 redirectGetCenterOf(Vec3i pos) {
-        Ship ship = getShip();
-        Vec3 result = CreateCompat.getCenterOf(pos);
-        if (ship != null && this.source.getAirCurrentWorld() != null) {
-            Vector3d tempVec = new Vector3d();
-            ship.getTransform().getShipToWorld().transformPosition(result.x, result.y, result.z, tempVec);
-            result = VectorConversionsMCKt.toMinecraft(tempVec);
-        }
-        return result;
+        original.call(instance, motion);
     }
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -89,17 +89,18 @@ dependencies {
     //modCompileOnly("com.simibubi.create:create-${minecraft_version}:${old_create_forge_version}:slim") { transitive = false }
     modCompileOnly("com.jozufozu.flywheel:flywheel-forge-${minecraft_version}:${old_flywheel_forge_version}") { transitive = false }
 
-//    if (old_create) {
-//        modRuntimeOnly("com.simibubi.create:create-${minecraft_version}:${old_create_forge_version}:slim") {
-//            exclude(group: 'com.github.AlphaMode', module: 'fakeconfigtoml')
-//            exclude(group: 'cc.tweaked')
-//            exclude(group: 'mezz.jei')
-//        }
-//        modRuntimeOnly("com.jozufozu.flywheel:flywheel-forge-${minecraft_version}:${old_flywheel_forge_version}")
-//    } else {
-//        modRuntimeOnly("com.simibubi.create:create-${minecraft_version}:${create_version}:slim")
-//        modRuntimeOnly("dev.engine-room.flywheel:flywheel-forge-${minecraft_version}:${flywheel_version}")
-//    }
+    if (old_create) {
+        modRuntimeOnly("com.simibubi.create:create-${minecraft_version}:${old_create_forge_version}:slim") {
+            exclude(group: 'com.github.AlphaMode', module: 'fakeconfigtoml')
+            exclude(group: 'cc.tweaked')
+            exclude(group: 'mezz.jei')
+        }
+        modRuntimeOnly("com.jozufozu.flywheel:flywheel-forge-${minecraft_version}:${old_flywheel_forge_version}")
+    } else {
+        modRuntimeOnly("com.simibubi.create:create-${minecraft_version}:${create_version}:slim")
+        modRuntimeOnly("dev.engine-room.flywheel:flywheel-forge-${minecraft_version}:${flywheel_version}")
+        modRuntimeOnly("net.createmod.ponder:Ponder-Forge-${minecraft_version}:${ponder_version}")
+    }
 
     // Weather2 1.20.1
     modImplementation("curse.maven:weather-storms-tornadoes-237746:5244118")
@@ -145,6 +146,9 @@ dependencies {
 
     // Cloth for config
     include(modImplementation("me.shedaniel.cloth:cloth-config-forge:${cloth_config_version}"))
+
+    // MCreator slop
+    modCompileOnly("maven.modrinth:create-stuff-additions:Fyf059LK")
 
     // Shade vs-core
     implementation("org.valkyrienskies.core:util:${rootProject.vs_core_version}")

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -147,9 +147,6 @@ dependencies {
     // Cloth for config
     include(modImplementation("me.shedaniel.cloth:cloth-config-forge:${cloth_config_version}"))
 
-    // MCreator slop
-    modCompileOnly("maven.modrinth:create-stuff-additions:Fyf059LK")
-
     // Shade vs-core
     implementation("org.valkyrienskies.core:util:${rootProject.vs_core_version}")
     implementation("org.valkyrienskies.core:api-game:${rootProject.vs_core_version}") {


### PR DESCRIPTION
<img width="854" height="480" alt="2025-07-31_15 34 57" src="https://github.com/user-attachments/assets/864430ef-3872-41d2-af4b-ae806d3a7ed4" />

#1161 mentions Create: Connected but this is just a VS<->Create issue as this problem is also present with blaze burners. The reason: VS2 checks if the fan is obstructed by ships and does it with a raycast. This cast does not exclude "self" ship. That becomes a problem because blaze burners and these fan catalyst things are solid blocks, which raycasts stop at, while from Create perspective these blocks are used in bulk processing and therefore should let air pass through.

Also I've modified other air current mixins so that they're more version agnostic, now bulk processing, entities being moved by shipyard fans and affected by bulk processing (like lighting on fire) works both with Create v0.5.1 and v6. That's really a 2.5 issue so no regular players have noticed this.