### PR TITLE
Remade the in ship fluid push mixin(s)

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
@@ -201,7 +201,6 @@ private fun getShipObjectManagingPosImpl(world: Level?, chunkX: Int, chunkZ: Int
  * followed by the AABB in the ship-space of the intersecting ships.
  */
 fun Level.transformFromWorldToNearbyShipsAndWorld(aabb: AABB, cb: Consumer<AABB>) {
-    cb.accept(aabb)
     val tmpAABB = AABBd()
     getShipsIntersecting(aabb).forEach { ship ->
         cb.accept(tmpAABB.set(aabb).transform(ship.worldToShip).toMinecraft())

--- a/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/feature/water_in_ships_entity/MixinEntity.java
+++ b/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/feature/water_in_ships_entity/MixinEntity.java
@@ -2,34 +2,37 @@ package org.valkyrienskies.mod.fabric.mixin.feature.water_in_ships_entity;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
+import java.util.function.Predicate;
 import net.minecraft.core.BlockPos;
 import net.minecraft.tags.TagKey;
-import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.At.Shift;
+import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
 @Mixin(Entity.class)
 public abstract class MixinEntity {
-
-    @Shadow
-    public abstract void setPos(double x, double y, double z);
-
-    @Shadow
-    public abstract Vec3 position();
 
     @Unique
     private boolean isModifyingWaterState = false;
@@ -51,104 +54,131 @@ public abstract class MixinEntity {
     @Shadow
     public abstract boolean updateFluidHeightAndDoFluidPushing(TagKey<Fluid> tagKey, double d);
 
-    @Shadow
-    public abstract boolean touchingUnloadedChunk();
-
-    @Shadow
-    public abstract AABB getBoundingBox();
-
-    @Shadow
-    public abstract boolean isPushedByFluid();
-
-    @Shadow
-    public abstract Vec3 getDeltaMovement();
-
-    @Shadow
-    public abstract void setDeltaMovement(Vec3 vec3);
-
-    @Shadow
-    protected Object2DoubleMap<TagKey<Fluid>> fluidHeight;
     @Unique
     private boolean isShipWater = false;
 
+    /**
+     * used to replace updateFluidHeightAndDoFluidPushing aABB in ship context
+     * */
+    @Unique
+    private AABB valkyrienskies$fluidPushAABB = null;
+
+    /**
+     * vector apply to the entity when getting pushed by liquid
+     * used to combine updateFluidHeightAndDoFluidPushing vec3 of normal and ship context
+     * */
+    @Unique
+    private Vec3 valkyrienskies$fluidPushVec = null;
+
+    /**
+     * Number of fluid pushing the entity, o in updateFluidHeightAndDoFluidPushing
+     * used to combine updateFluidHeightAndDoFluidPushing o of normal and ship context
+     * */
+    @Unique
+    private int valkyrienskies$fluidPushNumber = 0;
+
+    @Unique
+    private boolean valkyrienskies$fluidPushRet = false;
+
+    /**
+     * double that rely on other fluid push that is put in the fluidHeight, i don't know its utility but it
+     * used to combine updateFluidHeightAndDoFluidPushing e of normal and ship context
+     * */
+    @Unique
+    private double valkyrienskies$fluidPushE = 0;
+
+    @Unique
+    private boolean inShipContext() {
+        return valkyrienskies$fluidPushAABB != null;
+    }
+
+    @ModifyVariable(
+        method = "updateFluidHeightAndDoFluidPushing",
+        at = @At("STORE"),
+        remap = false
+    )
+    private AABB setFluidPushInShipContext(AABB original) {
+        if (inShipContext())
+            return valkyrienskies$fluidPushAABB;
+
+        return original;
+    }
+
+    @ModifyConstant(
+        method = "updateFluidHeightAndDoFluidPushing",
+        constant = @Constant(doubleValue = 0.0)
+    )
+    private double setFluidPushInShipContext(double constant) {
+        // valkyrienskies$fluidPushE = 0 before function end, no need to check inShipContext
+        return valkyrienskies$fluidPushE;
+    }
+
     @Inject(
-        at = @At("HEAD"),
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;length()D", ordinal = 0),
         method = "updateFluidHeightAndDoFluidPushing",
         cancellable = true
     )
-    // Overwrite the vanilla method, since it's written in a way that's really hard to precisely mixin into.
-    private void afterFluidStateUpdate(final TagKey<Fluid> tagKey, final double d,
-        final CallbackInfoReturnable<Boolean> cir) {
-
-        if (this.touchingUnloadedChunk()) {
-            cir.setReturnValue(false);
-            return;
+   private void shouldProcessPush(TagKey<Fluid> tagKey, double d, CallbackInfoReturnable<Boolean> cir,
+        @Local(name = "o") int numberPush, @Local(name = "bl2") boolean bl2,@Local(ordinal = 0) Vec3 vec3,
+        @Local(name = "e") double e) {
+        if (inShipContext()) {
+            //stop processing is in ship context, processing will be done after collectShipFluidPush in normal context
+            valkyrienskies$fluidPushE = e;
+            valkyrienskies$fluidPushNumber += numberPush;
+            valkyrienskies$fluidPushVec = valkyrienskies$fluidPushVec.add(vec3);
+            cir.setReturnValue(bl2);
         }
-
-        final Vec3[] vec3ref = {Vec3.ZERO};
-        final int[] oref = {0};
-        final boolean[] bl2ref = {false};
-        final double[] e = {0.0};
-
-        // The only change, gather fluid forces from nearby ships as well as the world.
-        VSGameUtilsKt.transformFromWorldToNearbyShipsAndWorld(level, this.getBoundingBox().deflate(0.001), aABB -> {
-            final int i = Mth.floor(aABB.minX);
-            final int j = Mth.ceil(aABB.maxX);
-            final int k = Mth.floor(aABB.minY);
-            final int l = Mth.ceil(aABB.maxY);
-            final int m = Mth.floor(aABB.minZ);
-            final int n = Mth.ceil(aABB.maxZ);
-            final boolean bl = this.isPushedByFluid();
-            final BlockPos.MutableBlockPos mutableBlockPos = new BlockPos.MutableBlockPos();
-            for (int p = i; p < j; ++p) {
-                for (int q = k; q < l; ++q) {
-                    for (int r = m; r < n; ++r) {
-                        final double f;
-                        mutableBlockPos.set(p, q, r);
-                        final FluidState fluidState = this.level.getFluidState(mutableBlockPos);
-                        if (!fluidState.is(tagKey) ||
-                            !((f = (float) q + fluidState.getHeight(this.level, mutableBlockPos)) >=
-                                aABB.minY)) {
-                            continue;
-                        }
-                        bl2ref[0] = true;
-                        e[0] = Math.max(f - aABB.minY, e[0]);
-                        if (!bl) {
-                            continue;
-                        }
-                        Vec3 vec32 = fluidState.getFlow(this.level, mutableBlockPos);
-                        if (e[0] < 0.4) {
-                            vec32 = vec32.scale(e[0]);
-                        }
-                        vec3ref[0] = vec3ref[0].add(vec32);
-                        ++oref[0];
-                    }
-                }
-            }
-        });
-
-        Vec3 vec3 = vec3ref[0];
-        final boolean bl2 = bl2ref[0];
-        final int o = oref[0];
-
-        if (vec3.length() > 0.0) {
-            if (o > 0) {
-                vec3 = vec3.scale(1.0 / (double) o);
-            }
-            if (!Player.class.isInstance(this)) {
-                vec3 = vec3.normalize();
-            }
-            final Vec3 vec33 = this.getDeltaMovement();
-            vec3 = vec3.scale(d);
-            if (Math.abs(vec33.x) < 0.003 && Math.abs(vec33.z) < 0.003 && vec3.length() < 0.0045000000000000005) {
-                vec3 = vec3.normalize().scale(0.0045);
-            }
-            this.setDeltaMovement(this.getDeltaMovement().add(vec3));
-        }
-        this.fluidHeight.put(tagKey, e[0]);
-
-        cir.setReturnValue(bl2);
     }
+
+    @Redirect(
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;length()D", ordinal = 0),
+        method = "updateFluidHeightAndDoFluidPushing"
+    )
+    private double collectShipFluidPush(Vec3 instance,
+        @Local(ordinal = 0, argsOnly = true) TagKey<Fluid> tagKey, @Local(ordinal = 0, argsOnly = true) double d,
+        @Local(ordinal = 0) AABB aabb, @Local(name = "bl2") boolean bl2, @Local(name = "o") int numberPush,
+        @Local(name = "e") double e)
+    {
+        valkyrienskies$fluidPushE = e;
+        valkyrienskies$fluidPushNumber = numberPush;
+        valkyrienskies$fluidPushRet = bl2;
+        valkyrienskies$fluidPushVec = instance;
+        VSGameUtilsKt.transformFromWorldToNearbyShipsAndWorld(level, aabb, (shipAabb) -> {
+            valkyrienskies$fluidPushAABB = shipAabb; // enable ship context
+            valkyrienskies$fluidPushRet = valkyrienskies$fluidPushRet || this.updateFluidHeightAndDoFluidPushing(tagKey, d);
+            //recall in the ship context
+        });
+        valkyrienskies$fluidPushAABB = null; //disable ship context
+        return valkyrienskies$fluidPushVec.length();
+    }
+    
+    @ModifyVariable(
+        method = "updateFluidHeightAndDoFluidPushing",
+        at = @At("LOAD"),
+        ordinal = 6
+    )
+    private int loadO(int origin) {
+        return valkyrienskies$fluidPushNumber;
+    }
+
+    @Redirect(
+        method = "updateFluidHeightAndDoFluidPushing",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;scale(D)Lnet/minecraft/world/phys/Vec3;", ordinal = 1)
+    )
+    private Vec3 setVec3ToPush(Vec3 instance, double d) {
+        return valkyrienskies$fluidPushVec.scale(d);
+    }
+
+    @Inject(
+        method = "updateFluidHeightAndDoFluidPushing",
+        at = @At("TAIL"),
+        cancellable = true
+    )
+    private void setFluidPushingReturnValue(TagKey<Fluid> tagKey, double d, CallbackInfoReturnable<Boolean> cir) {
+        valkyrienskies$fluidPushE = 0;
+        cir.setReturnValue(valkyrienskies$fluidPushRet);
+    }
+
 
     @WrapOperation(
         at = @At(value = "INVOKE",

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/feature/water_in_ships_entity/MixinEntity.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/feature/water_in_ships_entity/MixinEntity.java
@@ -2,24 +2,24 @@ package org.valkyrienskies.mod.forge.mixin.feature.water_in_ships_entity;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import net.minecraft.core.BlockPos;
-import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.common.extensions.IForgeEntity;
-import net.minecraftforge.fluids.FluidType;
-import org.apache.commons.lang3.tuple.MutableTriple;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
@@ -39,100 +39,86 @@ public abstract class MixinEntity {
     @Shadow
     public abstract double getZ();
 
-    @Shadow
-    public abstract boolean touchingUnloadedChunk();
-
-    @Shadow
-    public abstract AABB getBoundingBox();
-
-    @Shadow
-    public abstract boolean isPushedByFluid();
-
-    @Shadow
-    public abstract Vec3 getDeltaMovement();
-
-    @Shadow
-    public abstract void setDeltaMovement(Vec3 vec3);
-
     @Unique
     private boolean isShipWater = false;
 
+    /**
+     * used to replace updateFluidHeightAndDoFluidPushing aabb in ship context
+     * */
+    @Unique
+    private AABB valkyrienskies$fluidPushAABB = null;
+
+    /**
+     * list of fluid push to calculate
+     * used to combine updateFluidHeightAndDoFluidPushing interimCalcs of normal and ship context
+     * */
+    @Unique
+    private Object2ObjectMap<?,?> valkyrienskies$interimCalcs = null;
+
     @Shadow
-    protected abstract void setFluidTypeHeight(FluidType type, double height);
+    public abstract void updateFluidHeightAndDoFluidPushing(Predicate<FluidState> par1);
+
+    @Unique
+    private boolean inShipContext() {
+        return valkyrienskies$fluidPushAABB != null;
+    }
+
+    //IDE may show error, ignore its valid mixin
+    @ModifyVariable(
+        method = "updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V",
+        at = @At(value = "STORE"),
+        remap = false
+    )
+    private AABB setFluidPushAABB(AABB original) {
+        if (inShipContext())
+            return valkyrienskies$fluidPushAABB;
+
+        return original;
+    }
+
+    @Redirect(
+        method = "updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V",
+        at = @At(value = "NEW", target = "(I)Lit/unimi/dsi/fastutil/objects/Object2ObjectArrayMap;"),
+        remap = false
+    )
+    private Object2ObjectArrayMap<?, ?> setInterimCalcInstance(int capacity) {
+        if (inShipContext()) {
+            return (Object2ObjectArrayMap<?, ?>) valkyrienskies$interimCalcs;
+        }
+        return (Object2ObjectArrayMap<?, ?>) (valkyrienskies$interimCalcs = new Object2ObjectArrayMap<>(capacity));
+    }
 
     @Inject(
-        at = @At("HEAD"),
-        method = "updateFluidHeightAndDoFluidPushing()V",
+        method = "updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V",
+        at = @At(value = "INVOKE",
+            target = "Lit/unimi/dsi/fastutil/objects/Object2ObjectMap;forEach(Ljava/util/function/BiConsumer;)V"),
         remap = false,
         cancellable = true
     )
-    // Overwrite the forge method, since it's written in a way that's really hard to precisely mixin into.
-    private void afterFluidStateUpdate(final CallbackInfo callbackInfo) {
-        if (this.touchingUnloadedChunk()) {
-            return;
+
+    private void shouldProcessPush(Predicate<FluidState> shouldUpdate, CallbackInfo ci) {
+        if (inShipContext()) {
+            ci.cancel();
         }
-        VSGameUtilsKt.transformFromWorldToNearbyShipsAndWorld(level, this.getBoundingBox().deflate(0.001), aabb -> {
-            int i = Mth.floor(aabb.minX);
-            int j = Mth.ceil(aabb.maxX);
-            int k = Mth.floor(aabb.minY);
-            int l = Mth.ceil(aabb.maxY);
-            int i1 = Mth.floor(aabb.minZ);
-            int j1 = Mth.ceil(aabb.maxZ);
-            double d0 = 0.0;
-            boolean flag = this.isPushedByFluid();
-            boolean flag1 = false;
-            Vec3 vec3 = Vec3.ZERO;
-            boolean k1 = false;
-            BlockPos.MutableBlockPos blockpos$mutableblockpos = new BlockPos.MutableBlockPos();
-            Object2ObjectArrayMap<FluidType, MutableTriple>
-                interimCalcs = new Object2ObjectArrayMap<FluidType, MutableTriple>((Integer) FluidType.SIZE.get() - 1);
-            for (int l1 = i; l1 < j; ++l1) {
-                for (int i2 = k; i2 < l; ++i2) {
-                    for (int j2 = i1; j2 < j1; ++j2) {
-                        double d1;
-                        blockpos$mutableblockpos.set(l1, i2, j2);
-                        FluidState fluidstate = this.level.getFluidState(blockpos$mutableblockpos);
-                        FluidType fluidType2 = fluidstate.getFluidType();
-                        if (fluidType2.isAir() || !((d1 =
-                            (double) ((float) i2 + fluidstate.getHeight(this.level, blockpos$mutableblockpos))) >=
-                            aabb.minY)) continue;
-                        flag1 = true;
-                        MutableTriple interim2 =
-                            interimCalcs.computeIfAbsent(fluidType2, t -> MutableTriple.of(0.0, Vec3.ZERO, 0));
-                        interim2.setLeft(Math.max(d1 - aabb.minY, (Double) interim2.getLeft()));
-                        if (!((IForgeEntity) this).isPushedByFluid(fluidType2)) continue;
-                        Vec3 vec31 = fluidstate.getFlow(this.level, blockpos$mutableblockpos);
-                        if ((Double) interim2.getLeft() < 0.4) {
-                            vec31 = vec31.scale((Double) interim2.getLeft());
-                        }
-                        interim2.setMiddle(((Vec3) interim2.getMiddle()).add(vec31));
-                        interim2.setRight((Integer) interim2.getRight() + 1);
-                    }
-                }
-            }
-            interimCalcs.forEach((fluidType, interim) -> {
-                if (((Vec3) interim.getMiddle()).length() > 0.0) {
-                    if ((Integer) interim.getRight() > 0) {
-                        interim.setMiddle(((Vec3) interim.getMiddle()).scale(
-                            1.0 / (double) ((Integer) interim.getRight()).intValue()));
-                    }
-                    if (!Player.class.isInstance(this)) {
-                        interim.setMiddle(((Vec3) interim.getMiddle()).normalize());
-                    }
-                    Vec3 vec32 = this.getDeltaMovement();
-                    interim.setMiddle(((Vec3) interim.getMiddle()).scale(
-                        ((IForgeEntity) this).getFluidMotionScale((FluidType) fluidType)));
-                    double d2 = 0.003;
-                    if (Math.abs(vec32.x) < 0.003 && Math.abs(vec32.z) < 0.003 &&
-                        ((Vec3) interim.getMiddle()).length() < 0.0045000000000000005) {
-                        interim.setMiddle(((Vec3) interim.getMiddle()).normalize().scale(0.0045000000000000005));
-                    }
-                    this.setDeltaMovement(this.getDeltaMovement().add((Vec3) interim.getMiddle()));
-                }
-                this.setFluidTypeHeight((FluidType) fluidType, (Double) interim.getLeft());
-            });
+    }
+
+    @Redirect(
+        method = "updateFluidHeightAndDoFluidPushing(Ljava/util/function/Predicate;)V",
+        at = @At(value = "INVOKE",
+            target = "Lit/unimi/dsi/fastutil/objects/Object2ObjectMap;forEach(Ljava/util/function/BiConsumer;)V"),
+        remap = false
+    )
+    private void collectShipFluidPush(Object2ObjectMap instance, BiConsumer consumer,
+        @Local(ordinal = 0, argsOnly = true) Predicate<FluidState> shouldUpdate, @Local(ordinal = 0) AABB aabb) {
+        VSGameUtilsKt.transformFromWorldToNearbyShipsAndWorld(level, aabb, (shipAabb) -> {
+            valkyrienskies$fluidPushAABB = shipAabb; // enable ship context
+            this.updateFluidHeightAndDoFluidPushing(shouldUpdate); //recall in the ship context
         });
-        callbackInfo.cancel();
+        valkyrienskies$fluidPushAABB = null;
+        valkyrienskies$interimCalcs = null;
+
+        //processing collected push (vanilla and ship)
+        instance.forEach(consumer);
     }
 
     @WrapOperation(


### PR DESCRIPTION
The previous way was overriding the function (and copying vanilla behaviour to apply it to ship) which isn't great for compatibility with other mod that mixin in this function

this uses more complex mixin to let vanilla/forge gather all the fluid that will push the entity then inject code that recall the function and switching variable to make the gathering of ship (reuseing the function make it more compatible with other mod's mixin) and combining with vanilla then letting the vanilla/forge way of managing fluid pushing

i recommend using the mixin.debug.export to understand where it modify and capture value

it also fix #536 and make in ship fluid push in fabric (it wasn't the case before)