### PR TITLE
Fix shipyard entity rendering when pehkui installed

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntityRenderDispatcher.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntityRenderDispatcher.java
@@ -28,7 +28,7 @@ import org.valkyrienskies.mod.common.entity.ShipMountedToData;
 import org.valkyrienskies.mod.common.entity.handling.VSEntityManager;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 
-@Mixin(EntityRenderDispatcher.class)
+@Mixin(value = EntityRenderDispatcher.class, priority = 500)
 public class MixinEntityRenderDispatcher {
 
     @Shadow


### PR DESCRIPTION
Change mixin priority so that VS transforms rendering to the shipyard *before* other mods do their rendering shenanigans, which produces correct visuals.

Before:
<img width="359" height="114" alt="Screenshot_2025-11-23_at_6 17 37_PM" src="https://github.com/user-attachments/assets/715c7693-6aa5-489d-aa51-8e0fc21490ea" />

After:
<img width="334" height="118" alt="Screenshot 2025-11-23 at 6 46 16 PM" src="https://github.com/user-attachments/assets/08dd52fe-b7be-4a22-97ba-53c52e90cf5b" />
