### PR TITLE
Bug in dismounting dead entities on shipyard fixed

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/dismount_dead_entities/MixinLivingEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/dismount_dead_entities/MixinLivingEntity.java
@@ -32,7 +32,8 @@ public abstract class MixinLivingEntity extends Entity {
      */
     @Inject(method = "dismountVehicle", at = @At("HEAD"), cancellable = true)
     private void preDismountVehicle(final Entity entity, final CallbackInfo ci) {
-        if ((!this.isRemoved() && entity.isRemoved()) || (this.level().isLoaded(entity.blockPosition()) && this.level().getBlockState(entity.blockPosition()).is(BlockTags.PORTALS))) {            if (VSGameUtilsKt.isBlockInShipyard(level(), entity.position())) {
+        if ((!this.isRemoved() && entity.isRemoved()) || (this.level().isLoaded(entity.blockPosition()) && this.level().getBlockState(entity.blockPosition()).is(BlockTags.PORTALS))) {
+            if (VSGameUtilsKt.isBlockInShipyard(level(), entity.position())) {
                 final Ship ship = VSGameUtilsKt.getShipManagingPos(level(), entity.position());
                 if (ship != null) {
                     final Vector3dc transformedPos = ship.getTransform().getShipToWorld().transformPosition(VectorConversionsMCKt.toJOML(entity.position()));
@@ -40,13 +41,13 @@ public abstract class MixinLivingEntity extends Entity {
                     final Vec3 vec3 = new Vec3(this.getX(), d, this.getZ());
                     this.dismountTo(vec3.x, vec3.y, vec3.z);
                     ci.cancel();
+                } else {
+                    // We're in the shipyard but no ship?
+                    VS$LOGGER.debug("Modifying strange dismount");
+                    final Vec3 vec3 = new Vec3(this.getX(), this.getY(), this.getZ());
+                    this.dismountTo(vec3.x, vec3.y, vec3.z);
+                    ci.cancel();
                 }
-            } else {
-                // We're in the shipyard but no ship?
-                VS$LOGGER.debug("Modifying strange dismount");
-                final Vec3 vec3 = new Vec3(this.getX(), this.getY(), this.getZ());
-                this.dismountTo(vec3.x, vec3.y, vec3.z);
-                ci.cancel();
             }
         }
     }


### PR DESCRIPTION
The else statement was misplaced, which should have been conditioned to 'it is in shipyard, but not on a ship'. It was turned to 'it isn't in a shipyard' causing players to get stuck on shipyard when the mounted ship is deleted.