### PR TITLE
skip biome particles in ship chunks

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/client/world/MixinClientLevel.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/client/world/MixinClientLevel.java
@@ -159,27 +159,6 @@ public abstract class MixinClientLevel implements IShipObjectWorldClientProvider
                     (double) posX + 0.5, (double) posY + 0.5,
                     (double) posZ + 0.5, 0.0, 0.0, 0.0);
             }
-
-            if (!blockState.isCollisionShapeFullBlock(thisAsClientLevel, mutableBlockPos)) {
-                thisAsClientLevel.getBiome(mutableBlockPos)
-                    .value()
-                    .getAmbientParticle()
-                    .ifPresent(
-                        ambientParticleSettings -> {
-                            if (ambientParticleSettings.canSpawn(vsRandom)) {
-                                thisAsClientLevel.addParticle(
-                                    ambientParticleSettings.getOptions(),
-                                    (double) mutableBlockPos.getX() + vsRandom.nextDouble(),
-                                    (double) mutableBlockPos.getY() + vsRandom.nextDouble(),
-                                    (double) mutableBlockPos.getZ() + vsRandom.nextDouble(),
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                );
-                            }
-                        }
-                    );
-            }
         }
     }
 


### PR DESCRIPTION
Calling ``thisAsClientLevel.getBiome(mutableBlockPos)`` on every frame for every air block in a ship adds needless overhead. Also, biome particles for ship chunks look strange anyways.