### PR TITLE
Fix for arrows hitting ships at last

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/arrows_on_ships/MixinAbstractArrow.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/arrows_on_ships/MixinAbstractArrow.java
@@ -1,0 +1,112 @@
+package org.valkyrienskies.mod.mixin.feature.arrows_on_ships;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtUtils;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.projectile.AbstractArrow;
+import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.At.Shift;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.entity.handling.DefaultShipyardEntityHandler;
+import org.valkyrienskies.mod.common.entity.handling.VSEntityManager;
+import org.valkyrienskies.mod.common.entity.handling.WorldEntityHandler;
+
+@Mixin(AbstractArrow.class)
+public abstract class MixinAbstractArrow extends Projectile {
+    @Unique
+    @Nullable BlockPos vs$groundPos;
+
+    /**
+     * When checking whether the grounded state is still valid, blockstate is read at the position of arrow entity.
+     * On ships this fails as the arrow collides with shipyard blocks but checks for blocks in its world coordinates.
+     * Grounded arrows are immobile so checking against hit BlockPos and not arrow coordinates should yield the same
+     * result for all intents and purposes
+     */
+    @WrapOperation(
+        method = "tick",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/Level;getBlockState(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;"
+        )
+    )
+    BlockState trustSavedGroundPos(Level level, BlockPos blockPos, Operation<BlockState> original) {
+        return original.call(level, vs$groundPos != null ? vs$groundPos : blockPos);
+    }
+
+    @WrapMethod(
+        method = "addAdditionalSaveData"
+    )
+    void saveGroundPos(CompoundTag compoundTag, Operation<Void> original) {
+        original.call(compoundTag);
+        if (vs$groundPos != null) {
+            compoundTag.put("GroundPos", NbtUtils.writeBlockPos(vs$groundPos));
+        }
+    }
+
+    @WrapMethod(
+        method = "readAdditionalSaveData"
+    )
+    void loadGroundPos(CompoundTag compoundTag, Operation<Void> original) {
+        original.call(compoundTag);
+        if (compoundTag.contains("GroundPos")) {
+            vs$groundPos = NbtUtils.readBlockPos(compoundTag.getCompound("GroundPos"));
+        }
+    }
+
+    /**
+     * If the arrow hits a shipyard block, teleport it to the corresponding coordinates and reassign its entity handler
+     * to shipyard. Block hit position is saved for future use
+     */
+    @Inject(
+        method = "onHitBlock",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/entity/projectile/Projectile;onHitBlock(Lnet/minecraft/world/phys/BlockHitResult;)V",
+            shift = Shift.AFTER
+        )
+    )
+    void storeHitAndArrowPos(
+        BlockHitResult hit, CallbackInfo ci
+    ) {
+        vs$groundPos = hit.getBlockPos();
+        Ship ship = VSGameUtilsKt.getShipObjectManagingPos(level(), vs$groundPos);
+        if (ship != null) {
+            VSEntityManager.INSTANCE.setCustomHandler(this, DefaultShipyardEntityHandler.INSTANCE);
+            DefaultShipyardEntityHandler.INSTANCE.moveEntityFromWorldToShipyard(this, ship);
+        }
+    }
+
+    /**
+     * Called when arrow loses its ground. Removing the entity handler override and teleport to world coordinates.
+     */
+    @Inject(
+        method = "startFalling",
+        at = @At("HEAD")
+    )
+    void detachArrowFromShip(CallbackInfo ci) {
+        Ship ship = VSGameUtilsKt.getShipManagingPos(level(), this.position());
+        if (ship != null) {
+            VSEntityManager.INSTANCE.setCustomHandler(this, null);
+            WorldEntityHandler.INSTANCE.moveEntityFromShipyardToWorld(this, ship);
+        }
+    }
+
+    // Dummy constructor
+    public MixinAbstractArrow(EntityType<? extends Projectile> entityType, Level level) {
+        super(entityType, level);
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntity.java
@@ -1,9 +1,12 @@
 package org.valkyrienskies.mod.mixin.feature.shipyard_entities;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import java.util.Set;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Entity.RemovalReason;
@@ -24,12 +27,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.core.api.ships.LoadedShip;
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.entity.handling.VSEntityHandler;
 import org.valkyrienskies.mod.common.entity.handling.VSEntityManager;
 import org.valkyrienskies.mod.common.entity.handling.WorldEntityHandler;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
+import org.valkyrienskies.mod.mixinducks.feature.shipyard_entities.MixinEntityDuck;
 
 @Mixin(Entity.class)
-public abstract class MixinEntity {
+public abstract class MixinEntity implements MixinEntityDuck {
 
     @Shadow
     public abstract Level level();
@@ -85,6 +90,40 @@ public abstract class MixinEntity {
             isModifyingSetPos = false;
             ci.cancel();
         }
+    }
+
+    @WrapMethod(
+        method = "saveWithoutId"
+    )
+    private CompoundTag saveCustomEntityHandler(CompoundTag compoundTag, Operation<CompoundTag> original) {
+        original.call(compoundTag);
+        ResourceLocation name = VSEntityManager.INSTANCE.getHandlerName(vs_customHandler);
+        if (name != null) {
+            compoundTag.putString("CustomEntityHandler", name.toString());
+        }
+        return compoundTag;
+    }
+
+    @Inject(
+        method = "load",
+        at = @At("RETURN")
+    )
+    private void loadCustomEntityHandler(CompoundTag compoundTag, CallbackInfo ci) {
+        ResourceLocation name = new ResourceLocation(compoundTag.getString("CustomEntityHandler"));
+        VSEntityHandler handler = VSEntityManager.INSTANCE.getHandler(name);
+    }
+
+    @Unique
+    private VSEntityHandler vs_customHandler = null;
+
+    @Unique
+    public VSEntityHandler vs_getCustomHandler() {
+        return vs_customHandler;
+    }
+
+    @Unique
+    public void vs_setCustomHandler(VSEntityHandler handler) {
+        vs_customHandler = handler;
     }
 
     @Unique

--- a/common/src/main/java/org/valkyrienskies/mod/mixinducks/feature/shipyard_entities/MixinEntityDuck.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixinducks/feature/shipyard_entities/MixinEntityDuck.java
@@ -1,0 +1,9 @@
+package org.valkyrienskies.mod.mixinducks.feature.shipyard_entities;
+
+import org.valkyrienskies.mod.common.entity.handling.VSEntityHandler;
+
+public interface MixinEntityDuck {
+    public VSEntityHandler vs_getCustomHandler();
+
+    public void vs_setCustomHandler(VSEntityHandler handler);
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/api/ValkyrienSkies.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/api/ValkyrienSkies.kt
@@ -318,13 +318,13 @@ fun Level?.distanceSquared(x1: Double, y1: Double, z1: Double, x2: Double, y2: D
     val ship2 = this.getShipManagingBlock(x2, y2, z2)
 
     // Do this transform manually to avoid allocation
-    if (ship1 != null && ship2 != null && ship1 != ship2) {
-        ship1.shipToWorld.transformPositionInline(x1, y1, z1) { x, y, z ->
+    if (ship1 != ship2) {
+        ship1?.shipToWorld?.transformPositionInline(x1, y1, z1) { x, y, z ->
             inWorldX1 = x
             inWorldY1 = y
             inWorldZ1 = z
         }
-        ship2.shipToWorld.transformPositionInline(x2, y2, z2) { x, y, z ->
+        ship2?.shipToWorld?.transformPositionInline(x2, y2, z2) { x, y, z ->
             inWorldX2 = x
             inWorldY2 = y
             inWorldZ2 = z

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/AbstractShipyardEntityHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/AbstractShipyardEntityHandler.kt
@@ -9,7 +9,8 @@ import org.joml.Vector3d
 import org.valkyrienskies.core.api.ships.ClientShip
 import org.valkyrienskies.core.api.ships.Ship
 import org.valkyrienskies.mod.common.util.toJOML
-import org.valkyrienskies.mod.common.util.toMinecraft
+import kotlin.math.atan2
+import kotlin.math.sqrt
 
 abstract class AbstractShipyardEntityHandler : VSEntityHandler {
     override fun freshEntityInShipyard(entity: Entity, ship: Ship) {
@@ -55,5 +56,45 @@ abstract class AbstractShipyardEntityHandler : VSEntityHandler {
         // TODO: somewhere else position is already applied in the matrix stack
         // EW: i think it was in entity dragging logic
         matrixStack.mulPose(Quaternionf(ship.renderTransform.shipToWorldRotation))
+    }
+
+    fun moveEntityFromWorldToShipyard(entity: Entity, ship: Ship) =
+        moveEntityFromWorldToShipyard(entity, ship, entity.x, entity.y, entity.z)
+
+    fun moveEntityFromWorldToShipyard(
+        entity: Entity, ship: Ship, entityX: Double, entityY: Double, entityZ: Double
+    ) {
+
+        val newPos = ship.worldToShip.transformPosition(Vector3d(entityX, entityY, entityZ))
+        entity.setPos(newPos.x, newPos.y, newPos.z)
+        entity.xo = entity.x
+        entity.yo = entity.y
+        entity.zo = entity.z
+
+        // TODO: figure out maths
+
+        //val localVelocity = ship.transform.rotation.transform(entity.deltaMovement.toJOML())
+        //entity.deltaMovement = Vector3d(localVelocity).toMinecraft()
+
+        val localDirection = ship.transform.rotation.transform(entity.lookAngle.toJOML())
+
+        val yaw = -atan2(localDirection.x, localDirection.z)
+        val pitch = -atan2(localDirection.y, sqrt((localDirection.x * localDirection.x) + (localDirection.z * localDirection.z)))
+        entity.yRot = (yaw * (180 / Math.PI)).toFloat()
+        entity.xRot = (pitch * (180 / Math.PI)).toFloat()
+        entity.yRotO = entity.yRot
+        entity.xRotO = entity.xRot
+
+        /*if (entity is AbstractHurtingProjectile) {
+            val power = Vector3d(entity.xPower, entity.yPower, entity.zPower)
+
+            ship.transform.rotation.transform(power)
+
+            entity.xPower = power.x
+            entity.yPower = power.y
+            entity.zPower = power.z
+
+            ProjectileUtil.rotateTowardsMovement(entity, 1.0f)
+        }*/
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/VSEntityManager.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/VSEntityManager.kt
@@ -10,6 +10,7 @@ import org.valkyrienskies.mod.common.networking.PacketSyncVSEntityTypes
 import org.valkyrienskies.mod.common.util.MinecraftPlayer
 import org.valkyrienskies.mod.common.vsCore
 import org.valkyrienskies.mod.compat.CreateCompat
+import org.valkyrienskies.mod.mixinducks.feature.shipyard_entities.MixinEntityDuck
 import java.time.Duration
 import kotlin.text.RegexOption.IGNORE_CASE
 
@@ -55,7 +56,22 @@ object VSEntityManager {
         entityHandlers[entityType] = entityHandler
     }
 
+    /**
+     * Override entity handler for a specific entity.
+     * TODO: save and sync custom entity handlers?
+     *
+     * @param entity Entity instance
+     * @param entityHandler The entity handler
+     */
+    fun setCustomHandler(entity: Entity, entityHandler: VSEntityHandler?) {
+        (entity as? MixinEntityDuck)?.vs_setCustomHandler(entityHandler)
+    }
+
     fun getHandler(entity: Entity): VSEntityHandler {
+        val handler = (entity as? MixinEntityDuck)?.vs_getCustomHandler()
+        if (handler != null) {
+            return handler
+        }
         if (CreateCompat.isContraption(entity)) {
             return contraptionHandler
         }
@@ -86,6 +102,10 @@ object VSEntityManager {
 
     fun getHandler(type: ResourceLocation): VSEntityHandler? {
         return entityHandlersNamed[type]
+    }
+
+    fun getHandlerName(handler: VSEntityHandler?): ResourceLocation? {
+        return namedEntityHandlers[handler]
     }
 
     // Sends a packet with all the entity -> handler pairs to the client

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/PacketOverrideEntityHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/PacketOverrideEntityHandler.kt
@@ -1,0 +1,8 @@
+package org.valkyrienskies.mod.common.networking
+
+import org.valkyrienskies.core.impl.networking.simple.SimplePacket
+
+data class PacketOverrideEntityHandler(
+    val entityID: Int,
+    val handler: String
+): SimplePacket

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/VSGamePackets.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/VSGamePackets.kt
@@ -30,6 +30,7 @@ object VSGamePackets {
         PacketStopChunkUpdates::class.register()
         PacketRestartChunkUpdates::class.register()
         PacketSyncVSEntityTypes::class.register()
+        PacketOverrideEntityHandler::class.register() // TODO: not actually sent from anywhere
         PacketEntityShipMotion::class.register()
         PacketMobShipRotation::class.register()
         PacketPlayerShipMotion::class.register()
@@ -64,6 +65,17 @@ object VSGamePackets {
                         ?: throw IllegalStateException("No handler: $handler")
                 )
             }
+        }
+
+        PacketOverrideEntityHandler::class.registerClientHandler { setHandler ->
+            val mc = Minecraft.getInstance()
+            val level = mc.level ?: return@registerClientHandler
+            val entity = level.getEntity(setHandler.entityID) ?: return@registerClientHandler
+
+            VSEntityManager.setCustomHandler(
+                entity,
+                VSEntityManager.getHandler(ResourceLocation(setHandler.handler))
+            )
         }
 
         PacketEntityShipMotion::class.registerClientHandler { setMotion ->

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -38,6 +38,7 @@
     "feature.ai.path_retargeting.MixinAirAndWaterRandomPos",
     "feature.ai.path_retargeting.MixinDefaultRandomPos",
     "feature.ai.path_retargeting.MixinLandRandomPos",
+    "feature.arrows_on_ships.MixinAbstractArrow",
     "feature.bed_fix.MixinServerPlayer",
     "feature.block_placement_orientation.MixinBlockItem",
     "feature.block_placement_orientation.MixinBlockPlaceContext",


### PR DESCRIPTION
https://github.com/user-attachments/assets/9afa7a0b-5163-4876-8e5d-4ca379c9413d

Not expecting it to be merged soon as it actually changes some API: as an experiment I've made it possible to change entity handlers (world / shipyard) for individual entities. This should be persistent on world reload; sadly not yet networked (didn't find the best place to send these packets to players, for this specific fix this is not necessary but it's definitely unacceptable for something that will make its way to the API). As such there's a need for a "teleport from world to shipyard" procedure, WIP: correctly transform all the coordinates so visible rotation is preserved.

The bug itself is fixed, arrows correctly stick into the ships and stay there when the ship is in motion. Arrows were not added to the list of shipyard entities (as there are many different arrow entities extending AbstractArrow, besides, we want projectiles to obey world gravity and stuff even when launched on ships). Instead the handler is changed when an arrow gets stuck or unstuck.