### PR TITLE
Dismount/respawn/relog on ship fix

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/bed_fix/MixinPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/bed_fix/MixinPlayer.java
@@ -1,0 +1,33 @@
+package org.valkyrienskies.mod.mixin.feature.bed_fix;
+
+import java.util.Optional;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Mixin(Player.class)
+public abstract class MixinPlayer {
+    /**
+     * @author Bunting_chj
+     * @reason prevent respawning to shipyard when ship is deleted
+     */
+    @Inject(
+        method = "findRespawnPositionAndUseSpawnBlock",
+        at = @At("RETURN"),
+        cancellable = true
+    )
+    private static void cancelIfInShipyard(ServerLevel serverLevel, BlockPos blockPos, float f, boolean bl,
+        boolean bl2, CallbackInfoReturnable<Optional<Vec3>> cir){
+        if (cir.getReturnValue().isEmpty()) return;
+        Vec3 pos = cir.getReturnValue().get();
+        if (VSGameUtilsKt.isBlockInShipyard(serverLevel, pos) && VSGameUtilsKt.getShipManagingPos(serverLevel, pos) == null) {
+            cir.setReturnValue(Optional.empty());
+        }
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntity.java
@@ -1,9 +1,11 @@
 package org.valkyrienskies.mod.mixin.feature.shipyard_entities;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import java.util.Set;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Entity.RemovalReason;
@@ -203,4 +205,17 @@ public abstract class MixinEntity {
 
     @Shadow
     public Level level;
+
+    /**
+     * @author Bunting_chj
+     * @reason Allow entities to be loaded to shipyard
+     */
+    @WrapMethod(
+        method = "load"
+    )
+    private void loadShipyard(CompoundTag compoundTag, Operation<Void> original){
+        isModifyingSetPos = true;
+        original.call(compoundTag);
+        isModifyingSetPos = false;
+    }
 }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/command/level/MixinServerPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/command/level/MixinServerPlayer.java
@@ -16,6 +16,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 
 @Mixin(ServerPlayer.class)
@@ -65,8 +66,12 @@ public abstract class MixinServerPlayer extends Player {
             this.setYRot((float) yaw);
             this.setXRot((float) pitch);
 
-            final Vector3d inWorld = VSGameUtilsKt.toWorldCoordinates(ship, x, y, z);
-            this.teleportTo(level, inWorld.x, inWorld.y, inWorld.z, Set.of(), this.getYRot(), this.getXRot());
+            //Predict the position 2 ticks ahead for dismount
+            final Vector3d inWorld = ship.getTransform().getShipToWorld().transformPosition(x, y, z, new Vector3d());
+            final Vector3d inWorldPrev = ship.getPrevTickTransform().getShipToWorld().transformPosition(x, y, z, new Vector3d());
+            final Vector3d inWorldNext = inWorld.mul(3, new Vector3d()).sub(inWorldPrev.mul(2, new Vector3d()));
+            this.teleportTo(level, inWorldNext.x, inWorldNext.y, inWorldNext.z, Set.of(), this.getYRot(), this.getXRot());
+            ((IEntityDraggingInformationProvider)this).vs$dragImmediately(ship);
         }
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/WorldEntityHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/entity/handling/WorldEntityHandler.kt
@@ -8,7 +8,6 @@ import net.minecraft.world.entity.projectile.AbstractArrow
 import net.minecraft.world.entity.projectile.AbstractHurtingProjectile
 import net.minecraft.world.entity.projectile.Projectile
 import net.minecraft.world.entity.projectile.ProjectileUtil
-import org.joml.Quaternionf
 import org.joml.Vector3d
 import org.valkyrienskies.core.api.ships.ClientShip
 import org.valkyrienskies.core.api.ships.Ship
@@ -16,6 +15,8 @@ import org.valkyrienskies.core.util.component1
 import org.valkyrienskies.core.util.component2
 import org.valkyrienskies.core.util.component3
 import org.valkyrienskies.mod.common.applyShipVelocity
+import org.valkyrienskies.mod.common.getShipManaging
+import org.valkyrienskies.mod.common.isBlockInShipyard
 import org.valkyrienskies.mod.common.toWorldCoordinates
 import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider
 import org.valkyrienskies.mod.common.util.toJOML
@@ -43,6 +44,10 @@ object WorldEntityHandler : VSEntityHandler {
     }
 
     override fun positionSetFromVehicle(self: Entity, vehicle: Entity, x: Double, y: Double, z: Double) {
+        if (self.level().isBlockInShipyard(vehicle.position()) && vehicle.getShipManaging() == null) {
+            self.stopRiding()
+            return
+        }
         val (wx, wy, wz) = self.level().toWorldCoordinates(x, y, z)
         self.setPos(wx, wy, wz)
     }

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -38,6 +38,7 @@
     "feature.ai.path_retargeting.MixinAirAndWaterRandomPos",
     "feature.ai.path_retargeting.MixinDefaultRandomPos",
     "feature.ai.path_retargeting.MixinLandRandomPos",
+    "feature.bed_fix.MixinPlayer",
     "feature.bed_fix.MixinServerPlayer",
     "feature.block_placement.MixinBlockItem",
     "feature.block_placement.MixinBlockPlaceContext",


### PR DESCRIPTION
- Dismounting position of seats on ship is predicted 2 ticks ahead to prevent falling off.
- Relogging or respawning to deleted ship could send you to shipyard due to blocks still being at the position. Fixed by checking if the ship actually exists.
- Relogging on removed seats causing ghost seats are fixed.