### PR TITLE
Fix tnt explosion clip

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/explosions/MixinExplosion.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/explosions/MixinExplosion.java
@@ -133,9 +133,33 @@ public abstract class MixinExplosion {
         isModifyingExplosion = false;
     }
 
+    @WrapOperation(
+        method = "getSeenPercent",
+        at = @At(
+            value = "NEW",
+            target = "Lnet/minecraft/world/level/ClipContext;"
+        )
+    )
+    private static ClipContext getSeenPercent$ClipContext$new(
+        Vec3 from,
+        Vec3 to,
+        final ClipContext.Block blockClip,
+        final ClipContext.Block fluidClip,
+        final Entity source,
+        final Operation<ClipContext> operation
+    ) {
+        if (source != null) {
+            final Level level = source.level();
+            from = VSGameUtilsKt.toWorldCoordinates(level, from);
+            to = VSGameUtilsKt.toWorldCoordinates(level, to);
+        }
+        return operation.call(from, to, blockClip, fluidClip, source);
+    }
+
     // Don't raytrace the shipyard
     // getEntities already gives shipyard entities
-    @WrapOperation(method = "explode",
+    @WrapOperation(
+        method = "explode",
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/Level;getEntities(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Ljava/util/List;"

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/explosions/MixinExplosion.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/explosions/MixinExplosion.java
@@ -144,7 +144,7 @@ public abstract class MixinExplosion {
         Vec3 from,
         Vec3 to,
         final ClipContext.Block blockClip,
-        final ClipContext.Block fluidClip,
+        final ClipContext.Fluid fluidClip,
         final Entity source,
         final Operation<ClipContext> operation
     ) {


### PR DESCRIPTION
- **fix explosion when impacted entity is in shipyard**
- **fix typo**


When create contraptions which on a ship are under a TNT explosion, server will get spammed with clip warn

