### PR TITLE
Fixes for beta 11 - arrow orientation, chain riding crash

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinProjectile.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinProjectile.java
@@ -4,11 +4,10 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.TraceableEntity;
 import net.minecraft.world.entity.projectile.Projectile;
-import net.minecraft.world.entity.projectile.ProjectileUtil;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
-import net.minecraft.world.phys.HitResult.Type;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import org.joml.Vector3d;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -25,7 +24,7 @@ import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 public abstract class MixinProjectile extends Entity implements TraceableEntity {
 
     @Shadow
-    protected abstract boolean canHitEntity(Entity entity);
+    protected abstract void updateRotation();
 
     public MixinProjectile(EntityType<?> entityType, Level level) {
         super(entityType, level);
@@ -36,12 +35,12 @@ public abstract class MixinProjectile extends Entity implements TraceableEntity 
      * This makes arrows/tridents/fishing hooks stuck on a ship render at correct position.
      */
     @Inject(
-        method = "onHit",
+        method = "onHitBlock",
         at = @At("HEAD")
     )
-    private void sendToShipyard(HitResult hitResult, CallbackInfo ci) {
+    private void sendToShipyard(BlockHitResult blockHitResult, CallbackInfo ci) {
         Ship ship;
-        if (hitResult instanceof BlockHitResult blockHitResult && (ship = VSGameUtilsKt.getShipManagingPos(level(), blockHitResult.getBlockPos())) != null) {
+        if ((ship = VSGameUtilsKt.getShipManagingPos(level(), blockHitResult.getBlockPos())) != null) {
             Vector3d hitLocation = ship.getWorldToShip().transformPosition(VectorConversionsMCKt.toJOML(blockHitResult.location));
             blockHitResult.location = VectorConversionsMCKt.toMinecraft(hitLocation);
             DefaultShipyardEntityHandler.INSTANCE.moveEntityFromWorldToShipyard(this, ship);
@@ -58,8 +57,8 @@ public abstract class MixinProjectile extends Entity implements TraceableEntity 
     private void returnFromShipyard(CallbackInfo ci) {
         final Ship ship;
         if((ship = VSGameUtilsKt.getShipManaging(this)) == null) return;
-        HitResult result = ProjectileUtil.getHitResultOnMoveVector(this, this::canHitEntity);
-        if(result.getType() == Type.MISS) {
+        Iterable<VoxelShape> result = level().getBlockCollisions(this, this.getBoundingBox().inflate(0.1));
+        if(!result.iterator().hasNext()) {
             WorldEntityHandler.INSTANCE.moveEntityFromShipyardToWorld(this, ship);
         }
     }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/blockentity/MixinChainConveyorRidingHandler.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/blockentity/MixinChainConveyorRidingHandler.java
@@ -12,7 +12,6 @@ import net.minecraft.core.Vec3i;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3d;
-import org.joml.Vector3dc;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -31,9 +30,6 @@ public abstract class MixinChainConveyorRidingHandler {
     @Unique
     private static ClientShip vs$ridingShip;
 
-    @Unique
-    private static Vector3dc vs$prevPlayerPosInShip;
-
     @Inject(
         method = "embark",
         at = @At("HEAD")
@@ -41,7 +37,7 @@ public abstract class MixinChainConveyorRidingHandler {
     private static void preEmbark(BlockPos lift, float position, BlockPos connection, CallbackInfo ci) {
         vs$ridingShip = VSClientGameUtils.getClientShip(lift.getX(), lift.getY(), lift.getZ());
         Player player = Minecraft.getInstance().player;
-        if (player != null) ((IEntityDraggingInformationProvider)player).getDraggingInformation().setLastShipStoodOn(vs$ridingShip.getId());
+        if (player != null && vs$ridingShip != null) ((IEntityDraggingInformationProvider)player).getDraggingInformation().setLastShipStoodOn(vs$ridingShip.getId());
     }
 
     @Inject(

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/AbstractShipyardEntityHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/AbstractShipyardEntityHandler.kt
@@ -1,10 +1,13 @@
 package org.valkyrienskies.mod.common.entity.handling
 
 import com.mojang.blaze3d.vertex.PoseStack
+import com.mojang.logging.LogUtils
 import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.client.renderer.entity.EntityRenderer
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.projectile.AbstractArrow
 import net.minecraft.world.entity.projectile.AbstractHurtingProjectile
+import net.minecraft.world.entity.projectile.Projectile
 import net.minecraft.world.entity.projectile.ProjectileUtil
 import org.joml.Quaternionf
 import org.joml.Vector3d
@@ -79,17 +82,31 @@ abstract class AbstractShipyardEntityHandler : VSEntityHandler {
         entity.yo = shipyardPos.y
         entity.zo = shipyardPos.z
 
-        val direction = ship.shipToWorld.transformDirection(entity.lookAngle.toJOML()) // I thought this should be world to ship, but it was ship to world. I have no idea why. -Bunting_chj
-        val yaw = atan2(-direction.x, direction.z)
-        val pitch = -atan2(direction.y, sqrt((direction.x * direction.x) + (direction.z * direction.z)))
+
+        val direction : Vector3d
+        val yaw : Double
+        val pitch : Double
+
+        if (entity is AbstractArrow) {
+            direction = entity.deltaMovement.toJOML()
+            yaw = atan2(direction.x, direction.z)
+            pitch = atan2(direction.y, sqrt((direction.x * direction.x) + (direction.z * direction.z)))
+        } else {
+            direction = ship.worldToShip.transformDirection(entity.lookAngle.toJOML())
+            yaw = atan2(-direction.x, direction.z)
+            pitch = atan2(direction.y, sqrt((direction.x * direction.x) + (direction.z * direction.z)))
+        }
+
         entity.yRot = (yaw * (180 / Math.PI)).toFloat()
         entity.xRot = (pitch * (180 / Math.PI)).toFloat()
+        LogUtils.getLogger().info("Yaw {}, Pitch {}", entity.yRot, entity.xRot)
         entity.yRotO = entity.yRot
         entity.xRotO = entity.xRot
 
         if (entity is AbstractHurtingProjectile) {
             val power = Vector3d(entity.xPower, entity.yPower, entity.zPower)
-            ship.transform.shipToWorld.transformDirection(power)
+            ship.worldToShip.transformDirection(power)
+
             entity.xPower = power.x
             entity.yPower = power.y
             entity.zPower = power.z

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/WorldEntityHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/WorldEntityHandler.kt
@@ -4,7 +4,10 @@ import com.mojang.blaze3d.vertex.PoseStack
 import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.client.renderer.entity.EntityRenderer
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.projectile.AbstractArrow
 import net.minecraft.world.entity.projectile.AbstractHurtingProjectile
+import net.minecraft.world.entity.projectile.Projectile
+import net.minecraft.world.entity.projectile.ProjectileUtil
 import org.joml.Vector3d
 import org.valkyrienskies.core.api.ships.ClientShip
 import org.valkyrienskies.core.api.ships.Ship
@@ -73,9 +76,20 @@ object WorldEntityHandler : VSEntityHandler {
             .add(shipVelocity)
             .toMinecraft()
 
-        val direction = ship.transform.worldToShip.transformDirection(entity.lookAngle.toJOML()) // I thought this should be ship to world, but it was world to ship. I have no idea why. -Bunting_chj
-        val yaw = atan2(-direction.x, direction.z)
-        val pitch = -atan2(direction.y, sqrt((direction.x * direction.x) + (direction.z * direction.z)))
+        val direction : Vector3d
+        val yaw : Double
+        val pitch : Double
+
+        if (entity is AbstractArrow) {
+            direction = entity.deltaMovement.toJOML()
+            yaw = atan2(direction.x, direction.z)
+            pitch = atan2(direction.y, sqrt((direction.x * direction.x) + (direction.z * direction.z)))
+        } else {
+            direction = ship.shipToWorld.transformDirection(entity.lookAngle.toJOML())
+            yaw = atan2(-direction.x, direction.z)
+            pitch = atan2(direction.y, sqrt((direction.x * direction.x) + (direction.z * direction.z)))
+        }
+
         entity.yRot = (yaw * (180 / Math.PI)).toFloat()
         entity.xRot = (pitch * (180 / Math.PI)).toFloat()
         entity.yRotO = entity.yRot
@@ -84,11 +98,13 @@ object WorldEntityHandler : VSEntityHandler {
         if (entity is AbstractHurtingProjectile) {
             val power = Vector3d(entity.xPower, entity.yPower, entity.zPower)
 
-            ship.transform.worldToShip.transformDirection(power)
+            ship.shipToWorld.transformDirection(power)
 
             entity.xPower = power.x
             entity.yPower = power.y
             entity.zPower = power.z
+
+            ProjectileUtil.rotateTowardsMovement(entity, 1.0f)
         }
     }
 }


### PR DESCRIPTION
Fixed arrows not directed correctly, due to discrepancy in look vector and actual heading. Mojank moment.
Fixed game crashing when player rides a chain that isn't on a ship.