### PR TITLE
Improve /vs further

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembly.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembly.kt
@@ -150,7 +150,7 @@ fun createNewShipWithStructure(
                     level.removeBlockEntity(BlockPos(x, y, z))
                     level.getChunk(x,z).setBlockState(BlockPos(x,y,z), Blocks.AIR.defaultBlockState(), false)
 
-                    level.getChunk(BlockPos(x, y, z)).setBlockState(BlockPos(x, y, z), Blocks.AIR.defaultBlockState(), false)
+                    //level.getChunk(BlockPos(x, y, z)).setBlockState(BlockPos(x, y, z), Blocks.AIR.defaultBlockState(), false)
                 }
             }
         }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembly.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembly.kt
@@ -150,7 +150,7 @@ fun createNewShipWithStructure(
                     level.removeBlockEntity(BlockPos(x, y, z))
                     level.getChunk(x,z).setBlockState(BlockPos(x,y,z), Blocks.AIR.defaultBlockState(), false)
 
-                    //level.getChunk(BlockPos(x, y, z)).setBlockState(BlockPos(x, y, z), Blocks.AIR.defaultBlockState(), false)
+                    level.getChunk(BlockPos(x, y, z)).setBlockState(BlockPos(x, y, z), Blocks.AIR.defaultBlockState(), false)
                 }
             }
         }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/RelativeVector3Argument.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/RelativeVector3Argument.kt
@@ -48,8 +48,10 @@ class RelativeVector3Argument : ArgumentType<RelativeVector3> {
         private val DUMMY_EULER_ANGLES =
             RelativeVector3(RelativeValue(0.0, false), RelativeValue(0.0, false), RelativeValue(0.0, false))
 
+        @JvmStatic
         fun relativeVector3() = RelativeVector3Argument()
 
+        @JvmStatic
         fun getRelativeVector3(commandContext: CommandContext<CommandSourceStack?>, string: String?): RelativeVector3 {
             return commandContext.getArgument(
                 string,

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/RelativeVector3Argument.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/RelativeVector3Argument.kt
@@ -77,7 +77,9 @@ class RelativeVector3Argument : ArgumentType<RelativeVector3> {
                                 builder.suggest("(0 0 0)")
                             }
                         } else {
-                            return DUMMY_EULER_ANGLES
+                            throw SimpleCommandExceptionType(
+                                Component.translatable(VSCommands.VECTOR_ARG_FAIL_MESSAGE)
+                            ).createWithContext(reader)
                         }
                     }
 
@@ -91,7 +93,9 @@ class RelativeVector3Argument : ArgumentType<RelativeVector3> {
                                     builder.suggest("${builder.remaining}0 0 0)")
                                 }
                             } else {
-                                return DUMMY_EULER_ANGLES
+                                throw SimpleCommandExceptionType(
+                                    Component.translatable(VSCommands.VECTOR_ARG_FAIL_MESSAGE)
+                                ).createWithContext(reader)
                             }
                         }
 
@@ -104,7 +108,9 @@ class RelativeVector3Argument : ArgumentType<RelativeVector3> {
                                     builder.suggest("${builder.remaining} 0 0)")
                                 }
                             } else {
-                                return DUMMY_EULER_ANGLES
+                                throw SimpleCommandExceptionType(
+                                    Component.translatable(VSCommands.VECTOR_ARG_FAIL_MESSAGE)
+                                ).createWithContext(reader)
                             }
                         }
 
@@ -118,7 +124,9 @@ class RelativeVector3Argument : ArgumentType<RelativeVector3> {
                                         builder.suggest("${builder.remaining}0 0)")
                                     }
                                 } else {
-                                    return DUMMY_EULER_ANGLES
+                                    throw SimpleCommandExceptionType(
+                                        Component.translatable(VSCommands.VECTOR_ARG_FAIL_MESSAGE)
+                                    ).createWithContext(reader)
                                 }
                             }
 
@@ -131,7 +139,9 @@ class RelativeVector3Argument : ArgumentType<RelativeVector3> {
                                         builder.suggest("${builder.remaining} 0)")
                                     }
                                 } else {
-                                    return DUMMY_EULER_ANGLES
+                                    throw SimpleCommandExceptionType(
+                                        Component.translatable(VSCommands.VECTOR_ARG_FAIL_MESSAGE)
+                                    ).createWithContext(reader)
                                 }
                             }
 
@@ -144,10 +154,27 @@ class RelativeVector3Argument : ArgumentType<RelativeVector3> {
                                             builder.suggest("${builder.remaining}0)")
                                         }
                                     } else {
-                                        return DUMMY_EULER_ANGLES
+                                        throw SimpleCommandExceptionType(
+                                            Component.translatable(VSCommands.VECTOR_ARG_FAIL_MESSAGE)
+                                        ).createWithContext(reader)
                                     }
                                 }
-                                val worldCoordinate3 = WorldCoordinate.parseDouble(reader, false)
+
+
+                                // So we don't get index out of range when they haven't finished the command
+                                val worldCoordinate3 = if (reader.remainingLength > 1 && reader.peek(1) == ')') {
+                                    // Use a temporary reader without ')' so WorldCoordinate doesn't break
+                                    StringReader(reader.string.substring(0, reader.cursor + 1)).apply {
+                                        cursor = reader.cursor
+                                    }.let {
+                                        // Advance original cursor
+                                        WorldCoordinate.parseDouble(it, false).also { reader.read() }
+                                    }
+                                } else {
+                                    // Normal logic (no ')' to worry about)
+                                    WorldCoordinate.parseDouble(reader, false)
+                                }
+
                                 if (reader.canRead()) {
                                     if (reader.peek() == ')') {
                                         reader.skip()
@@ -169,11 +196,11 @@ class RelativeVector3Argument : ArgumentType<RelativeVector3> {
                                         suggest { builder ->
                                             builder.suggest("${builder.remaining})")
                                         }
-                                        throw SimpleCommandExceptionType(
-                                            Component.translatable("Expected )")
-                                        ).createWithContext(reader)
+
                                     } else {
-                                        return DUMMY_EULER_ANGLES
+                                        throw SimpleCommandExceptionType(
+                                            Component.translatable(VSCommands.VECTOR_ARG_FAIL_MESSAGE)
+                                        ).createWithContext(reader)
                                     }
                                 }
                             }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/ShipArgument.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/ShipArgument.kt
@@ -55,12 +55,16 @@ class ShipArgument private constructor(val selectorOnly: Boolean) : ArgumentType
 
     companion object {
 
+        @JvmStatic
         fun selectorOnly(): ShipArgument = ShipArgument(true)
+
+        @JvmStatic
         fun ships(): ShipArgument = ShipArgument(false)
 
         /**
          * @return Can return either a loaded ship or an unloaded ship
          */
+        @JvmStatic
         fun getShips(context: CommandContext<CommandSourceStack>, argName: String): Set<Ship> {
             val selector = context.getArgument(argName, ShipSelector::class.java)
 
@@ -78,6 +82,7 @@ class ShipArgument private constructor(val selectorOnly: Boolean) : ArgumentType
         /**
          * @return Can return either a loaded ship or an unloaded ship
          */
+        @JvmStatic
         fun getShip(context: CommandContext<CommandSourceStack>, argName: String): Ship {
             val selector = context.getArgument(argName, ShipSelector::class.java)
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
@@ -4,15 +4,19 @@ import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.arguments.BoolArgumentType
 import com.mojang.brigadier.arguments.DoubleArgumentType
 import com.mojang.brigadier.arguments.StringArgumentType
+import com.mojang.brigadier.context.CommandContext
 import net.minecraft.commands.CommandRuntimeException
 import net.minecraft.commands.CommandSourceStack
 import net.minecraft.commands.Commands.argument
 import net.minecraft.commands.Commands.literal
 import net.minecraft.commands.SharedSuggestionProvider
 import net.minecraft.commands.arguments.coordinates.Vec3Argument
+import net.minecraft.core.BlockPos
 import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.Component.translatable
+import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.level.block.Blocks
 import net.minecraft.world.phys.BlockHitResult
 import org.valkyrienskies.core.api.ships.ServerShip
 import org.valkyrienskies.core.api.world.ServerShipWorld
@@ -23,6 +27,7 @@ import org.valkyrienskies.mod.common.getShipManagingPos
 import org.valkyrienskies.mod.common.shipObjectWorld
 import org.valkyrienskies.mod.common.util.toJOML
 import org.valkyrienskies.mod.common.vsCore
+import org.valkyrienskies.mod.common.yRange
 import org.valkyrienskies.mod.mixin.feature.commands.ClientSuggestionProviderAccessor
 import org.valkyrienskies.mod.util.logger
 
@@ -45,16 +50,12 @@ object VSCommands {
                 .then(literal("delete")
                     .then(argument("ships", ShipArgument.ships())
                         .executes {
-                            try {
-                                val r = ShipArgument.getShips(it, "ships").toList() as List<ServerShip>
-                                vsCore.deleteShips(it.source.shipWorld as ServerShipWorld, r)
-                                it.source.sendVSMessage(translatable(DELETED_SHIPS_MESSAGE, r.size))
-                                r.size
-                            } catch (e: Exception) {
-                                if (e !is CommandRuntimeException) LOGGER.throwing(e)
-                                throw e
+                            deleteShip(it)
+                        }.then(argument("deleteBlocks", BoolArgumentType.bool())
+                            .executes {
+                                deleteShip(it, BoolArgumentType.getBool(it, "deleteBlocks"))
                             }
-                        }
+                        )
                     )
                 ).then(literal("rename")
                     .then(argument("ship", ShipArgument.ships())
@@ -371,6 +372,32 @@ object VSCommands {
                 }.build()
             )
         }*/
+    }
+
+    fun deleteShip(context: CommandContext<CommandSourceStack>, deleteBlocks: Boolean = false): Int {
+        val r = ShipArgument.getShips(context, "ships").toList() as List<ServerShip>
+
+        if (deleteBlocks) {
+            for (ship in r) {
+                var level = context.source.level;
+                if (level is ServerLevel) {
+                    val aabb = ship.shipAABB ?: continue
+                    // There has to be a better way to do this...
+                    for (x in aabb.minX()..aabb.maxX()) {
+                        for (y in aabb.minY()..aabb.maxY()) {
+                            for (z in aabb.minZ()..aabb.maxZ()) {
+                                // Not sure if 2 is what we want, but its what /fill uses
+                                level.setBlock(BlockPos(x, y, z), Blocks.AIR.defaultBlockState(), 2)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        vsCore.deleteShips(context.source.shipWorld as ServerShipWorld, r)
+        context.source.sendVSMessage(translatable(DELETED_SHIPS_MESSAGE, r.size))
+        return r.size
     }
 
     fun registerClientCommands(dispatcher: CommandDispatcher<CommandSourceStack>) {

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
@@ -33,6 +33,8 @@ object VSCommands {
     private const val TELEPORT_SHIP_SUCCESS_MESSAGE = "command.valkyrienskies.teleport.success"
     private const val GET_SHIP_SUCCESS_MESSAGE = "command.valkyrienskies.get_ship.success"
     private const val GET_SHIP_FAIL_MESSAGE = "command.valkyrienskies.get_ship.fail"
+    const val VECTOR_ARG_FAIL_MESSAGE = "command.valkyrienskies.vector_arg.fail"
+
     private const val GET_SHIP_ONLY_USABLE_BY_ENTITIES_MESSAGE = "command.valkyrienskies.get_ship.only_usable_by_entities"
     private const val TELEPORTED_MULTIPLE_SHIPS_SUCCESS = "command.valkyrienskies.teleport.multiple_ship_success"
     private const val TELEPORT_FIRST_ARG_CAN_ONLY_INPUT_1_SHIP = "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship"

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
@@ -28,7 +28,6 @@ import org.valkyrienskies.mod.common.getShipManagingPos
 import org.valkyrienskies.mod.common.shipObjectWorld
 import org.valkyrienskies.mod.common.util.toJOML
 import org.valkyrienskies.mod.common.vsCore
-import org.valkyrienskies.mod.common.yRange
 import org.valkyrienskies.mod.mixin.feature.commands.ClientSuggestionProviderAccessor
 import org.valkyrienskies.mod.util.logger
 
@@ -366,7 +365,7 @@ object VSCommands {
 
         if (deleteBlocks) {
             for (ship in r) {
-                var level = context.source.level;
+                var level = context.source.level
                 if (level is ServerLevel) {
                     val aabb = ship.shipAABB ?: continue
                     // There has to be a better way to do this...

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
@@ -22,6 +22,7 @@ import org.valkyrienskies.core.api.ships.ServerShip
 import org.valkyrienskies.core.api.world.ServerShipWorld
 import org.valkyrienskies.core.api.world.ShipWorld
 import org.valkyrienskies.core.apigame.ShipTeleportData
+import org.valkyrienskies.mod.common.config.VSGameConfig
 import org.valkyrienskies.mod.common.dimensionId
 import org.valkyrienskies.mod.common.getShipManagingPos
 import org.valkyrienskies.mod.common.shipObjectWorld
@@ -47,7 +48,44 @@ object VSCommands {
     fun registerServerCommands(dispatcher: CommandDispatcher<CommandSourceStack>) {
         dispatcher.register(
             literal("vs")
+                // Non operator commands
+
+                .then(literal("get-ship")
+                .requires{ it.hasPermission(VSGameConfig.SERVER.Commands.getShipCommandPerms)}
+                .executes {
+
+                    val mcCommandContext = it
+
+                    var success = false
+                    val sourceEntity: Entity? = mcCommandContext.source.entity
+                    if (sourceEntity != null) {
+                        val rayTrace = sourceEntity.pick(10.0, 1.0.toFloat(), false)
+                        if (rayTrace is BlockHitResult) {
+                            val ship = sourceEntity.level().getShipManagingPos(rayTrace.blockPos)
+                            if (ship != null) {
+                                it.source.sendVSMessage(
+                                    translatable(GET_SHIP_SUCCESS_MESSAGE, ship.slug, ship.id)
+                                )
+                                success = true
+                            }
+                        }
+                        if (success) {
+                            1
+                        } else {
+                            it.source.sendVSMessage(translatable(GET_SHIP_FAIL_MESSAGE))
+                            0
+                        }
+                    } else {
+                        it.source.sendVSMessage(
+                            translatable(GET_SHIP_ONLY_USABLE_BY_ENTITIES_MESSAGE)
+                        )
+                        0
+                    }
+
+                })
+                // Operator commands
                 .then(literal("delete")
+                .requires{ it.hasPermission(VSGameConfig.SERVER.Commands.deleteShipCommandPerms)}
                     .then(argument("ships", ShipArgument.ships())
                         .executes {
                             deleteShip(it)
@@ -58,6 +96,7 @@ object VSCommands {
                         )
                     )
                 ).then(literal("rename")
+                .requires{ it.hasPermission(VSGameConfig.SERVER.Commands.renameShipCommandPerms)}
                     .then(argument("ship", ShipArgument.ships())
                         .then(argument("newName", StringArgumentType.string())
                             .executes {
@@ -71,7 +110,8 @@ object VSCommands {
                     )
                 )
                 .then(
-                    literal("set-static").then(
+                    literal("set-static")
+                        .requires{ it.hasPermission(VSGameConfig.SERVER.Commands.setStaticShipCommandPerms)}.then(
                         argument("ships", ShipArgument.ships()).then(
                             argument("is-static", BoolArgumentType.bool()).executes {
                                 val r = ShipArgument.getShips(it, "ships").toList() as List<ServerShip>
@@ -90,7 +130,8 @@ object VSCommands {
                 )
                 //Scale a ship
                 .then(
-                    literal("scale").then(
+                    literal("scale")
+                        .requires{ it.hasPermission(VSGameConfig.SERVER.Commands.scaleShipCommandPerms)}.then(
                         argument("ship", ShipArgument.ships())
                             .then(argument("newScale", DoubleArgumentType.doubleArg(0.001))
                                 .executes {
@@ -105,7 +146,8 @@ object VSCommands {
                     )
                 )
                 .then(
-                    literal("teleport").then(
+                    literal("teleport")
+                        .requires{ it.hasPermission(VSGameConfig.SERVER.Commands.teleportShipCommandPerms)}.then(
                         argument("ships", ShipArgument.ships()).then(
                             argument("position", Vec3Argument.vec3()).executes {
                                 // If only position is present then we execute this code
@@ -254,37 +296,7 @@ object VSCommands {
                         )
                     )
                 )
-                .then(literal("get-ship").executes {
 
-                    val mcCommandContext = it
-
-                    var success = false
-                    val sourceEntity: Entity? = mcCommandContext.source.entity
-                    if (sourceEntity != null) {
-                        val rayTrace = sourceEntity.pick(10.0, 1.0.toFloat(), false)
-                        if (rayTrace is BlockHitResult) {
-                            val ship = sourceEntity.level().getShipManagingPos(rayTrace.blockPos)
-                            if (ship != null) {
-                                it.source.sendVSMessage(
-                                    translatable(GET_SHIP_SUCCESS_MESSAGE, ship.slug, ship.id)
-                                )
-                                success = true
-                            }
-                        }
-                        if (success) {
-                            1
-                        } else {
-                            it.source.sendVSMessage(translatable(GET_SHIP_FAIL_MESSAGE))
-                            0
-                        }
-                    } else {
-                        it.source.sendVSMessage(
-                            translatable(GET_SHIP_ONLY_USABLE_BY_ENTITIES_MESSAGE)
-                        )
-                        0
-                    }
-
-                })
 
         )
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
@@ -2,6 +2,7 @@ package org.valkyrienskies.mod.common.command
 
 import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.arguments.BoolArgumentType
+import com.mojang.brigadier.arguments.DoubleArgumentType
 import com.mojang.brigadier.arguments.StringArgumentType
 import net.minecraft.commands.CommandRuntimeException
 import net.minecraft.commands.CommandSourceStack
@@ -92,6 +93,22 @@ object VSCommands {
                                     throw e
                                 }
                             })
+                    )
+                )
+                //Scale a ship
+                .then(
+                    literal("scale").then(
+                        argument("ship", ShipArgument.ships())
+                            .then(argument("newScale", DoubleArgumentType.doubleArg(0.001))
+                                .executes {
+                                    vsCore.scaleShip(
+                                        it.source.shipWorld as ServerShipWorld,
+                                        ShipArgument.getShip(it, "ship") as ServerShip,
+                                        DoubleArgumentType.getDouble(it, "newScale")
+                                    )
+                                    1
+                                }
+                            )
                     )
                 )
                 .then(

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
@@ -61,16 +61,11 @@ object VSCommands {
                     .then(argument("ship", ShipArgument.ships())
                         .then(argument("newName", StringArgumentType.string())
                             .executes {
-                                try {
-                                    vsCore.renameShip(
-                                        ShipArgument.getShip(it, "ship") as ServerShip,
-                                        StringArgumentType.getString(it, "newName")
-                                    )
-                                    1
-                                } catch (e: Exception) {
-                                    if (e !is CommandRuntimeException) LOGGER.throwing(e)
-                                    throw e
-                                }
+                                vsCore.renameShip(
+                                    ShipArgument.getShip(it, "ship") as ServerShip,
+                                    StringArgumentType.getString(it, "newName")
+                                )
+                                1
                             }
                         )
                     )
@@ -79,22 +74,17 @@ object VSCommands {
                     literal("set-static").then(
                         argument("ships", ShipArgument.ships()).then(
                             argument("is-static", BoolArgumentType.bool()).executes {
-                                try {
-                                    val r = ShipArgument.getShips(it, "ships").toList() as List<ServerShip>
-                                    val isStatic = BoolArgumentType.getBool(it, "is-static")
-                                    r.forEach { ship ->
-                                        ship.isStatic = isStatic
-                                    }
-                                    it.source.sendVSMessage(
-                                        translatable(
-                                            SET_SHIP_STATIC_SUCCESS_MESSAGE, r.size, if (isStatic) "true" else "false"
-                                        )
-                                    )
-                                    r.size
-                                } catch (e: Exception) {
-                                    if (e !is CommandRuntimeException) LOGGER.throwing(e)
-                                    throw e
+                                val r = ShipArgument.getShips(it, "ships").toList() as List<ServerShip>
+                                val isStatic = BoolArgumentType.getBool(it, "is-static")
+                                r.forEach { ship ->
+                                    ship.isStatic = isStatic
                                 }
+                                it.source.sendVSMessage(
+                                    translatable(
+                                        SET_SHIP_STATIC_SUCCESS_MESSAGE, r.size, if (isStatic) "true" else "false"
+                                    )
+                                )
+                                r.size
                             })
                     )
                 )
@@ -119,14 +109,47 @@ object VSCommands {
                         argument("ships", ShipArgument.ships()).then(
                             argument("position", Vec3Argument.vec3()).executes {
                                 // If only position is present then we execute this code
-                                try {
+
+                                val r = ShipArgument.getShips(it, "ships").toList() as List<ServerShip>
+                                val position =
+                                    Vec3Argument.getVec3(it, "position")
+                                val dimensionId = it.source.level.dimensionId
+                                val shipTeleportData: ShipTeleportData =
+                                    vsCore.newShipTeleportData(
+                                        newPos = position.toJOML(),
+                                        newDimension = dimensionId
+                                    )
+                                r.forEach { ship ->
+                                    vsCore.teleportShip(
+                                        it.source.shipWorld as ServerShipWorld,
+                                        ship, shipTeleportData
+                                    )
+                                }
+                                it.source.sendVSMessage(
+                                    translatable(TELEPORT_SHIP_SUCCESS_MESSAGE, r.size, shipTeleportData.toString())
+                                )
+                                r.size
+
+                            }.then(
+                                argument("euler-angles", RelativeVector3Argument.relativeVector3()).executes {
+                                    // If only position is present then we execute this code
+
                                     val r = ShipArgument.getShips(it, "ships").toList() as List<ServerShip>
                                     val position =
                                         Vec3Argument.getVec3(it, "position")
+                                    val eulerAngles =
+                                        RelativeVector3Argument.getRelativeVector3(
+                                            it, "euler-angles"
+                                        )
+
+                                    val source = it.source
                                     val dimensionId = it.source.level.dimensionId
                                     val shipTeleportData: ShipTeleportData =
                                         vsCore.newShipTeleportData(
                                             newPos = position.toJOML(),
+                                            newRot = eulerAngles.toEulerRotationFromMCEntity(
+                                                source.rotation.x.toDouble(), source.rotation.y.toDouble(),
+                                            ),
                                             newDimension = dimensionId
                                         )
                                     r.forEach { ship ->
@@ -139,21 +162,23 @@ object VSCommands {
                                         translatable(TELEPORT_SHIP_SUCCESS_MESSAGE, r.size, shipTeleportData.toString())
                                     )
                                     r.size
-                                } catch (e: Exception) {
-                                    if (e !is CommandRuntimeException) LOGGER.throwing(e)
-                                    throw e
-                                }
-                            }.then(
-                                argument("euler-angles", RelativeVector3Argument.relativeVector3()).executes {
-                                    // If only position is present then we execute this code
-                                    try {
+
+                                }.then(
+                                    argument("velocity", RelativeVector3Argument.relativeVector3()).executes {
+                                        // If only position is present then we execute this code
+
                                         val r = ShipArgument.getShips(it, "ships").toList() as List<ServerShip>
                                         val position =
-                                            Vec3Argument.getVec3(it, "position")
+                                            Vec3Argument.getVec3(
+                                                it, "position"
+                                            )
                                         val eulerAngles =
                                             RelativeVector3Argument.getRelativeVector3(
                                                 it, "euler-angles"
                                             )
+                                        val velocity = RelativeVector3Argument.getRelativeVector3(
+                                            it, "velocity"
+                                        )
 
                                         val source = it.source
                                         val dimensionId = it.source.level.dimensionId
@@ -163,6 +188,7 @@ object VSCommands {
                                                 newRot = eulerAngles.toEulerRotationFromMCEntity(
                                                     source.rotation.x.toDouble(), source.rotation.y.toDouble(),
                                                 ),
+                                                newVel = velocity.toVector3d(0.0, 0.0, 0.0),
                                                 newDimension = dimensionId
                                             )
                                         r.forEach { ship ->
@@ -175,14 +201,13 @@ object VSCommands {
                                             translatable(TELEPORT_SHIP_SUCCESS_MESSAGE, r.size, shipTeleportData.toString())
                                         )
                                         r.size
-                                    } catch (e: Exception) {
-                                        if (e !is CommandRuntimeException) LOGGER.throwing(e)
-                                        throw e
-                                    }
-                                }.then(
-                                    argument("velocity", RelativeVector3Argument.relativeVector3()).executes {
-                                        // If only position is present then we execute this code
-                                        try {
+
+                                    }.then(
+                                        argument(
+                                            "angular-velocity", RelativeVector3Argument.relativeVector3()
+                                        ).executes {
+                                            // If only position is present then we execute this code
+
                                             val r = ShipArgument.getShips(it, "ships").toList() as List<ServerShip>
                                             val position =
                                                 Vec3Argument.getVec3(
@@ -195,6 +220,9 @@ object VSCommands {
                                             val velocity = RelativeVector3Argument.getRelativeVector3(
                                                 it, "velocity"
                                             )
+                                            val angularVelocity = RelativeVector3Argument.getRelativeVector3(
+                                                it, "angular-velocity"
+                                            )
 
                                             val source = it.source
                                             val dimensionId = it.source.level.dimensionId
@@ -205,6 +233,7 @@ object VSCommands {
                                                         source.rotation.x.toDouble(), source.rotation.y.toDouble(),
                                                     ),
                                                     newVel = velocity.toVector3d(0.0, 0.0, 0.0),
+                                                    newOmega = angularVelocity.toVector3d(0.0, 0.0, 0.0),
                                                     newDimension = dimensionId
                                                 )
                                             r.forEach { ship ->
@@ -217,58 +246,7 @@ object VSCommands {
                                                 translatable(TELEPORT_SHIP_SUCCESS_MESSAGE, r.size, shipTeleportData.toString())
                                             )
                                             r.size
-                                        } catch (e: Exception) {
-                                            if (e !is CommandRuntimeException) LOGGER.throwing(e)
-                                            throw e
-                                        }
-                                    }.then(
-                                        argument(
-                                            "angular-velocity", RelativeVector3Argument.relativeVector3()
-                                        ).executes {
-                                            // If only position is present then we execute this code
-                                            try {
-                                                val r = ShipArgument.getShips(it, "ships").toList() as List<ServerShip>
-                                                val position =
-                                                    Vec3Argument.getVec3(
-                                                        it, "position"
-                                                    )
-                                                val eulerAngles =
-                                                    RelativeVector3Argument.getRelativeVector3(
-                                                        it, "euler-angles"
-                                                    )
-                                                val velocity = RelativeVector3Argument.getRelativeVector3(
-                                                    it, "velocity"
-                                                )
-                                                val angularVelocity = RelativeVector3Argument.getRelativeVector3(
-                                                    it, "angular-velocity"
-                                                )
 
-                                                val source = it.source
-                                                val dimensionId = it.source.level.dimensionId
-                                                val shipTeleportData: ShipTeleportData =
-                                                    vsCore.newShipTeleportData(
-                                                        newPos = position.toJOML(),
-                                                        newRot = eulerAngles.toEulerRotationFromMCEntity(
-                                                            source.rotation.x.toDouble(), source.rotation.y.toDouble(),
-                                                        ),
-                                                        newVel = velocity.toVector3d(0.0, 0.0, 0.0),
-                                                        newOmega = angularVelocity.toVector3d(0.0, 0.0, 0.0),
-                                                        newDimension = dimensionId
-                                                    )
-                                                r.forEach { ship ->
-                                                    vsCore.teleportShip(
-                                                        it.source.shipWorld as ServerShipWorld,
-                                                        ship, shipTeleportData
-                                                    )
-                                                }
-                                                it.source.sendVSMessage(
-                                                    translatable(TELEPORT_SHIP_SUCCESS_MESSAGE, r.size, shipTeleportData.toString())
-                                                )
-                                                r.size
-                                            } catch (e: Exception) {
-                                                if (e !is CommandRuntimeException) LOGGER.throwing(e)
-                                                throw e
-                                            }
                                         }
                                     )
                                 )
@@ -277,38 +255,35 @@ object VSCommands {
                     )
                 )
                 .then(literal("get-ship").executes {
-                    try {
-                        val mcCommandContext = it
 
-                        var success = false
-                        val sourceEntity: Entity? = mcCommandContext.source.entity
-                        if (sourceEntity != null) {
-                            val rayTrace = sourceEntity.pick(10.0, 1.0.toFloat(), false)
-                            if (rayTrace is BlockHitResult) {
-                                val ship = sourceEntity.level().getShipManagingPos(rayTrace.blockPos)
-                                if (ship != null) {
-                                    it.source.sendVSMessage(
-                                        translatable(GET_SHIP_SUCCESS_MESSAGE, ship.slug, ship.id)
-                                    )
-                                    success = true
-                                }
+                    val mcCommandContext = it
+
+                    var success = false
+                    val sourceEntity: Entity? = mcCommandContext.source.entity
+                    if (sourceEntity != null) {
+                        val rayTrace = sourceEntity.pick(10.0, 1.0.toFloat(), false)
+                        if (rayTrace is BlockHitResult) {
+                            val ship = sourceEntity.level().getShipManagingPos(rayTrace.blockPos)
+                            if (ship != null) {
+                                it.source.sendVSMessage(
+                                    translatable(GET_SHIP_SUCCESS_MESSAGE, ship.slug, ship.id)
+                                )
+                                success = true
                             }
-                            if (success) {
-                                1
-                            } else {
-                                it.source.sendVSMessage(translatable(GET_SHIP_FAIL_MESSAGE))
-                                0
-                            }
+                        }
+                        if (success) {
+                            1
                         } else {
-                            it.source.sendVSMessage(
-                                translatable(GET_SHIP_ONLY_USABLE_BY_ENTITIES_MESSAGE)
-                            )
+                            it.source.sendVSMessage(translatable(GET_SHIP_FAIL_MESSAGE))
                             0
                         }
-                    } catch (e: Exception) {
-                        if (e !is CommandRuntimeException) LOGGER.throwing(e)
-                        throw e
+                    } else {
+                        it.source.sendVSMessage(
+                            translatable(GET_SHIP_ONLY_USABLE_BY_ENTITIES_MESSAGE)
+                        )
+                        0
                     }
+
                 })
 
         )

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -185,10 +185,39 @@ object VSGameConfig {
         )
         var defaultSplitGraceTimer = 1
 
-        @JsonSchema(
-            description = "The permission level required to use the /vs command. Must be 0 <= x <= 4"
-        )
-        var vsCommandPerms = 2
+        val Commands = COMMANDS()
+
+        class COMMANDS {
+            @JsonSchema(
+                description = "The permission level required to use the /vs delete command. Must be 0 <= x <= 4"
+            )
+            var deleteShipCommandPerms = 2
+
+            @JsonSchema(
+                description = "The permission level required to use the /vs get-ship command. Must be 0 <= x <= 4"
+            )
+            var getShipCommandPerms = 0
+
+            @JsonSchema(
+                description = "The permission level required to use the /vs rename command. Must be 0 <= x <= 4"
+            )
+            var renameShipCommandPerms = 2
+
+            @JsonSchema(
+                description = "The permission level required to use the /vs scale command. Must be 0 <= x <= 4"
+            )
+            var scaleShipCommandPerms = 2
+
+            @JsonSchema(
+                description = "The permission level required to use the /vs set-static command. Must be 0 <= x <= 4"
+            )
+            var setStaticShipCommandPerms = 2
+
+            @JsonSchema(
+                description = "The permission level required to use the /vs teleport command. Must be 0 <= x <= 4"
+            )
+            var teleportShipCommandPerms = 2
+        }
     }
 
     class Common {

--- a/common/src/main/resources/assets/valkyrienskies/lang/en_us.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/en_us.json
@@ -30,5 +30,6 @@
   "command.valkyrienskies.get_ship.success": "Found ship with slug %s and id %s",
   "command.valkyrienskies.get_ship.fail": "No ship found",
   "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship can only be run by entities!",
-  "command.valkyrienskies.scale.success": "Scaled %d ships!"
+  "command.valkyrienskies.scale.success": "Scaled %d ships!",
+  "command.valkyrienskies.vector_arg.fail": "Invalid vector argument"
 }


### PR DESCRIPTION
Re add the /vs scale command that got disabled in 2.3 sometime between 1.18 and 1.20, and then got lost in my command fixing PR

Fix the relative vector argument so it gives accurate errors and suggestions

Add an optional argument to /vs delete to clear out the shipyard while deleting the ship