### PR TITLE
Add basic assembly blacklist addons can use

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
@@ -1,7 +1,6 @@
 package org.valkyrienskies.mod.common
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation
-import com.mojang.logging.LogUtils
 import net.minecraft.client.Minecraft
 import net.minecraft.client.multiplayer.ClientLevel
 import net.minecraft.core.BlockPos
@@ -17,6 +16,7 @@ import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.level.ChunkPos
 import net.minecraft.world.level.Level
+import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.level.chunk.LevelChunkSection
 import net.minecraft.world.phys.AABB
 import net.minecraft.world.phys.Vec3
@@ -38,11 +38,11 @@ import org.valkyrienskies.core.internal.world.VsiServerShipWorld
 import org.valkyrienskies.core.internal.world.VsiShipWorld
 import org.valkyrienskies.core.internal.world.chunks.VsiTerrainUpdate
 import org.valkyrienskies.core.util.expand
+import org.valkyrienskies.mod.common.ValkyrienSkiesMod.ASSEMBLE_BLACKLIST
 import org.valkyrienskies.mod.common.entity.ShipMountedToData
 import org.valkyrienskies.mod.common.entity.ShipMountedToDataProvider
 import org.valkyrienskies.mod.common.util.DimensionIdProvider
 import org.valkyrienskies.mod.common.util.EntityDragger.serversideEyePosition
-import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider
 import org.valkyrienskies.mod.common.util.MinecraftPlayer
 import org.valkyrienskies.mod.common.util.set
 import org.valkyrienskies.mod.common.util.toJOML
@@ -536,4 +536,13 @@ fun Entity?.applyShipVelocity(ship: Ship?) {
         .add(ship.angularVelocity.cross(relPos, Vector3d()))
         .mul(0.05)
     this.push(shipSpeed.x, shipSpeed.y, shipSpeed.z)
+}
+
+/**
+ * Is the [BlockState] in the `assemble_blacklist`
+ * ([ValkyrienSkiesMod.ASSEMBLE_BLACKLIST]) block tag
+ */
+@Suppress("unused")
+fun BlockState?.inAssemblyBlacklist(): Boolean {
+    return this?.`is`(ASSEMBLE_BLACKLIST) ?: false
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/ValkyrienSkiesMod.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/ValkyrienSkiesMod.kt
@@ -9,6 +9,7 @@ import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceKey
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.MinecraftServer
+import net.minecraft.tags.TagKey
 import net.minecraft.world.entity.EntityType
 import net.minecraft.world.item.CreativeModeTab
 import net.minecraft.world.item.Item
@@ -66,6 +67,9 @@ object ValkyrienSkiesMod {
     private val dimensionalGTPAs: HashMap<DimensionId, GameToPhysicsAdapter> = HashMap()
 
     val VS_CREATIVE_TAB = ResourceKey.create(Registries.CREATIVE_MODE_TAB, ResourceLocation("valkyrienskies"))
+
+    val ASSEMBLE_BLACKLIST: TagKey<Block> =
+        TagKey.create(Registries.BLOCK, ResourceLocation(MOD_ID, "assemble_blacklist"))
 
     @JvmStatic
     var currentServer: MinecraftServer? = null

--- a/common/src/main/resources/data/valkyrienskies/tags/block/assemble_blacklist.json
+++ b/common/src/main/resources/data/valkyrienskies/tags/block/assemble_blacklist.json
@@ -1,0 +1,20 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:air",
+    "minecraft:bedrock",
+    "minecraft:barrier",
+    "minecraft:end_gateway",
+    "minecraft:end_portal",
+    "minecraft:end_portal_frame",
+    "minecraft:command_block",
+    "minecraft:chain_command_block",
+    "minecraft:repeating_command_block",
+    "minecraft:structure_block",
+    "minecraft:structure_void",
+    {
+      "id": "computercraft:computer_command",
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
Adds an `assemble_blacklist` block tag, registered as a `TagKey` in `ValkyrienSkiesMod`, along with a `BlockState` extension function in `VSGameUtilsKt`.
```kotlin
/**
 * Is the [BlockState] in the `assemble_blacklist`
 * ([ValkyrienSkiesMod.ASSEMBLE_BLACKLIST]) block tag
 */
fun BlockState?.inAssemblyBlacklist(): Boolean {
    return this?.`is`(ASSEMBLE_BLACKLIST) ?: false
}
```

After some deliberation, the choice was made to **not** include natural blocks in the blacklist. This is because it would encourage addons to use the blacklist (which would inevitable fail with modded natural blocks), instead of adding proper anti-assemble-entire-world checks.