### PR TITLE
fix sneaking on ships

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinPlayer.java
@@ -2,17 +2,13 @@ package org.valkyrienskies.mod.mixin.feature.entity_collision;
 
 import static org.valkyrienskies.mod.common.util.EntityDragger.backOff;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import net.minecraft.world.entity.MoverType;
-import net.minecraft.world.entity.player.Abilities;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.core.api.world.ShipWorld;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
@@ -21,36 +17,37 @@ import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider;
 @Mixin(Player.class)
 public abstract class MixinPlayer implements IEntityDraggingInformationProvider {
 
-    @Shadow
-    protected abstract boolean isStayingOnGroundSurface();
-
-    @Shadow
-    @Final
-    private Abilities abilities;
-
     // Allow players to crouch walk on ships
-    @Inject(method = "maybeBackOffFromEdge", at = @At("HEAD"), cancellable = true)
-    private void preMaybeBackOffFromEdge(final Vec3 vec3, final MoverType moverType,
-        final CallbackInfoReturnable<Vec3> callbackInfoReturnable) {
-        if (getDraggingInformation().isEntityBeingDraggedByAShip() && getDraggingInformation().getLastShipStoodOn() != null && getDraggingInformation().getTicksSinceStoodOnShip() < 1) {
-            Player player = (Player) (Object) this;
-            Level level = player.level();
-            if (level != null ) { // && level.isClientSide) {
-                ShipWorld shipWorld = VSGameUtilsKt.getShipObjectWorld(level);
-                if (shipWorld == null) {
-                    return;
-                }
-                Ship ship = shipWorld.getLoadedShips().getById(
-                    getDraggingInformation().getLastShipStoodOn());
-                if (ship == null) {
-                    return;
-                }
-                if (vec3.y <= 0.0f && (moverType == MoverType.SELF || moverType == MoverType.PLAYER) && this.isStayingOnGroundSurface() && !this.abilities.flying) {
-                    Vec3 adjustedVec = backOff(vec3, ship, player, level);
+    @WrapMethod(method = "maybeBackOffFromEdge")
+    private Vec3 preMaybeBackOffFromEdge(Vec3 vec3, MoverType moverType, Operation<Vec3> original) {
+        Vec3 vanillaResult = original.call(vec3, moverType);
 
-                    callbackInfoReturnable.setReturnValue(adjustedVec);
-                }
-            }
+        // Only apply ship-edge protection if vanilla decided to apply backoff
+        if (vanillaResult.subtract(vec3).lengthSqr() < 0.001) {
+            return vanillaResult;
         }
+
+        Player player = (Player) (Object) this;
+        Level level = player.level();
+        if (level == null) {
+            return vanillaResult;
+        }
+
+        ShipWorld shipWorld = VSGameUtilsKt.getShipObjectWorld(level);
+        if (shipWorld == null) {
+            return vanillaResult;
+        }
+
+        Ship ship = null;
+        var dragInfo = getDraggingInformation();
+        if (dragInfo != null && dragInfo.getLastShipStoodOn() != null) {
+            ship = shipWorld.getLoadedShips().getById(dragInfo.getLastShipStoodOn());
+        }
+
+        if (ship == null) {
+            return vanillaResult;
+        }
+
+        return backOff(vec3, ship, player, level);
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
@@ -234,67 +234,86 @@ object EntityDragger {
 
     @JvmStatic
     fun backOff(vec3: Vec3, ship: Ship, player: Player, cLevel: Level): Vec3 {
-        var transformedVec = ship.worldToShip.transformDirection(vec3.toJOML(), Vector3d())
+        // Early exit: if there's ground ahead in the movement direction, allow full movement
+        // This lets us walk away from edges without being blocked
+        val movementLength = vec3.length()
+        if (movementLength > 0) {
+            val checkDistance = movementLength + player.bbWidth
+            val checkOffset = vec3.normalize().scale(checkDistance)
+            val checkPosWorld = player.position().add(checkOffset)
+            // Transform to ship space for the raycast (where ship blocks actually exist)
+            val checkPosShip = ship.worldToShip.transformPosition(checkPosWorld.toJOML(), Vector3d())
+            val checkStart = Vec3(checkPosShip.x(), checkPosShip.y(), checkPosShip.z())
+            val checkEnd = Vec3(checkPosShip.x(), checkPosShip.y() - player.maxUpStep().toDouble(), checkPosShip.z())
+            val clipContext = ClipContext(checkStart, checkEnd, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, player)
+            val result = cLevel.clip(clipContext)
+            if (result.type == HitResult.Type.BLOCK) {
+                // Ground ahead, allow full movement
+                return vec3
+            }
+        }
+
+        val transformedVec = ship.worldToShip.transformDirection(vec3.toJOML(), Vector3d())
         var d = transformedVec.x
-        var e = transformedVec.y
+        val e = transformedVec.y
         var f = transformedVec.z
+        val halfWidth = player.bbWidth / 4.0 // players walking on a moving ship should be careful
 
-        while (d != 0.0 && !isValidWalkablePosition(cLevel, ship, player, d, Direction.EAST)) {
-            if (d < 0.025 && d >= -0.025) {
-                d = 0.0
-            } else if (d > 0.0) {
-                d -= 0.025
+        val stepDown = player.maxUpStep().toDouble()
+        // Get player position in ship space for axis-specific checks
+        val playerPosShip = ship.worldToShip.transformPosition(player.position().toJOML(), Vector3d())
+
+        // Early exit for X axis: check both sides (offset by halfWidth in Z) for ground ahead
+        if (d != 0.0) {
+            val xCheckDist = d + (if (d > 0) -halfWidth else halfWidth)
+            // Check in ship space (where ship blocks actually exist)
+            val xStart1 = Vec3(playerPosShip.x() + xCheckDist, playerPosShip.y(), playerPosShip.z() + halfWidth)
+            val xEnd1 = Vec3(xStart1.x, xStart1.y - stepDown, xStart1.z)
+            val xResult1 = cLevel.clip(ClipContext(xStart1, xEnd1, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, player))
+
+            val xStart2 = Vec3(playerPosShip.x() + xCheckDist, playerPosShip.y(), playerPosShip.z() - halfWidth)
+            val xEnd2 = Vec3(xStart2.x, xStart2.y - stepDown, xStart2.z)
+            val xResult2 = cLevel.clip(ClipContext(xStart2, xEnd2, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, player))
+
+            if (xResult1.type == HitResult.Type.BLOCK || xResult2.type == HitResult.Type.BLOCK) {
+                d = transformedVec.x // Ground ahead on at least one side, keep original X movement
             } else {
-                d += 0.025
+                while (d != 0.0 && !isValidWalkablePosition(cLevel, ship, player, d, Direction.EAST, halfWidth)) {
+                    if (d < 0.05 && d >= -0.05) {
+                        d = 0.0
+                    } else if (d > 0.0) {
+                        d -= 0.05
+                    } else {
+                        d += 0.05
+                    }
+                }
             }
         }
 
-        while (f != 0.0 && !isValidWalkablePosition(cLevel, ship, player, f, Direction.SOUTH)) {
-            if (f < 0.025 && f >= -0.025) {
-                f = 0.0
-            } else if (f > 0.0) {
-                f -= 0.025
-            } else {
-                f += 0.025
-            }
-        }
+        // Early exit for Z axis: check both sides (offset by halfWidth in X) for ground ahead
+        if (f != 0.0) {
+            val zCheckDist = f + (if (f > 0) -halfWidth else halfWidth)
+            // Check in ship space (where ship blocks actually exist)
+            val zStart1 = Vec3(playerPosShip.x() + halfWidth, playerPosShip.y(), playerPosShip.z() + zCheckDist)
+            val zEnd1 = Vec3(zStart1.x, zStart1.y - stepDown, zStart1.z)
+            val zResult1 = cLevel.clip(ClipContext(zStart1, zEnd1, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, player))
 
-        while (e != 0.0 && !isValidWalkablePosition(cLevel, ship, player, e, Direction.UP)) {
-            if (e < 0.025 && e >= -0.025) {
-                e = 0.0
-            } else if (e > 0.0) {
-                e -= 0.025
-            } else {
-                e += 0.025
-            }
-        }
+            val zStart2 = Vec3(playerPosShip.x() - halfWidth, playerPosShip.y(), playerPosShip.z() + zCheckDist)
+            val zEnd2 = Vec3(zStart2.x, zStart2.y - stepDown, zStart2.z)
+            val zResult2 = cLevel.clip(ClipContext(zStart2, zEnd2, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, player))
 
-        while (d != 0.0 && f != 0.0 && e != 0.0 &&
-            !isValidWalkablePosition(cLevel, ship, player, d, Direction.EAST) &&
-            !isValidWalkablePosition(cLevel, ship, player, f, Direction.SOUTH) &&
-            !isValidWalkablePosition(cLevel, ship, player, e, Direction.UP)) {
-            if (d < 0.025 && d >= -0.025) {
-                d = 0.0
-            } else if (d > 0.0) {
-                d -= 0.025
+            if (zResult1.type == HitResult.Type.BLOCK || zResult2.type == HitResult.Type.BLOCK) {
+                f = transformedVec.z // Ground ahead on at least one side, keep original Z movement
             } else {
-                d += 0.025
-            }
-
-            if (f < 0.025 && f >= -0.025) {
-                f = 0.0
-            } else if (f > 0.0) {
-                f -= 0.025
-            } else {
-                f += 0.025
-            }
-
-            if (e < 0.025 && e >= -0.025) {
-                e = 0.0
-            } else if (e > 0.0) {
-                e -= 0.025
-            } else {
-                e += 0.025
+                while (f != 0.0 && !isValidWalkablePosition(cLevel, ship, player, f, Direction.SOUTH, halfWidth)) {
+                    if (f < 0.05 && f >= -0.05) {
+                        f = 0.0
+                    } else if (f > 0.0) {
+                        f -= 0.05
+                    } else {
+                        f += 0.05
+                    }
+                }
             }
         }
 
@@ -303,27 +322,14 @@ object EntityDragger {
     }
 
     private fun isValidWalkablePosition(
-        level: Level, ship: Ship, player: Player, step: Double, dir: Direction
+        level: Level, ship: Ship, player: Player, step: Double, dir: Direction, halfWidth: Double
     ): Boolean {
-        // todo: eventually figure this out
-        // val downDirInShip: Vector3dc? = ship.worldToShip.transformDirection(
-        //     Vector3d(0.0, -1.0, 0.0), Vector3d()
-        // ).normalize().mul(player.maxUpStep().toDouble())
-        //
-        // val potentialMovement = ship.transform.shipToWorld.transformDirection(Vector3d(dir.step())).normalize().mul(step).add(downDirInShip)
-        //
-        // val shipPolygons = EntityShipCollisionUtils.getShipPolygonsCollidingWithEntity(
-        //     player, potentialMovement.toMinecraft(), player.getBoundingBox().inflate(-0.1), level
-        // )
-        // val noWorldCollision = level.noCollision(player, player.getBoundingBox().move(potentialMovement.toMinecraft()))
-        //
-        // val noCollision = noWorldCollision && shipPolygons.isEmpty()
-        val clipContext = stepTowardsEdge(level, ship, player, step, dir)
+        val clipContext = stepTowardsEdge(ship, player, step, dir, halfWidth)
         val result = level.clip(clipContext)
         if (result.type != HitResult.Type.BLOCK) {
             return false
         }
-        //get the normal of the hit face in worldspace
+
         val hitShip = level.getLoadedShipManagingPos(result.blockPos)
         if (hitShip != null) {
             val hitSide = result.direction.normal.toJOMLD()
@@ -335,22 +341,22 @@ object EntityDragger {
                 return false
             }
         }
-
         return true
     }
 
     private fun stepTowardsEdge(
-        level: Level?, ship: Ship, player: Player, step: Double, dir: Direction
+        ship: Ship, player: Player, step: Double, dir: Direction, halfWidth: Double
     ): ClipContext {
-        val potentialPosition = player.position().add(ship.transform.shipToWorld.transformDirection(Vector3d(dir.step())).normalize().mul(step).toMinecraft())
-        val downDirInShip: Vector3dc? = ship.worldToShip.transformDirection(
-            Vector3d(0.0, -1.0, 0.0), Vector3d()
-        ).normalize().mul(player.maxUpStep().toDouble())
+        // Calculate check position: movement - half player width in movement direction
+        val dirVec = ship.transform.shipToWorld.transformDirection(Vector3d(dir.step())).normalize()
+        val offsetDistance = step + (if (step > 0) -halfWidth else halfWidth)
+        val potentialPosition = player.position().add(dirVec.mul(offsetDistance).toMinecraft())
 
-        val maxDistPos: Vector3dc = potentialPosition.toJOML().add(downDirInShip, Vector3d())
+        // Raycast downward to check for ground
+        val maxDistPos = potentialPosition.add(0.0, -player.maxUpStep().toDouble(), 0.0)
 
         return ClipContext(
-            potentialPosition, maxDistPos.toMinecraft(), ClipContext.Block.COLLIDER,
+            potentialPosition, maxDistPos, ClipContext.Block.COLLIDER,
             ClipContext.Fluid.NONE, player
         )
     }


### PR DESCRIPTION
Now sneaking on a ship works as it should, where you can walk at a slower speed without falling off the edge of the ship.

Limitations: sometimes it doesn't let you walk while shifting if you're right in the corner of a block, or standing on something narrow like a fence post