### PR TITLE
Add nix flake and direnv config, gitignore direnv cache

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ forge*changelog.txt
 # Files generated for Fabric
 /fabric/src/generated/
 /.architectury-transformer/debug.log
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761672384,
+        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Valkyrien Skies 2 dev env";
+
+  inputs = {
+    nixpkgs = {
+      url = "github:nixos/nixpkgs/nixos-unstable";
+    };
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+  };
+  outputs =
+    { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        gradle_path = "./gradlew";
+
+        runFabric = pkgs.writeShellScriptBin "runFabric" (''${gradle_path} :fabric:runClient'');
+        runFabricServer = pkgs.writeShellScriptBin "runFabricServer" (''${gradle_path} :fabric:runServer'');
+
+        runForge = pkgs.writeShellScriptBin "runForge" (''${gradle_path} :forge:runClient'');
+        runForgeServer = pkgs.writeShellScriptBin "runForgeServer" (''${gradle_path} :forge:runServer'');
+
+      in
+      {
+        devShell = pkgs.mkShell {
+          shellHook = ''
+            export LD_LIBRARY_PATH="''${LD_LIBRARY_PATH}''${LD_LIBRARY_PATH:+:}${pkgs.libglvnd}/lib"
+          '';
+
+          buildInputs = with pkgs; [
+            jdk17
+            gradle_7
+            zenity
+
+            runFabric
+            runFabricServer
+
+            runForge
+            runForgeServer
+
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Add a nix flake for nix & nixos developers

What this is:

A premade dev shell with all required system dependencies and env vars for anyone using the nix package manager

(this is also required for devs on nixos (me) to be able to build the repository because gradle can be weird about its different system paths)

- Flake.nix - the configuration file itsself, where dependencies and config are declared

- Flake.lock - the lock file containing git revs of all dependencies (it uses this to grab the exact same version of dependencies I tested with, can be updated with ``nix flake update``) - this IS meant to go in source control even though it is a generated file, similar to poetry.lock, cargo.lock, etc in other languages

- .envrc - tells a tool called direnv to automatically load the nix flake when CDing into the directory (the first time it will ask the user to type a command to confirm they trust the configuration before doing so)


(this doesn't interfere with other users in any way, the files only do anything for people using nix)