### PR TITLE
Flywheel compat bug fix

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/compat/flywheel/BlockEntityVisualizerDecorator.java
+++ b/common/src/main/java/org/valkyrienskies/mod/compat/flywheel/BlockEntityVisualizerDecorator.java
@@ -27,7 +27,7 @@ public class BlockEntityVisualizerDecorator<T extends BlockEntity> implements Bl
         if(VSGameUtilsKt.getShipManagingPos(blockEntity.getLevel(), blockEntity.getBlockPos()) instanceof ClientShip ship){
             final VisualEmbedding embedding = ShipEmbeddingManager.INSTANCE.getOrCreateEmbedding(ship, ctx);
             BlockEntityVisual<? super T> visual = inner.createVisual(embedding, blockEntity, partialTick);
-            ShipEmbeddingManager.INSTANCE.registerBlockEntity(blockEntity, ship);
+            ShipEmbeddingManager.INSTANCE.register(blockEntity, ship);
             return visual;
         }
         else return inner.createVisual(ctx, blockEntity, partialTick);

--- a/common/src/main/java/org/valkyrienskies/mod/compat/flywheel/EntityVisualizerDecorator.java
+++ b/common/src/main/java/org/valkyrienskies/mod/compat/flywheel/EntityVisualizerDecorator.java
@@ -28,9 +28,6 @@ public class EntityVisualizerDecorator<T extends Entity> implements EntityVisual
             VisualEmbedding embedding = ShipEmbeddingManager.INSTANCE.getOrCreateEmbedding(ship, ctx);
             EntityVisual<? super T> visual = inner.createVisual(embedding, entity, partialTick);
             return visual;
-        } else if (VSGameUtilsKt.isBlockInShipyard(entity.level(), entity.blockPosition())) {
-            ShipEmbeddingManager.INSTANCE.enqueueFutureVisualization(entity);
-            return null;
         } else return inner.createVisual(ctx, entity, partialTick);
     }
 

--- a/common/src/main/java/org/valkyrienskies/mod/compat/flywheel/EntityVisualizerDecorator.java
+++ b/common/src/main/java/org/valkyrienskies/mod/compat/flywheel/EntityVisualizerDecorator.java
@@ -27,10 +27,11 @@ public class EntityVisualizerDecorator<T extends Entity> implements EntityVisual
         if(VSGameUtilsKt.getShipManaging(entity) instanceof ClientShip ship){
             VisualEmbedding embedding = ShipEmbeddingManager.INSTANCE.getOrCreateEmbedding(ship, ctx);
             EntityVisual<? super T> visual = inner.createVisual(embedding, entity, partialTick);
-            ShipEmbeddingManager.INSTANCE.registerEntity(entity, ship);
             return visual;
-        }
-        else return inner.createVisual(ctx, entity, partialTick);
+        } else if (VSGameUtilsKt.isBlockInShipyard(entity.level(), entity.blockPosition())) {
+            ShipEmbeddingManager.INSTANCE.enqueueFutureVisualization(entity);
+            return null;
+        } else return inner.createVisual(ctx, entity, partialTick);
     }
 
     @Override

--- a/common/src/main/java/org/valkyrienskies/mod/compat/flywheel/ShipEmbeddingManager.java
+++ b/common/src/main/java/org/valkyrienskies/mod/compat/flywheel/ShipEmbeddingManager.java
@@ -1,10 +1,10 @@
 package org.valkyrienskies.mod.compat.flywheel;
 
 import dev.engine_room.flywheel.api.visualization.VisualizationManager;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.entity.EntitySection;
 import org.valkyrienskies.core.impl.hooks.VSEvents.ShipUnloadEventClient;
 import dev.engine_room.flywheel.api.visualization.VisualEmbedding;
 import dev.engine_room.flywheel.api.visualization.VisualizationContext;
@@ -17,7 +17,6 @@ import org.joml.Quaternionf;
 import org.joml.Vector3d;
 import org.joml.Vector3f;
 import org.valkyrienskies.core.api.ships.ClientShip;
-import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.hooks.VSGameEvents;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 
@@ -41,12 +40,22 @@ public class ShipEmbeddingManager {
 
     protected static ConcurrentHashMap<BlockEntity, ClientShip> vs$shipBEs = new ConcurrentHashMap<>();
 
-    protected static Queue<Entity> vs$entitiesQueue = new ConcurrentLinkedQueue<>();
-
     private ShipEmbeddingManager(){
         ShipUnloadEventClient.Companion.on(event -> this.unloadShip(event.getShip()));
         VSGameEvents.INSTANCE.getShipsStartRendering().on(event -> this.updateAllShips());
         VSGameEvents.INSTANCE.getShipsStartRenderingSodium().on(event -> this.updateAllShips());
+        VSGameEvents.INSTANCE.getEntitySectionSetShip().on(event -> this.updateEntitySection(event.getSection()));
+    }
+
+    private void updateEntitySection(EntitySection<?> section){
+        VisualizationManager manager = VisualizationManager.get(Minecraft.getInstance().level);
+        if (manager == null) return;
+        section.getEntities().forEach(
+            entity -> {
+                manager.entities().queueAdd((Entity) entity);
+                manager.entities().queueRemove((Entity) entity);
+            }
+        );
     }
 
     /**
@@ -94,16 +103,6 @@ public class ShipEmbeddingManager {
             final Vec3i origin = vs$EmbeddingOrigin.get(ship);
             setEmbeddingTransform(embedding, ship, anchor, origin);
         }
-        vs$entitiesQueue.removeIf(
-            entity -> {
-                final VisualizationManager manager = VisualizationManager.get(entity.level());
-                if(VSGameUtilsKt.getShipManaging(entity) != null && manager != null) {
-                    manager.entities().queueAdd(entity);
-                    return true;
-                }
-                return false;
-            }
-        );
     }
     /**
      * Removes ship from the storage.
@@ -168,9 +167,5 @@ public class ShipEmbeddingManager {
 
     public void register(BlockEntity blockEntity, ClientShip ship) {
         vs$shipBEs.put(blockEntity, ship);
-    }
-
-    public void enqueueFutureVisualization(Entity entity) {
-        if(VSGameUtilsKt.isBlockInShipyard(entity.level(), entity.blockPosition())) vs$entitiesQueue.add(entity);
     }
 }

--- a/common/src/main/java/org/valkyrienskies/mod/compat/flywheel/ShipEmbeddingManager.java
+++ b/common/src/main/java/org/valkyrienskies/mod/compat/flywheel/ShipEmbeddingManager.java
@@ -52,8 +52,8 @@ public class ShipEmbeddingManager {
         if (manager == null) return;
         section.getEntities().forEach(
             entity -> {
-                manager.entities().queueAdd((Entity) entity);
                 manager.entities().queueRemove((Entity) entity);
+                manager.entities().queueAdd((Entity) entity);
             }
         );
     }

--- a/common/src/main/java/org/valkyrienskies/mod/compat/flywheel/ShipEmbeddingManager.java
+++ b/common/src/main/java/org/valkyrienskies/mod/compat/flywheel/ShipEmbeddingManager.java
@@ -1,7 +1,8 @@
 package org.valkyrienskies.mod.compat.flywheel;
 
 import dev.engine_room.flywheel.api.visualization.VisualizationManager;
-import net.minecraft.client.Minecraft;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.valkyrienskies.core.impl.hooks.VSEvents.ShipUnloadEventClient;
@@ -16,6 +17,7 @@ import org.joml.Quaternionf;
 import org.joml.Vector3d;
 import org.joml.Vector3f;
 import org.valkyrienskies.core.api.ships.ClientShip;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.hooks.VSGameEvents;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 
@@ -37,9 +39,9 @@ public class ShipEmbeddingManager {
 
     protected static ConcurrentHashMap<ClientShip, VisualEmbedding> vs$shipEmbedding = new ConcurrentHashMap<>();
 
-    protected static ConcurrentHashMap<Entity, ClientShip> vs$shipEntitiesWithVisual = new ConcurrentHashMap<>();
+    protected static ConcurrentHashMap<BlockEntity, ClientShip> vs$shipBEs = new ConcurrentHashMap<>();
 
-    protected static ConcurrentHashMap<BlockEntity, ClientShip> vs$shipBlockEntitiesWithVisual = new ConcurrentHashMap<>();
+    protected static Queue<Entity> vs$entitiesQueue = new ConcurrentLinkedQueue<>();
 
     private ShipEmbeddingManager(){
         ShipUnloadEventClient.Companion.on(event -> this.unloadShip(event.getShip()));
@@ -56,14 +58,17 @@ public class ShipEmbeddingManager {
         VisualEmbedding prevEmbedding = vs$shipEmbedding.get(ship);
         if(prevEmbedding != null && ctx.renderOrigin().equals(vs$EmbeddingOrigin.get(ship))) return prevEmbedding;
 
-        // remove previous mapping of entities/blockEntities and embedding
-        vs$shipEntitiesWithVisual.entrySet().removeIf(
-            entry -> entry.getValue() == ship
+        // remove previous mapping of visuals and embedding
+        vs$shipBEs.entrySet().removeIf(
+            entry -> {
+                final VisualizationManager manager = VisualizationManager.get(entry.getKey().getLevel());
+                if (entry.getValue() == ship && manager != null){
+                    manager.blockEntities().queueRemove(entry.getKey());
+                    manager.blockEntities().queueAdd(entry.getKey());
+                    return true;
+                } else return false;
+            }
         );
-        vs$shipBlockEntitiesWithVisual.entrySet().removeIf(
-            entry -> entry.getValue() == ship
-        );
-
         if(prevEmbedding != null) prevEmbedding.delete();
 
         BlockPos anchor = BlockPos.containing(VectorConversionsMCKt.toMinecraft(ship.getRenderTransform().getPositionInShip()));
@@ -82,13 +87,23 @@ public class ShipEmbeddingManager {
      * Ideally this should be called every frame when ships have their transform changed, so it's bound to ShipStartRendering event.
      * @author Bunting_chj
      */
-    public void updateAllShips() {
+    public synchronized void updateAllShips() {
         for(final ClientShip ship : vs$shipEmbedding.keySet()){
             final Vec3i anchor = vs$shipAnchor.get(ship);
             final VisualEmbedding embedding = vs$shipEmbedding.get(ship);
             final Vec3i origin = vs$EmbeddingOrigin.get(ship);
             setEmbeddingTransform(embedding, ship, anchor, origin);
         }
+        vs$entitiesQueue.removeIf(
+            entity -> {
+                final VisualizationManager manager = VisualizationManager.get(entity.level());
+                if(VSGameUtilsKt.getShipManaging(entity) != null && manager != null) {
+                    manager.entities().queueAdd(entity);
+                    return true;
+                }
+                return false;
+            }
+        );
     }
     /**
      * Removes ship from the storage.
@@ -101,27 +116,14 @@ public class ShipEmbeddingManager {
         if(embedding != null){
             embedding.delete();
         }
-
-        final VisualizationManager manager = VisualizationManager.get(Minecraft.getInstance().level);
-        if (manager != null) {
-            vs$shipEntitiesWithVisual.entrySet().removeIf ( entry-> {
-                    if (entry.getValue() == ship) {
-                        manager.entities().queueRemove(entry.getKey());
-                        return true;
-                    }
-                    return false;
-                }
-            );
-            vs$shipBlockEntitiesWithVisual.entrySet().removeIf ( entry-> {
-                    if (entry.getValue() == ship) {
-                        manager.blockEntities().queueRemove(entry.getKey());
-                        return true;
-                    }
-                    return false;
-                }
-            );
-        }
-
+        vs$shipBEs.entrySet().removeIf(
+            entry -> {
+                if (entry.getValue() == ship) {
+                    VisualizationManager.get(entry.getKey().getLevel()).blockEntities().queueRemove(entry.getKey());
+                    return true;
+                } else return false;
+            }
+        );
         vs$shipAnchor.remove(ship);
         vs$EmbeddingOrigin.remove(ship);
     }
@@ -134,21 +136,7 @@ public class ShipEmbeddingManager {
      */
 
     public synchronized void unloadAllShip() {
-        final VisualizationManager manager = VisualizationManager.get(Minecraft.getInstance().level);
-        if (manager != null) {
-            vs$shipEntitiesWithVisual.forEach(
-                (entity, ship) -> manager.entities().queueRemove(entity)
-            );
-            vs$shipBlockEntitiesWithVisual.forEach(
-                (blockEntity, clientShip) -> manager.blockEntities().queueRemove(blockEntity)
-            );
-        }
-        vs$shipEmbedding.forEach(
-            (ship, embedding) -> {
-                embedding.delete();
-            }
-        );
-        vs$shipEntitiesWithVisual.clear();
+        vs$shipBEs.clear();
         vs$shipEmbedding.clear();
         vs$shipAnchor.clear();
         vs$EmbeddingOrigin.clear();
@@ -178,11 +166,11 @@ public class ShipEmbeddingManager {
         embedding.transforms(poseMatrix, normalMatrix);
     }
 
-    public void registerEntity(Entity entity, ClientShip ship) {
-        vs$shipEntitiesWithVisual.put(entity, ship);
+    public void register(BlockEntity blockEntity, ClientShip ship) {
+        vs$shipBEs.put(blockEntity, ship);
     }
 
-    public void registerBlockEntity(BlockEntity blockEntity, ClientShip ship) {
-        vs$shipBlockEntitiesWithVisual.put(blockEntity, ship);
+    public void enqueueFutureVisualization(Entity entity) {
+        if(VSGameUtilsKt.isBlockInShipyard(entity.level(), entity.blockPosition())) vs$entitiesQueue.add(entity);
     }
 }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntitySection.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntitySection.java
@@ -7,6 +7,8 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.hooks.VSGameEvents;
+import org.valkyrienskies.mod.common.hooks.VSGameEvents.EntitySectionSetShip;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 import org.valkyrienskies.mod.mixinducks.world.OfShip;
 
@@ -24,6 +26,7 @@ public class MixinEntitySection implements OfShip {
     @Override
     public void setShip(final Ship ship) {
         this.ofShip = ship;
+        if (ship != null) VSGameEvents.INSTANCE.getEntitySectionSetShip().emit(new EntitySectionSetShip(EntitySection.class.cast(this), ship));
     }
 
     @ModifyVariable(

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntitySectionStorage.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntitySectionStorage.java
@@ -1,5 +1,6 @@
 package org.valkyrienskies.mod.mixin.feature.shipyard_entities;
 
+import java.util.concurrent.ConcurrentHashMap;
 import net.minecraft.core.SectionPos;
 import net.minecraft.util.AbortableIterationConsumer;
 import net.minecraft.world.entity.Entity;
@@ -14,6 +15,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.valkyrienskies.core.impl.hooks.VSEvents.ShipLoadEventClient;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 import org.valkyrienskies.mod.mixinducks.world.OfLevel;
@@ -36,13 +38,36 @@ public abstract class MixinEntitySectionStorage implements OfLevel {
     @Override
     public void setLevel(final Level level) {
         this.level = level;
+        if(level.isClientSide) ShipLoadEventClient.Companion.on(this::handleShipLoad);
     }
 
     @Unique
     private boolean loopingShips = false;
 
+    @Unique
+    private ConcurrentHashMap<Long, EntitySection<Entity>> delayedSections = new ConcurrentHashMap<>();
+
+    private void handleShipLoad(ShipLoadEventClient event){
+        delayedSections.entrySet().removeIf(
+            entry -> {
+                final Long l = entry.getKey();
+                final EntitySection<Entity> section = entry.getValue();
+                if(VSGameUtilsKt.getShipManagingPos(level, SectionPos.x(l), SectionPos.z(l)) == event.getShip()) {
+                    ((OfShip) section).setShip(event.getShip());
+                    return true;
+                }
+                return false;
+            }
+        );
+    }
+
     @Inject(method = "createSection", at = @At("RETURN"))
     void onSectionCreate(final long l, final CallbackInfoReturnable<EntitySection<Entity>> cir) {
+        if (VSGameUtilsKt.getShipManagingPos(level, SectionPos.x(l), SectionPos.z(l)) == null) {
+            if (VSGameUtilsKt.isChunkInShipyard(level, SectionPos.x(l), SectionPos.z(l))) {
+                delayedSections.put(l, cir.getReturnValue());
+            }
+        }
         ((OfShip) cir.getReturnValue()).setShip(
             VSGameUtilsKt.getShipManagingPos(level, SectionPos.x(l), SectionPos.z(l))
         );

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/transform_particles/MixinParticle.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/transform_particles/MixinParticle.java
@@ -50,9 +50,15 @@ public abstract class MixinParticle {
         if (ship == null) {
             return;
         }
-
         // in-world position
-        final Vector3d p = ship.getRenderTransform().getShipToWorld().transformPosition(new Vector3d(x, y, z));
+
+        // Particles are delayed by one tick before movement so adding the ship's delta by 1 tick here.
+        Vector3d tempVel = ship.getVelocity().get(new Vector3d());
+        tempVel.add(ship.getRenderTransform().getShipToWorld().transformDirection(new Vector3d(x, y, z).sub(ship.getTransform().getPositionInShip())).cross(ship.getOmega()));
+        tempVel.mul(0.05);
+        final Vector3d p = ship.getTransform().getShipToWorld().transformPosition(new Vector3d(x, y, z));
+        ship.getPrevTickTransform().getWorldToShip().transformPosition(p);
+        ship.getTransform().getShipToWorld().transformPosition(p);
         this.setPos(p.x, p.y, p.z);
         this.xo = p.x;
         this.yo = p.y;
@@ -75,9 +81,11 @@ public abstract class MixinParticle {
             return;
         }
 
-        final Matrix4dc transform = ship.getRenderTransform().getShipToWorld();
+        final Matrix4dc transform = ship.getTransform().getShipToWorld();
         // in-world position
         final Vector3d p = transform.transformPosition(new Vector3d(x, y, z));
+        ship.getPrevTickTransform().getWorldToShip().transformPosition(p);
+        transform.transformPosition(p);
         // in-world velocity
         final Vector3d v = transform
             // Rotate velocity wrt ship transform

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/MixinAirCurrent.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/MixinAirCurrent.java
@@ -107,7 +107,7 @@ public abstract class MixinAirCurrent {
                         Vec3.atCenterOf(end),
                         ClipContext.Block.OUTLINE,
                         ClipContext.Fluid.NONE,
-                        null));
+                        null), true, null, true);
 
                 // Distance from start to end but, its not squared so, slow -_-
                 cir.setReturnValue((float) result.getLocation().distanceTo(centerStart));

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/MixinAirFlowParticle.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/MixinAirFlowParticle.java
@@ -34,6 +34,24 @@ public abstract class MixinAirFlowParticle extends SimpleAnimatedParticle {
         super(level, x, y, z, sprites, gravity);
     }
 
+    // Particles are delayed by one tick before movement so adding the ship's delta by 1 tick here.
+    @WrapOperation(
+        method = "<init>",
+        at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/kinetics/fan/AirFlowParticle;setPos(DDD)V")
+    )
+    private void setPos(AirFlowParticle particle, double x, double y, double z, Operation<Void> original) {
+        Ship ship = getShip();
+        if(ship != null) {
+            Vector3d p = new Vector3d(x, y, z);
+            ship.getPrevTickTransform().getWorldToShip().transformPosition(p);
+            ship.getTransform().getShipToWorld().transformPosition(p);
+            original.call(particle, p.x, p.y, p.z);
+            return;
+        }
+        original.call(particle, x, y, z);
+    }
+
+
     @Unique
     private Ship getShip() {
         if (source instanceof IExtendedAirCurrentSource se)
@@ -56,8 +74,10 @@ public abstract class MixinAirFlowParticle extends SimpleAnimatedParticle {
     private boolean redirectBounds(AABB instance, double x, double y, double z) {
         AirCurrent current = source.getAirCurrent();
         Level level = source.getAirCurrentWorld();
-        if (current != null && level != null) {
-            return VSGameUtilsKt.transformAabbToWorld(level, instance).contains(x, y, z);
+        Ship ship = getShip();
+        if (current != null && level != null && ship != null) {
+            Vector3d tempPos = ship.getTransform().getWorldToShip().transformPosition(x, y, z, new Vector3d());
+            return instance.contains(tempPos.x, tempPos.y, tempPos.z);
         }
 
         return instance.contains(x, y, z);
@@ -89,5 +109,26 @@ public abstract class MixinAirFlowParticle extends SimpleAnimatedParticle {
             dir = VectorConversionsMCKt.toMinecraft(tempVec);
         }
         return original.call(dir, d);
+    }
+
+    /**
+     * Not many particles need to be 'dragged' by the ship, but airflow particles are indicator of something that is fixed to the ship.
+     * Therefore, this logic is similar to that of entity dragging feature.
+     */
+    @WrapOperation(
+        method = "tick", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/kinetics/fan/AirFlowParticle;move(DDD)V")
+    )
+    private void moveWithShip(AirFlowParticle particle, double x, double y, double z, Operation<Void> original){
+        original.call(particle, x, y, z);
+        Ship ship = getShip();
+        if (ship != null) {
+            Vector3d p = new Vector3d(this.x, this.y, this.z);
+            ship.getPrevTickTransform().getWorldToShip().transformPosition(p);
+            ship.getTransform().getShipToWorld().transformPosition(p);
+            this.xd = p.x - this.xo;
+            this.yd = p.y - this.yo;
+            this.zd = p.z - this.zo;
+            this.setPos(p.x, p.y, p.z);
+        }
     }
 }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/client/MixinGhostBlockRenderer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/client/MixinGhostBlockRenderer.java
@@ -27,7 +27,7 @@ public class MixinGhostBlockRenderer {
         final ClientShip ship = VSClientGameUtils.getClientShip(pos.getX(), pos.getY(), pos.getZ());
         if(ship != null) {
             ms.pushPose();
-            final Vec3 cameraInShip = VectorConversionsMCKt.toMinecraft(ship.getWorldToShip().transformPosition(VectorConversionsMCKt.toJOML(camera)));
+            final Vec3 cameraInShip = VectorConversionsMCKt.toMinecraft(ship.getRenderTransform().getWorldToShip().transformPosition(VectorConversionsMCKt.toJOML(camera)));
             ms.mulPose(VectorConversionsMCKt.toFloat(ship.getRenderTransform().getShipToWorldRotation()));
             ms.last().pose().scale(ship.getRenderTransform().getShipToWorldScaling().get(new Vector3f()));
             original.call(ms, buffer, cameraInShip, params);

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/hooks/VSGameEvents.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/hooks/VSGameEvents.kt
@@ -9,9 +9,13 @@ import me.jellysquid.mods.sodium.client.render.chunk.terrain.TerrainRenderPass
 import net.minecraft.client.renderer.LevelRenderer
 import net.minecraft.client.renderer.LevelRenderer.RenderChunkInfo
 import net.minecraft.client.renderer.RenderType
+import net.minecraft.world.level.entity.EntityAccess
+import net.minecraft.world.level.entity.EntitySection
 import org.joml.Matrix4f
 import org.valkyrienskies.core.api.ships.ClientShip
+import org.valkyrienskies.core.api.ships.Ship
 import org.valkyrienskies.core.impl.util.events.EventEmitterImpl
+import javax.swing.text.html.parser.Entity
 
 object VSGameEvents {
 
@@ -20,11 +24,16 @@ object VSGameEvents {
 
     val renderShip = EventEmitterImpl<ShipRenderEvent>()
     val postRenderShip = EventEmitterImpl<ShipRenderEvent>()
+    val entitySectionSetShip = EventEmitterImpl<EntitySectionSetShip>()
     val shipsStartRendering = EventEmitterImpl<ShipStartRenderEvent>()
     val renderShipSodium = EventEmitterImpl<ShipRenderEventSodium>()
     val postRenderShipSodium = EventEmitterImpl<ShipRenderEventSodium>()
     val shipsStartRenderingSodium = EventEmitterImpl<ShipStartRenderEventSodium>()
 
+    data class EntitySectionSetShip(
+        val section: EntitySection<EntityAccess>,
+        val ship: Ship
+    )
 
     data class ShipStartRenderEvent(
         val renderer: LevelRenderer,

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/world/RaycastUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/world/RaycastUtils.kt
@@ -32,7 +32,7 @@ private val logger = LogManager.getLogger("RaycastUtilsKt")
 
 @JvmOverloads
 fun Level.clipIncludeShips(
-    ctx: ClipContext, shouldTransformHitPos: Boolean = true, skipShip: ShipId? = null
+    ctx: ClipContext, shouldTransformHitPos: Boolean = true, skipShip: ShipId? = null, skipWorld: Boolean = false
 ): BlockHitResult {
     val vanillaHit = vanillaClip(ctx)
 
@@ -47,6 +47,12 @@ fun Level.clipIncludeShips(
     var closestHit = vanillaHit
     var closestHitPos = vanillaHit.location
     var closestHitDist = closestHitPos.distanceToSqr(ctx.from)
+    if(skipWorld) {
+        val line = ctx.to.subtract(ctx.from)
+        closestHit = BlockHitResult.miss(ctx.to, Direction.getNearest(line.x, line.y, line.z), BlockPos.containing(ctx.to))
+        closestHitPos = ctx.to
+        closestHitDist = line.lengthSqr()
+    }
 
     val clipAABB: AABBdc = AABBd(ctx.from.toJOML(), ctx.to.toJOML()).correctBounds()
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/world/RaycastUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/world/RaycastUtils.kt
@@ -34,7 +34,10 @@ private val logger = LogManager.getLogger("RaycastUtilsKt")
 fun Level.clipIncludeShips(
     ctx: ClipContext, shouldTransformHitPos: Boolean = true, skipShip: ShipId? = null, skipWorld: Boolean = false
 ): BlockHitResult {
-    val vanillaHit = vanillaClip(ctx)
+    val vanillaHit = if(skipWorld) {
+        val line = ctx.to.subtract(ctx.from)
+        BlockHitResult.miss(ctx.to, Direction.getNearest(line.x, line.y, line.z), BlockPos.containing(ctx.to))
+    } else vanillaClip(ctx)
 
     if (shipObjectWorld == null) {
         logger.error(
@@ -47,12 +50,6 @@ fun Level.clipIncludeShips(
     var closestHit = vanillaHit
     var closestHitPos = vanillaHit.location
     var closestHitDist = closestHitPos.distanceToSqr(ctx.from)
-    if(skipWorld) {
-        val line = ctx.to.subtract(ctx.from)
-        closestHit = BlockHitResult.miss(ctx.to, Direction.getNearest(line.x, line.y, line.z), BlockPos.containing(ctx.to))
-        closestHitPos = ctx.to
-        closestHitDist = line.lengthSqr()
-    }
 
     val clipAABB: AABBdc = AABBd(ctx.from.toJOML(), ctx.to.toJOML()).correctBounds()
 


### PR DESCRIPTION
From the Create 6 fix PR, the entity visuals(contraptions) on ship could be invisible upon reloading, and visuals could be duplicated on unloading and reloading the ship from distance.

Also, if you load the world for the first time after the game boots, it could cause contraptions to load earlier than the ships, therfore can't have a embedding bound to the ship. To prevent this Ship Embedding Manager will hold a queue of entities which are in shipyard but the ship isn't loaded yet, and enqueue them to the Visualization Manager after the ship is loaded.

Latter needs more investigation because the load order also seems to affect shipyard entities like minecarts, making them not interactable.