### PR TITLE
Projectiles to shipyard

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/client/multiplayer/MixinClientPacketListener.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/client/multiplayer/MixinClientPacketListener.java
@@ -14,9 +14,11 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.At.Shift;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.core.api.ships.ClientShip;
 import org.valkyrienskies.mod.common.IShipObjectWorldClientCreator;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.ValkyrienSkiesMod;
+import org.valkyrienskies.mod.common.entity.handling.WorldEntityHandler;
 
 @Mixin(ClientPacketListener.class)
 public class MixinClientPacketListener {
@@ -59,6 +61,25 @@ public class MixinClientPacketListener {
             entity.setUUID(packet.getUUID());
             this.level.putNonPlayerEntity(i, entity);
         }
+    }
+
+    /**
+     * If the player picks up an item/arrow that is on shipyard, animation picking it up has problem lerping the position.
+     * To prevent this, the entity is repositioned from shipyard to world again.
+     * @author Bunting_chj
+     */
+
+    @WrapOperation(
+        method = "handleTakeItemEntity",
+        at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/client/multiplayer/ClientLevel;getEntity(I)Lnet/minecraft/world/entity/Entity;")
+    )
+    private Entity setPositionBackToWorld(ClientLevel level, int i, Operation<Entity> getEntity) {
+        Entity entity = getEntity.call(level, i);
+        if(VSGameUtilsKt.getShipManaging(entity) instanceof ClientShip ship) {
+            WorldEntityHandler.INSTANCE.moveEntityFromShipyardToWorld(entity, ship);
+        }
+        return entity;
     }
 
     /**

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/client/renderer/MixinLevelRenderer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/client/renderer/MixinLevelRenderer.java
@@ -1,12 +1,23 @@
 package org.valkyrienskies.mod.mixin.client.renderer;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.core.BlockPos;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
 @Mixin(LevelRenderer.class)
 public abstract class MixinLevelRenderer {
+
+    @Shadow
+    private @Nullable ClientLevel level;
 
     /**
      * @reason This mixin forces the game to always render block damage.
@@ -66,4 +77,24 @@ public abstract class MixinLevelRenderer {
 
      */
 
+    /**
+     * If an entity, for example an arrow stuck on a ship, is attached outside the border of the ship's chunk claim,
+     * it won't be rendered because the chunk isn't compiled.
+     * This injector bypasses that if the entity is in shipyard next to the compiled chunk.
+     */
+    @WrapOperation(
+        method = "renderLevel",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/LevelRenderer;isChunkCompiled(Lnet/minecraft/core/BlockPos;)Z")
+    )
+    private boolean isInShipyardBorder(LevelRenderer instance, BlockPos blockPos, Operation<Boolean> original){
+        if(original.call(instance, blockPos)) return true;
+        if(VSGameUtilsKt.isBlockInShipyard(level, blockPos)) {
+            BlockPos blockPos1 = blockPos.offset(-1, -1, -1);
+            BlockPos blockPos2 = blockPos.offset(1, 1, 1);
+            for(BlockPos neighbor : BlockPos.betweenClosed(blockPos1, blockPos2)) {
+                if (original.call(instance, neighbor)) return true;
+            }
+        }
+        return false;
+    }
 }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/FEATURE.md
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/FEATURE.md
@@ -18,6 +18,7 @@ in the ship.
   the vehicle position as the entities' position.
     * This fixes players falling through the world when loading if they were
     mounted to a ship entity when the game saved.
+* `MixinProjectile` Moves projectile to and from shipyard to keep them stick on where they landed.
 * `MixinEntityRenderDispatcher#render` Handles rendering of entities.
     * This is relevant for rendering entities on ships.
 * `MixinEntityRenderDispatcher#shouldRender` Handles rendering of entities.

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinProjectile.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinProjectile.java
@@ -1,0 +1,66 @@
+package org.valkyrienskies.mod.mixin.feature.shipyard_entities;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.TraceableEntity;
+import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.entity.projectile.ProjectileUtil;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.HitResult.Type;
+import org.joml.Vector3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.entity.handling.DefaultShipyardEntityHandler;
+import org.valkyrienskies.mod.common.entity.handling.WorldEntityHandler;
+import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
+
+@Mixin(Projectile.class)
+public abstract class MixinProjectile extends Entity implements TraceableEntity {
+
+    @Shadow
+    protected abstract boolean canHitEntity(Entity entity);
+
+    public MixinProjectile(EntityType<?> entityType, Level level) {
+        super(entityType, level);
+    }
+
+    /**
+     * If the projectile hit the ship, sends it to the shipyard.
+     * This makes arrows/tridents/fishing hooks stuck on a ship render at correct position.
+     */
+    @Inject(
+        method = "onHit",
+        at = @At("HEAD")
+    )
+    private void sendToShipyard(HitResult hitResult, CallbackInfo ci) {
+        Ship ship;
+        if (hitResult instanceof BlockHitResult blockHitResult && (ship = VSGameUtilsKt.getShipManagingPos(level(), blockHitResult.getBlockPos())) != null) {
+            Vector3d hitLocation = ship.getWorldToShip().transformPosition(VectorConversionsMCKt.toJOML(blockHitResult.location));
+            blockHitResult.location = VectorConversionsMCKt.toMinecraft(hitLocation);
+            DefaultShipyardEntityHandler.INSTANCE.moveEntityFromWorldToShipyard(this, ship);
+        }
+    }
+
+    /**
+     * If the projectile is no longer touching any block on shipyard, return it to the world.
+     */
+    @Inject(
+        method = "tick",
+        at = @At("HEAD")
+    )
+    private void returnFromShipyard(CallbackInfo ci) {
+        final Ship ship;
+        if((ship = VSGameUtilsKt.getShipManaging(this)) == null) return;
+        HitResult result = ProjectileUtil.getHitResultOnMoveVector(this, this::canHitEntity);
+        if(result.getType() == Type.MISS) {
+            WorldEntityHandler.INSTANCE.moveEntityFromShipyardToWorld(this, ship);
+        }
+    }
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/AbstractShipyardEntityHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/AbstractShipyardEntityHandler.kt
@@ -12,6 +12,8 @@ import org.valkyrienskies.core.api.ships.ClientShip
 import org.valkyrienskies.core.api.ships.Ship
 import org.valkyrienskies.mod.common.util.toJOML
 import org.valkyrienskies.mod.common.util.toMinecraft
+import kotlin.math.atan2
+import kotlin.math.sqrt
 
 abstract class AbstractShipyardEntityHandler : VSEntityHandler {
     override fun freshEntityInShipyard(entity: Entity, ship: Ship) {
@@ -63,7 +65,7 @@ abstract class AbstractShipyardEntityHandler : VSEntityHandler {
         moveEntityFromWorldToShipyard(entity, ship, entity.x, entity.y, entity.z)
 
     fun moveEntityFromWorldToShipyard(entity: Entity, ship: Ship, entityX: Double, entityY: Double, entityZ: Double) {
-        val shipyardPos = ship.worldToShip.transformPosition(entity.position().toJOML())
+        val shipyardPos = ship.worldToShip.transformPosition(entityX, entityY, entityZ, Vector3d())
         val relativePos: Vector3d = entity.position().toJOML().sub(ship.transform.positionInWorld)
         val shipPosVelocity = Vector3d(ship.velocity)
             .add(Vector3d(ship.angularVelocity).cross(relativePos))
@@ -72,15 +74,26 @@ abstract class AbstractShipyardEntityHandler : VSEntityHandler {
         ship.worldToShip.transformDirection(relativeDeltaOnShip)
         entity.setPos(shipyardPos.x, shipyardPos.y, shipyardPos.z)
         entity.deltaMovement = relativeDeltaOnShip.toMinecraft()
-        entity.xo = shipyardPos.x - relativeDeltaOnShip.x
-        entity.yo = shipyardPos.y - relativeDeltaOnShip.y
-        entity.zo = shipyardPos.z - relativeDeltaOnShip.z
+
+        entity.xo = shipyardPos.x
+        entity.yo = shipyardPos.y
+        entity.zo = shipyardPos.z
+
+        val direction = ship.shipToWorld.transformDirection(entity.lookAngle.toJOML()) // I thought this should be world to ship, but it was ship to world. I have no idea why. -Bunting_chj
+        val yaw = atan2(-direction.x, direction.z)
+        val pitch = -atan2(direction.y, sqrt((direction.x * direction.x) + (direction.z * direction.z)))
+        entity.yRot = (yaw * (180 / Math.PI)).toFloat()
+        entity.xRot = (pitch * (180 / Math.PI)).toFloat()
+        entity.yRotO = entity.yRot
+        entity.xRotO = entity.xRot
+
         if (entity is AbstractHurtingProjectile) {
             val power = Vector3d(entity.xPower, entity.yPower, entity.zPower)
-            ship.transform.worldToShip.transformDirection(power)
+            ship.transform.shipToWorld.transformDirection(power)
             entity.xPower = power.x
             entity.yPower = power.y
             entity.zPower = power.z
+
             ProjectileUtil.rotateTowardsMovement(entity, 1.0f)
         }
     }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/AbstractShipyardEntityHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/AbstractShipyardEntityHandler.kt
@@ -4,6 +4,8 @@ import com.mojang.blaze3d.vertex.PoseStack
 import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.client.renderer.entity.EntityRenderer
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.projectile.AbstractHurtingProjectile
+import net.minecraft.world.entity.projectile.ProjectileUtil
 import org.joml.Quaternionf
 import org.joml.Vector3d
 import org.valkyrienskies.core.api.ships.ClientShip
@@ -55,5 +57,31 @@ abstract class AbstractShipyardEntityHandler : VSEntityHandler {
         // TODO: somewhere else position is already applied in the matrix stack
         // EW: i think it was in entity dragging logic
         matrixStack.mulPose(Quaternionf(ship.renderTransform.shipToWorldRotation))
+    }
+
+    fun moveEntityFromWorldToShipyard(entity: Entity, ship: Ship) =
+        moveEntityFromWorldToShipyard(entity, ship, entity.x, entity.y, entity.z)
+
+    fun moveEntityFromWorldToShipyard(entity: Entity, ship: Ship, entityX: Double, entityY: Double, entityZ: Double) {
+        val shipyardPos = ship.worldToShip.transformPosition(entity.position().toJOML())
+        val relativePos: Vector3d = entity.position().toJOML().sub(ship.transform.positionInWorld)
+        val shipPosVelocity = Vector3d(ship.velocity)
+            .add(Vector3d(ship.angularVelocity).cross(relativePos))
+            .mul(0.05)
+        val relativeDeltaOnShip: Vector3d = entity.deltaMovement.toJOML().sub(shipPosVelocity)
+        ship.worldToShip.transformDirection(relativeDeltaOnShip)
+        entity.setPos(shipyardPos.x, shipyardPos.y, shipyardPos.z)
+        entity.deltaMovement = relativeDeltaOnShip.toMinecraft()
+        entity.xo = shipyardPos.x - relativeDeltaOnShip.x
+        entity.yo = shipyardPos.y - relativeDeltaOnShip.y
+        entity.zo = shipyardPos.z - relativeDeltaOnShip.z
+        if (entity is AbstractHurtingProjectile) {
+            val power = Vector3d(entity.xPower, entity.yPower, entity.zPower)
+            ship.transform.worldToShip.transformDirection(power)
+            entity.xPower = power.x
+            entity.yPower = power.y
+            entity.zPower = power.z
+            ProjectileUtil.rotateTowardsMovement(entity, 1.0f)
+        }
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/VSEntityManager.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/VSEntityManager.kt
@@ -5,6 +5,7 @@ import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.EntityType
+import net.minecraft.world.entity.projectile.Projectile
 import org.valkyrienskies.mod.common.ValkyrienSkiesMod
 import org.valkyrienskies.mod.common.networking.PacketSyncVSEntityTypes
 import org.valkyrienskies.mod.common.util.MinecraftPlayer
@@ -74,7 +75,7 @@ object VSEntityManager {
             val className = entity::class.java.simpleName
             val registryName = BuiltInRegistries.ENTITY_TYPE.getKey(entity.type)
 
-            if (className.contains("SeatEntity", true) || registryName.path.contains(seatRegistryName)) {
+            if (entity is Projectile || className.contains("SeatEntity", true) || registryName.path.contains(seatRegistryName)) {
                 return DefaultShipyardEntityHandler
             }
         } catch (ex: Exception) {

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/WorldEntityHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/WorldEntityHandler.kt
@@ -74,8 +74,8 @@ object WorldEntityHandler : VSEntityHandler {
             .add(shipVelocity)
             .toMinecraft()
 
-        val direction = ship.transform.shipToWorldRotation.transform(entity.lookAngle.toJOML())
-        val yaw = -atan2(direction.x, direction.z)
+        val direction = ship.transform.worldToShip.transformDirection(entity.lookAngle.toJOML()) // I thought this should be ship to world, but it was world to ship. I have no idea why. -Bunting_chj
+        val yaw = atan2(-direction.x, direction.z)
         val pitch = -atan2(direction.y, sqrt((direction.x * direction.x) + (direction.z * direction.z)))
         entity.yRot = (yaw * (180 / Math.PI)).toFloat()
         entity.xRot = (pitch * (180 / Math.PI)).toFloat()
@@ -85,7 +85,7 @@ object WorldEntityHandler : VSEntityHandler {
         if (entity is AbstractHurtingProjectile) {
             val power = Vector3d(entity.xPower, entity.yPower, entity.zPower)
 
-            ship.transform.shipToWorldRotation.transform(power)
+            ship.transform.worldToShip.transformDirection(power)
 
             entity.xPower = power.x
             entity.yPower = power.y

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -38,6 +38,7 @@
     "feature.ai.path_retargeting.MixinAirAndWaterRandomPos",
     "feature.ai.path_retargeting.MixinDefaultRandomPos",
     "feature.ai.path_retargeting.MixinLandRandomPos",
+    "feature.shipyard_entities.MixinProjectile",
     "feature.bed_fix.MixinServerPlayer",
     "feature.block_placement.MixinBlockItem",
     "feature.block_placement.MixinBlockPlaceContext",


### PR DESCRIPTION
If any projectile collides with ship block, it'll be sent to shipyard. If said projectile stops colliding with the ship blocks, it'll return to worldspace.
This PR is meant to fix arrows not sticking on ship, but implements it by generic projectile, so other things like fishing hooks also work as the same.
Arrows and tridents can be picked up normally thanks to previous existing code. Loyal tridents return to the owner too, while the initial velocity is a bit off.