### PR TITLE
Add changelog system to auto-publishing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,3 @@
+- Fixed train stations not being placeable on ships
+- Fixed create fans not processing depots in the world
+- Fixed/polished up the redstone contact compat with ships

--- a/gradle-scripts/publish-curseforge.gradle
+++ b/gradle-scripts/publish-curseforge.gradle
@@ -38,6 +38,9 @@ curseforge {
                     }
                 }
                 displayName = fileDisplayName
+
+                changelogType = "markdown"
+                changelog = file('changelog.md')
             }
         }
     }
@@ -53,6 +56,7 @@ modrinth {
     projectId = project.modrinth_project_id
     versionType = vsReleaseType
     versionName = fileDisplayName
+    changelog = file('changelog.md').text
     versionNumber = "${project.minecraft_version}-${project.loader_platform.toLowerCase()}-${project.version}"
     uploadFile = remapJar
     gameVersions = [project.minecraft_version]

--- a/gradle-scripts/publish-curseforge.gradle
+++ b/gradle-scripts/publish-curseforge.gradle
@@ -40,7 +40,7 @@ curseforge {
                 displayName = fileDisplayName
 
                 changelogType = "markdown"
-                changelog = file('changelog.md')
+                changelog = rootProject.file('changelog.md')
             }
         }
     }
@@ -56,7 +56,7 @@ modrinth {
     projectId = project.modrinth_project_id
     versionType = vsReleaseType
     versionName = fileDisplayName
-    changelog = file('changelog.md').text
+    changelog = rootProject.file('changelog.md').text
     versionNumber = "${project.minecraft_version}-${project.loader_platform.toLowerCase()}-${project.version}"
     uploadFile = remapJar
     gameVersions = [project.minecraft_version]


### PR DESCRIPTION
Also pre-emptively added changelog for beta.12

Probably needs @Rubydesic approval before merging.

Basically, both the curseforge and modrinth publish tasks now read the `changelog.md` file and use it as a (markdown) changelog. I've used this on starlance, so I know it works. 