### PR TITLE
Fixed relogs not teleporting players + removed now unused config option

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/teleport_reconnected_player_to_ship/MixinServerPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/teleport_reconnected_player_to_ship/MixinServerPlayer.java
@@ -62,7 +62,7 @@ public abstract class MixinServerPlayer extends Player {
     void rememberLastShip(final CompoundTag compoundTag, final CallbackInfo ci) {
         final EntityDraggingInformation draggingInformation = ((IEntityDraggingInformationProvider) this).getDraggingInformation();
 
-        if (draggingInformation.getTicksSinceStoodOnShip() > VSGameConfig.SERVER.getMaxAirborneTicksForReconnectedPlayerTeleport())
+        if (!draggingInformation.isEntityBeingDraggedByAShip())
             return;
 
         @Nullable final Long lastShipId = draggingInformation.getLastShipStoodOn();

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -132,13 +132,6 @@ object VSGameConfig {
         var teleportReconnectedPlayers = true
 
         @JsonSchema(
-            description = "Determines how many airborne ticks after a player leaves the ground of a" +
-                "ship that they are still considered part of it when they disconnect, such that they will" +
-                "be teleported back to it after reconnecnting."
-        )
-        var maxAirborneTicksForReconnectedPlayerTeleport = 4
-
-        @JsonSchema(
             description = "If true, when a mob gets unloaded, its position on a ship is saved such that " +
                 "if the ship is moved, when the mob loads back in it will be teleported to the same position in the ship." +
                 " This helps prevent mobs from falling off of ships."


### PR DESCRIPTION
Fixes #486.... Again...

As reported by @blockninja124: https://github.com/ValkyrienSkies/Valkyrien-Skies-2/issues/486#issuecomment-3486857669, the current solution no longer works. This PR fixes that.

(More than an) edge-case: When a ship "splits" (ie, a joining part breaks, and the two halves are split into two separate ships), there is a chance the player will be standing on the new half, so they will not be teleported. Ideally we'd use a more sophisticated system on the server to store such positions, and automatically translate them, but for right now I think this is good enough.

If you really want me to, I can attempt to tackle that, but I will need pointers as to where that splitting code is, a cursory search didn't lead me anywhere.

Anyway, hope this is helpful for a feature patch update

P.S. Peer review/peer testing appreciated!