### PR TITLE
[1.20.1/2.3] Dynmap Support

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     // TIS-3d
     modCompileOnly("maven.modrinth:tis3d:${tis3d_version}")
 
+    // Dynmap
+    modCompileOnly("maven.modrinth:dynmap:${dynmap_version}")
+
     //Common create compat,
     //We just use a version from a platform and hope the classes exist on both versions and mixins apply correctly
     modCompileOnly("com.simibubi.create:create-fabric-${minecraft_version}:${create_fabric_version}")

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     // CC-Tweaked
     modCompileOnly("cc.tweaked:cc-tweaked-${minecraft_version}-common:${cc_tweaked_version}")
 
+    // Dynmap
+    modCompileOnly("maven.modrinth:dynmap:${dynmap_version}")
+
     // Common create compat,
     // We just use a version from a platform and hope the classes exist on both versions and mixins apply correctly
     modCompileOnly("com.simibubi.create:create-fabric-${minecraft_version}:${create_fabric_version}")

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -79,9 +79,9 @@ object VSGameConfig {
             var showIconMarkers = true
             @JsonSchema(description = "Show Ships as Polyline Markers on Dynmap")
             var showPolylineMarkers = true
-            @JsonSchema
+            @JsonSchema(description = "Show the Ship ID in the label")
             var showShipId = true
-            @JsonSchema
+            @JsonSchema(description = "Show the Ship Mass in the label")
             var showShipMass = true
         }
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -96,6 +96,19 @@ object VSGameConfig {
             var stormDampening = 0.0f
         }
 
+        val Dynmap = DYNMAP()
+
+        class DYNMAP {
+            @JsonSchema(description = "Show Ships as Icon Markers on Dynmap")
+            var showIconMarkers = true
+            @JsonSchema(description = "Show Ships as Polyline Markers on Dynmap")
+            var showPolylineMarkers = true
+            @JsonSchema(description = "Show the Ship ID in the label")
+            var showShipId = true
+            @JsonSchema(description = "Show the Ship Mass in the label")
+            var showShipMass = true
+        }
+
 
         @JsonSchema(
             description = "By default, the vanilla server prevents block interacts past a certain distance " +

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -72,6 +72,19 @@ object VSGameConfig {
             var canTurtlesLeaveScaledShips = false
         }
 
+        val Dynmap = DYNMAP()
+
+        class DYNMAP {
+            @JsonSchema(description = "Show Ships as Icon Markers on Dynmap")
+            var showIconMarkers = true
+            @JsonSchema(description = "Show Ships as Polyline Markers on Dynmap")
+            var showPolylineMarkers = true
+            @JsonSchema
+            var showShipId = true
+            @JsonSchema
+            var showShipMass = true
+        }
+
         @JsonSchema(
             description = "By default, the vanilla server prevents block interacts past a certain distance " +
                 "to prevent cheat clients from breaking blocks halfway across the map. " +

--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/dynmap/DynmapHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/dynmap/DynmapHandler.kt
@@ -1,0 +1,165 @@
+package org.valkyrienskies.mod.compat.dynmap
+
+import net.minecraft.server.level.ServerLevel
+import org.dynmap.DynmapCommonAPI
+import org.dynmap.DynmapCommonAPIListener
+import org.dynmap.markers.GenericMarker
+import org.dynmap.markers.Marker
+import org.dynmap.markers.MarkerIcon
+import org.dynmap.markers.MarkerSet
+import org.dynmap.markers.PolyLineMarker
+import org.joml.Vector3d
+import org.joml.primitives.AABBdc
+import org.valkyrienskies.core.api.ships.QueryableShipData
+import org.valkyrienskies.core.api.ships.ServerShip
+import org.valkyrienskies.mod.common.ValkyrienSkiesMod
+import org.valkyrienskies.mod.common.config.VSGameConfig
+import org.valkyrienskies.mod.common.shipObjectWorld
+import kotlin.random.Random
+
+abstract class DynmapHandler : DynmapCommonAPIListener() {
+    var api: DynmapCommonAPI? = null
+
+    override fun apiEnabled(dynmapCommonAPI: DynmapCommonAPI) {
+        this.api = dynmapCommonAPI
+    }
+
+    open fun register() {
+        register(this)
+    }
+
+    fun updateMarkers(level: ServerLevel) {
+        val worldName = getWorldName(level)
+        val allShips = level.shipObjectWorld.allShips
+
+        val markerSet = getOrCreateMarkerSet() ?: return
+
+        clearUnusedIconMarkers(markerSet, allShips)
+        if (VSGameConfig.SERVER.Dynmap.showIconMarkers)
+            allShips.forEach { ship -> renderShipIconMarker(ship, markerSet, worldName) }
+
+        clearUnusedPolylineMarkers(markerSet, allShips)
+        if (VSGameConfig.SERVER.Dynmap.showPolylineMarkers)
+            allShips.forEach { ship -> renderShipPolylineMarker(ship, markerSet, worldName) }
+    }
+
+    private fun clearUnusedIconMarkers(markerSet: MarkerSet, data: QueryableShipData<ServerShip>) {
+        markerSet.markers?.forEach { marker -> clearUnusedMarker(marker, data, VSGameConfig.SERVER.Dynmap.showIconMarkers) }
+    }
+
+    private fun clearUnusedPolylineMarkers(markerSet: MarkerSet, data: QueryableShipData<ServerShip>) {
+        markerSet.polyLineMarkers?.forEach { marker -> clearUnusedMarker(marker, data, VSGameConfig.SERVER.Dynmap.showPolylineMarkers) }
+    }
+
+    private fun clearUnusedMarker(marker: GenericMarker, data: QueryableShipData<ServerShip>, enabled: Boolean) {
+        val id = marker.markerID.replace("ship", "").toLong()
+        if (data.getById(id) == null || !enabled)
+            marker.deleteMarker()
+    }
+
+    private fun renderShipIconMarker(data: ServerShip, markerSet: MarkerSet, world: String) {
+        val pos = data.transform.positionInWorld
+        val label = ""//createShipLabel(data, this.config)
+        val icon = getOrCreateIcon()
+
+        val marker: Marker = markerSet.findMarker("ship${data.id}") ?: run {
+            markerSet.createMarker("ship${data.id}", label, true, world, pos.x(), pos.y(), pos.z(), icon, true)
+            return
+        }
+        marker.description = label
+        marker.setLocation(world, pos.x(), pos.y(), pos.z())
+        marker.markerIcon = icon
+    }
+
+    private fun renderShipPolylineMarker(data: ServerShip, markerSet: MarkerSet, world: String) {
+        val arrays = getArraysFromAABB(data.worldAABB)
+        val label = createShipLabel(data)
+        val marker: PolyLineMarker = markerSet.findPolyLineMarker("ship${data.id}") ?: run {
+            val self = markerSet.createPolyLineMarker("ship${data.id}", label, true, world, arrays.first, arrays.second, arrays.third, true)
+            self?.setLineStyle(5, self.lineOpacity, Random.nextInt(0x000000, 0xFFFFFF))
+            self ?: return
+        }
+        marker.description = label
+        marker.setCornerLocations(arrays.first, arrays.second, arrays.third)
+    }
+
+    private fun getOrCreateMarkerSet(): MarkerSet? =
+        this.api?.markerAPI?.getMarkerSet(ValkyrienSkiesMod.MOD_ID) ?: run {
+            this.api?.markerAPI?.createMarkerSet(ValkyrienSkiesMod.MOD_ID, "VS Ship Markers", null, true)
+        }
+
+    private fun getArraysFromAABB(aabb: AABBdc): Triple<DoubleArray, DoubleArray, DoubleArray> {
+        val x = doubleArrayOf(
+            aabb.minX(), // 1
+            aabb.minX(), // 1
+            aabb.minX(), // 1
+            aabb.minX(), // 1
+            aabb.minX(), // 1
+            aabb.minX(), // 2
+            aabb.maxX(), // 2
+            aabb.maxX(), // 2
+            aabb.minX(), // 2
+            aabb.maxX(), // 2
+            aabb.maxX(), // 3
+            aabb.maxX(), // 3
+            aabb.maxX(), // 3
+            aabb.maxX(), // 3
+            aabb.minX(), // 4
+            aabb.minX(), // 4
+            aabb.maxX() // 4
+        )
+        val y = doubleArrayOf(
+            aabb.minY(), // 1
+            aabb.maxY(), // 1
+            aabb.maxY(), // 1
+            aabb.minY(), // 1
+            aabb.minY(), // 1
+            aabb.maxY(), // 2
+            aabb.maxY(), // 2
+            aabb.minY(), // 2
+            aabb.minY(), // 2
+            aabb.minY(), // 2
+            aabb.minY(), // 3
+            aabb.maxY(), // 3
+            aabb.maxY(), // 3
+            aabb.maxY(), // 3
+            aabb.maxY(), // 4
+            aabb.minY(), // 4
+            aabb.minY() // 4
+        )
+        val z = doubleArrayOf(
+            aabb.minZ(), // 1
+            aabb.minZ(), // 1
+            aabb.maxZ(), // 1
+            aabb.maxZ(), // 1
+            aabb.minZ(), // 1
+            aabb.minZ(), // 2
+            aabb.minZ(), // 2
+            aabb.minZ(), // 2
+            aabb.minZ(), // 2
+            aabb.minZ(), // 2
+            aabb.maxZ(), // 3
+            aabb.maxZ(), // 3
+            aabb.minZ(), // 3
+            aabb.maxZ(), // 3
+            aabb.maxZ(), // 4
+            aabb.maxZ(), // 4
+            aabb.maxZ() // 4
+        )
+
+        return Triple(x, y, z)
+    }
+
+    private fun createShipLabel(ship: ServerShip): String {
+        var label = "<h1>${ship.slug}</h1>"
+
+        if (VSGameConfig.SERVER.Dynmap.showShipId) label += "<p><strong>Ship ID: </strong>${ship.id}</p>"
+        if (VSGameConfig.SERVER.Dynmap.showShipMass) label += "<p><strong>Ship Mass: </strong>${ship.inertiaData.mass} kg</p>"
+
+        return label
+    }
+
+    abstract fun getWorldName(level: ServerLevel): String
+
+    abstract fun getOrCreateIcon(): MarkerIcon?
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/dynmap/DynmapHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/dynmap/DynmapHandler.kt
@@ -59,7 +59,7 @@ abstract class DynmapHandler : DynmapCommonAPIListener() {
 
     private fun renderShipIconMarker(data: ServerShip, markerSet: MarkerSet, world: String) {
         val pos = data.transform.positionInWorld
-        val label = ""//createShipLabel(data, this.config)
+        val label = createShipLabel(data)
         val icon = getOrCreateIcon()
 
         val marker: Marker = markerSet.findMarker("ship${data.id}") ?: run {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -87,6 +87,9 @@ dependencies {
     modCompileOnly("com.jamieswhiteshirt:reach-entity-attributes:${reach_entity_attributes_version}")
     modCompileOnly("dev.cafeteria:fake-player-api:${fake_player_api_version}")
     modCompileOnly("io.github.tropheusj:milk-lib:${milk_lib_version}")
+
+    // Dynmap
+    modCompileOnly("maven.modrinth:dynmap:${dynmap_version}")
 }
 
 // Copy the VS common access widener to the generated resources folder

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -82,6 +82,9 @@ dependencies {
     modCompileOnly("com.jamieswhiteshirt:reach-entity-attributes:${reach_entity_attributes_version}")
     modCompileOnly("dev.cafeteria:fake-player-api:${fake_player_api_version}")
     modCompileOnly("io.github.tropheusj:milk-lib:${milk_lib_version}")
+
+    // Dynmap
+    modCompileOnly("maven.modrinth:dynmap:${dynmap_version}")
 }
 
 // Copy the VS common access widener to the generated resources folder

--- a/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/common/ValkyrienSkiesModFabric.kt
+++ b/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/common/ValkyrienSkiesModFabric.kt
@@ -25,6 +25,7 @@ import net.minecraft.world.item.CreativeModeTab
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.Item.Properties
 import net.minecraft.world.level.block.Block
+import org.dynmap.modsupport.ModSupportAPI
 import org.valkyrienskies.core.apigame.VSCoreFactory
 import org.valkyrienskies.mod.client.EmptyRenderer
 import org.valkyrienskies.mod.client.VSPhysicsEntityRenderer
@@ -47,6 +48,7 @@ import org.valkyrienskies.mod.common.hooks.VSGameEvents
 import org.valkyrienskies.mod.common.item.PhysicsEntityCreatorItem
 import org.valkyrienskies.mod.common.item.ShipAssemblerItem
 import org.valkyrienskies.mod.common.item.ShipCreatorItem
+import org.valkyrienskies.mod.fabric.compat.dynmap.FabricDynmapHandler
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicBoolean
@@ -186,6 +188,9 @@ class ValkyrienSkiesModFabric : ModInitializer {
         CommonLifecycleEvents.TAGS_LOADED.register { _, _ ->
             VSGameEvents.tagsAreLoaded.emit(Unit)
         }
+
+        if (FabricLoader.getInstance().isModLoaded("dynmap"))
+            FabricDynmapHandler().register()
     }
 
     /**

--- a/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/compat/dynmap/FabricDynmapHandler.kt
+++ b/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/compat/dynmap/FabricDynmapHandler.kt
@@ -1,0 +1,29 @@
+package org.valkyrienskies.mod.fabric.compat.dynmap
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents
+import net.minecraft.server.level.ServerLevel
+import org.dynmap.fabric_1_20.DynmapMod.plugin
+import org.dynmap.fabric_1_20.FabricWorld
+import org.dynmap.markers.MarkerIcon
+import org.valkyrienskies.mod.common.ValkyrienSkiesMod
+import org.valkyrienskies.mod.compat.dynmap.DynmapHandler
+
+class FabricDynmapHandler: DynmapHandler() {
+    override fun register() {
+        super.register()
+        ServerTickEvents.END_WORLD_TICK.register(this::updateMarkers)
+    }
+
+    override fun getWorldName(level: ServerLevel): String {
+        return FabricWorld.getWorldName(plugin, level)
+    }
+
+    override fun getOrCreateIcon(): MarkerIcon? =
+        this.api?.markerAPI?.getMarkerIcon("ship") ?: run {
+            plugin?.fabricServer?.let {
+                this.api?.markerAPI?.createMarkerIcon("loaded_ship", "ship",
+                    it.openResource(ValkyrienSkiesMod.MOD_ID, "assets/valkyrienskies/icon.png"))
+            }
+        }
+}

--- a/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/compat/dynmap/FabricDynmapHandler.kt
+++ b/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/compat/dynmap/FabricDynmapHandler.kt
@@ -22,7 +22,7 @@ class FabricDynmapHandler: DynmapHandler() {
     override fun getOrCreateIcon(): MarkerIcon? =
         this.api?.markerAPI?.getMarkerIcon("ship") ?: run {
             plugin?.fabricServer?.let {
-                this.api?.markerAPI?.createMarkerIcon("loaded_ship", "ship",
+                this.api?.markerAPI?.createMarkerIcon("ship", "ship",
                     it.openResource(ValkyrienSkiesMod.MOD_ID, "assets/valkyrienskies/icon.png"))
             }
         }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -88,6 +88,9 @@ dependencies {
     // Epic Fight
     modCompileOnly("maven.modrinth:epic-fight:20.10.3")
 
+    // Dynmap
+    modCompileOnly("maven.modrinth:dynmap:${dynmap_version}")
+
     // Add Kotlin for Forge (3.12.0)
     forgeRuntimeLibrary("maven.modrinth:kotlin-for-forge:${kotlin_version}")
 

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -84,6 +84,9 @@ dependencies {
     // Epic Fight
     modCompileOnly("maven.modrinth:epic-fight:20.10.3")
 
+    // Dynmap
+    modCompileOnly("maven.modrinth:dynmap:${dynmap_version}")
+
     // Add Kotlin for Forge (3.12.0)
     forgeRuntimeLibrary("maven.modrinth:kotlin-for-forge:${kotlin_version}")
 

--- a/forge/gradle.properties
+++ b/forge/gradle.properties
@@ -13,3 +13,5 @@ registrate_version = MC1.20-1.3.3
 #Extra
 # https://modrinth.com/mod/embeddium/versions
 embeddium_version = 0.2.9+mc1.20.1
+# https://modrinth.com/plugin/dynmap/versions
+dynmap_version=RtI5TFAi

--- a/forge/gradle.properties
+++ b/forge/gradle.properties
@@ -14,3 +14,5 @@ cc_tweaked_version = 1.109.0
 #Extra
 # https://modrinth.com/mod/embeddium/versions
 embeddium_version = 0.2.9+mc1.20.1
+# https://modrinth.com/plugin/dynmap/versions
+dynmap_version=RtI5TFAi

--- a/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ValkyrienSkiesModForge.kt
+++ b/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ValkyrienSkiesModForge.kt
@@ -177,7 +177,7 @@ class ValkyrienSkiesModForge {
 
         if (ModList.get().isLoaded("dynmap")) {
             ForgeDynmapHandler().register()
-            modBus.addListener(ForgeDynmapHandler::tick)
+            forgeBus.addListener(ForgeDynmapHandler::tick)
         }
     }
 

--- a/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ValkyrienSkiesModForge.kt
+++ b/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ValkyrienSkiesModForge.kt
@@ -52,6 +52,7 @@ import org.valkyrienskies.mod.common.item.PhysicsEntityCreatorItem
 import org.valkyrienskies.mod.common.item.ShipAssemblerItem
 import org.valkyrienskies.mod.common.item.ShipCreatorItem
 import org.valkyrienskies.mod.compat.clothconfig.VSClothConfig
+import org.valkyrienskies.mod.forge.compat.ForgeDynmapHandler
 import org.valkyrienskies.mod.forge.compat.epicfight.FracturedBlockStateInfoProvider
 
 @Mod(MOD_ID)
@@ -172,6 +173,11 @@ class ValkyrienSkiesModForge {
 
         if (ModList.get().isLoaded("epicfight")) {
             FracturedBlockStateInfoProvider.register()
+        }
+
+        if (ModList.get().isLoaded("dynmap")) {
+            ForgeDynmapHandler().register()
+            modBus.addListener(ForgeDynmapHandler::tick)
         }
     }
 

--- a/forge/src/main/kotlin/org/valkyrienskies/mod/forge/compat/ForgeDynmapHandler.kt
+++ b/forge/src/main/kotlin/org/valkyrienskies/mod/forge/compat/ForgeDynmapHandler.kt
@@ -22,7 +22,7 @@ class ForgeDynmapHandler : DynmapHandler() {
         this.api?.markerAPI?.getMarkerIcon("ship") ?: run {
             plugin?.ForgeServer()?.let {
                 this.api?.markerAPI?.createMarkerIcon("loaded_ship", "ship",
-                    it.openResource(ValkyrienSkiesMod.MOD_ID, "assets/valkyrienskies/icon.png"))
+                    it.openResource(ValkyrienSkiesMod.MOD_ID, "icon.png"))
             }
         }
 

--- a/forge/src/main/kotlin/org/valkyrienskies/mod/forge/compat/ForgeDynmapHandler.kt
+++ b/forge/src/main/kotlin/org/valkyrienskies/mod/forge/compat/ForgeDynmapHandler.kt
@@ -21,8 +21,8 @@ class ForgeDynmapHandler : DynmapHandler() {
     override fun getOrCreateIcon(): MarkerIcon? =
         this.api?.markerAPI?.getMarkerIcon("ship") ?: run {
             plugin?.ForgeServer()?.let {
-                this.api?.markerAPI?.createMarkerIcon("loaded_ship", "ship",
-                    it.openResource(ValkyrienSkiesMod.MOD_ID, "icon.png"))
+                this.api?.markerAPI?.createMarkerIcon("ship", "ship",
+                    it.openResource(ValkyrienSkiesMod.MOD_ID, "assets/valkyrienskies/icon.png"))
             }
         }
 

--- a/forge/src/main/kotlin/org/valkyrienskies/mod/forge/compat/ForgeDynmapHandler.kt
+++ b/forge/src/main/kotlin/org/valkyrienskies/mod/forge/compat/ForgeDynmapHandler.kt
@@ -1,0 +1,38 @@
+package org.valkyrienskies.mod.forge.compat
+
+import net.minecraft.server.level.ServerLevel
+import net.minecraftforge.event.TickEvent.LevelTickEvent
+import org.dynmap.forge_1_20.DynmapMod.plugin
+import org.dynmap.forge_1_20.ForgeWorld
+import org.dynmap.markers.MarkerIcon
+import org.valkyrienskies.mod.common.ValkyrienSkiesMod
+import org.valkyrienskies.mod.compat.dynmap.DynmapHandler
+
+class ForgeDynmapHandler : DynmapHandler() {
+    override fun register() {
+        super.register()
+        INSTANCE = this
+    }
+
+    override fun getWorldName(level: ServerLevel): String {
+        return ForgeWorld.getWorldName(level)
+    }
+
+    override fun getOrCreateIcon(): MarkerIcon? =
+        this.api?.markerAPI?.getMarkerIcon("ship") ?: run {
+            plugin?.ForgeServer()?.let {
+                this.api?.markerAPI?.createMarkerIcon("loaded_ship", "ship",
+                    it.openResource(ValkyrienSkiesMod.MOD_ID, "assets/valkyrienskies/icon.png"))
+            }
+        }
+
+    companion object {
+        var INSTANCE: ForgeDynmapHandler? = null
+
+        fun tick(event: LevelTickEvent) {
+            (event.level as? ServerLevel)?.let {
+                INSTANCE?.updateMarkers(it)
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,6 +29,9 @@ flywheel_version_fabric=0.6.9-6
 # https://modrinth.com/mod/create-big-cannons/versions
 createbigcannons_version= 5.8.2
 
+# https://modrinth.com/plugin/dynmap/versions
+dynmap_version=IIQSYMHC
+
 vs_core_version=1.1.0+cf6990a85d
 # Prevent kotlin from autoincluding stdlib as a dependency, which breaks
 # gradle's composite builds (includeBuild) for some reason. We'll add it manually

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,9 @@ flywheel_version_fabric=0.6.9-6
 # https://modrinth.com/mod/create-big-cannons/versions
 createbigcannons_version= 0.5.2.a
 
+# https://modrinth.com/plugin/dynmap/versions
+dynmap_version=IIQSYMHC
+
 vs_core_version=1.1.0+b19b27c4a4
 # Prevent kotlin from autoincluding stdlib as a dependency, which breaks
 # gradle's composite builds (includeBuild) for some reason. We'll add it manually


### PR DESCRIPTION
This PR brings Dynmap support into VS!

![Image of the Dynmap Support in action](https://media.discordapp.net/attachments/662249805430390795/1431943584369606676/image.png?ex=68ff40e2&is=68fdef62&hm=68291dc8681225e82bdf9dece99e5138b888a6a0d2bd3a027c0ce11d71b30ad2&=&format=webp&quality=lossless)

As shown above, it adds both an icon marker and an encompassing polyline marker. These are, of course, configurable via the new Dynmap configuration section.

![Config](https://media.discordapp.net/attachments/1107778211632390267/1431944171324706846/image.png?ex=68ff416e&is=68fdefee&hm=009fa3b8373275c72f35f446e944d01f261f42bf01f7df049d57430914bc8f65&=&format=webp&quality=lossless)

It also adds new compile only dependencies pointing to the Modrinth versions of Dynmap and maintains loader-specific functionality by having a base `DynmapHandler` in common for most of the logic and `FabricDynmapHandler`/`ForgeDynmapHandler` for platform-specific calls. This is necessary due to the differing classpaths and classes available to Forge and Fabric within Dynmap.

Ship markers are updated at the end of gametick from the `allShips` list.