### PR TITLE
Update VSMassDataLoader.kt

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
@@ -162,8 +162,15 @@ object MassDatapackResolver : BlockStateInfoProvider {
         else -> 100
     }
 
-
-    private fun generateStairCollisionShapes(stairShapes: Array<VoxelShape>): Map<VoxelShape, SolidBlockShape> {
+    /**
+     * This is mostly an internal function, not meant for public use.
+     * If however, you absolutely _need_ it to generate some stair collision shapes,
+     * then it is left public.
+     *
+     * @see generateShapeFromVoxel
+     */
+    @JvmStatic
+    fun generateStairCollisionShapes(stairShapes: Array<VoxelShape>): Map<VoxelShape, SolidBlockShape> {
         val testPoints = listOf(
             CollisionPoint(.25f, .25f, .25f, .25f),
             CollisionPoint(.25f, .25f, .75f, .25f),
@@ -219,7 +226,8 @@ object MassDatapackResolver : BlockStateInfoProvider {
         return map
     }
 
-    private fun generateShapeFromVoxel(voxelShape: VoxelShape): BoxesBlockShape? {
+    @JvmStatic
+    fun generateShapeFromVoxel(voxelShape: VoxelShape): BoxesBlockShape? {
         val posBoxes = ArrayList<AABBic>()
         var failed = false
         var maxBoxesToTest = 20
@@ -260,6 +268,11 @@ object MassDatapackResolver : BlockStateInfoProvider {
         }
     }
 
+    /**
+     * This is left public so it can be used in [org.valkyrienskies.mod.mixin.server.MixinMinecraftServer].
+     *
+     * It is **not recommended** to call this yourself!
+     */
     fun registerAllBlockStates(blockStates: Iterable<BlockState>) {
         val fullLodBoundingBox = AABBi(0, 0, 0, 15, 15, 15)
         val fullBlockCollisionPoints = listOf(
@@ -380,4 +393,5 @@ object MassDatapackResolver : BlockStateInfoProvider {
     }
 
     private val logger by logger()
+
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ energy_version=2.3.0
 
 # https://modrinth.com/plugin/dynmap/versions
 dynmap_version=IIQSYMHC
-vs_core_version=1.1.0+03b8d72dbc
+vs_core_version=1.1.0+93d0c758c4
 # Ideally we'd determine these automatically from vs_core. Add them manually for now
 krunch_version=1.0.0+85f7a9945b
 krunch_api_version=1.0.0+e38d2989db


### PR DESCRIPTION
It's now named MassDatapackResolver.kt to accurately reflect the top-level class inside.

Some util functions inside, `generateStairCollisionShapes` and `generateShapeFromVoxel`, have been exposed.

`registerAllBlockStates` has had javadoc added to clarify it shouldn't be used, despite being public.