### PR TITLE
Actually use the runRegisterBlockStateEvent method

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSMassDataLoader.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSMassDataLoader.kt
@@ -369,11 +369,10 @@ object MassDatapackResolver : BlockStateInfoProvider {
             }
             mcBlockStateToVs[blockState] = vsBlockState
         }
-
+        runRegisterBlockStateEvent()
         registeredBlocks = true
     }
 
-    // TODO implement
     private fun runRegisterBlockStateEvent() {
         val event = RegisterBlockStateEventImpl()
         ValkyrienSkiesMod.api.registerBlockStateEvent.emit(event)


### PR DESCRIPTION
Now the registerBlockStateEvent event is _actually_ emitted