### PR TITLE
[1.20.1] Gradle Cleanup - Less Transitive Dependencies and Repository Content Exclusion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,18 +97,26 @@ subprojects {
             }
             maven {
                 url = "https://cursemaven.com"
-                content { includeGroup("curse.maven") }
+                content {
+                    includeGroup("curse.maven")
+                }
             }
-            maven { // Mod Menu
+            maven {
+                name = "Mod Menu"
                 url = "https://maven.terraformersmc.com/releases/"
-                content { includeGroup("com.terraformersmc") }
+                content {
+                    includeGroup("com.terraformersmc")
+                }
             }
             maven {
                 name = 'Kotlin for Forge'
                 url = 'https://thedarkcolour.github.io/KotlinForForge/'
-                content { includeGroup("thedarkcolour") }
+                content {
+                    includeGroup("thedarkcolour")
+                }
             }
             maven {
+                name = "Registrate"
                 name = 'tterrag maven'
                 url = 'https://maven.tterrag.com/'
                 content {
@@ -116,26 +124,36 @@ subprojects {
                     includeGroup("com.tterrag.registrate_fabric")
                 }
             }
-            maven { // Twilight Forest
+            maven {
+                name = "Twilight Forest, TeamReborn Energy API"
                 url = "https://modmaven.dev/"
                 content {
                     includeGroup("teamtwilight")
                     includeGroup("teamreborn")
                 }
             }
-            maven { // LazyDFU, Suggestion Tweaker, Create Big Cannons
+            maven {
+                name = "LazyDFU, Suggestion Tweaker"
                 url = "https://api.modrinth.com/maven"
-                content { includeGroup("maven.modrinth") }
+                content {
+                    includeGroup("maven.modrinth")
+                }
             }
-            maven { // Cloth Config, REI
+            maven {
+                name = "Cloth Config, REI"
                 url = "https://maven.shedaniel.me/"
-                content { includeGroup("me.shedaniel") }
+                content {
+                    includeGroup("me.shedaniel")
+                }
             }
             maven {
                 url = "https://maven.architectury.dev/"
-                content { includeGroup("dev.architectury") }
+                content {
+                    includeGroup("dev.architectury")
+                }
             }
-            maven { // Create, Ponder, Flywheel
+            maven {
+                name = "Create, Ponder, Flywheel"
                 url = "https://maven.createmod.net"
                 content {
                     includeGroup("com.simibubi.create")
@@ -143,21 +161,30 @@ subprojects {
                     includeGroup("dev.engine-room.flywheel")
                 }
             }
-            maven { // Registrate
+            maven {
+                name = "Registrate"
                 url = "https://maven.ithundxr.dev/mirror"
-                content { includeGroup("com.tterrag.registrate") }
+                content {
+                    includeGroup("com.tterrag.registrate")
+                }
             }
-            maven { // ForgeConfigAPIPort
+            maven {
+                name = "ForgeConfigAPIPort"
                 url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/"
-                content { includeGroup("fuzs.forgeconfigapiport") }
+                content {
+                    includeGroup("fuzs.forgeconfigapiport")
+                }
             }
 
-            // mavens for Create Fabric and dependencies
-            maven { // Porting Lib releases
+            maven {
+                name = "Porting Lib releases"
                 url = "https://mvn.devos.one/releases"
-                content { includeGroup("io.github.fabricators_of_create.Porting-Lib") }
+                content {
+                    includeGroup("io.github.fabricators_of_create.Porting-Lib")
+                }
             }
-            maven { // Create and several dependencies
+            maven {
+                name = "Create and several dependencies"
                 url = "https://mvn.devos.one/snapshots/"
                 content {
                     includeGroup("io.github.tropheusj")
@@ -166,26 +193,41 @@ subprojects {
                     includeGroup("com.tterrag.registrate_fabric")
                 }
             }
-            maven { // Fake Player API
+            maven {
+                name = "Fake Player API"
                 url = "https://maven.cafeteria.dev/releases"
-                content { includeGroup("dev.cafeteria") }
-            }
-            maven { // Reach Entity Attributes
-                url = "https://maven.jamieswhiteshirt.com/libs-release"
-                content { includeGroup("com.jamieswhiteshirt") }
-            }
-            maven { // Fabric ASM for Porting Lib
-                url = "https://jitpack.io/"
-                content { includeGroupAndSubgroups("com.github") }
-            }
-
-            maven { // Create Big Cannons
-                url = "https://maven.realrobotix.me/master/"
-                content { includeGroup("com.rbasamoyai") }
+                content {
+                    includeGroup("dev.cafeteria")
+                }
             }
             maven {
+                name = "Reach Entity Attributes"
+                url = "https://maven.jamieswhiteshirt.com/libs-release"
+                content {
+                    includeGroup("com.jamieswhiteshirt")
+                }
+            }
+            maven {
+                name = "Jitpack"
+                url = "https://jitpack.io/"
+                content {
+                    includeGroupAndSubgroups("com.github")
+                }
+            }
+
+            maven {
+                name = "Ritchie's Projectile Lib"
+                url = "https://maven.realrobotix.me/master/"
+                content {
+                    includeGroup("com.rbasamoyai")
+                }
+            }
+            maven {
+                name = "Create Big Cannons"
                 url = "https://maven.realrobotix.me/createbigcannons/"
-                content { includeGroup("com.rbasamoyai") }
+                content {
+                    includeGroup("com.rbasamoyai")
+                }
             }
             maven {
                 name = "CC-Tweaked"
@@ -201,7 +243,8 @@ subprojects {
                     includeGroup("dev.ftb.mods")
                 }
             }
-            maven { // Hexcasting
+            maven {
+                name = "Hexcasting, Paucal, Patchouli"
                 url = "https://maven.blamejared.com"
                 content {
                     includeGroup("at.petra-k.hexcasting")
@@ -209,11 +252,15 @@ subprojects {
                     includeGroup("vazkii.patchouli")
                 }
             }
-            maven { // Hexical via temporary Maven
+            maven {
+                name = "[Temporary] Hexical"
                 url = "https://maven.pool.net.eu.org/"
-                content { includeGroup("miyucomics.hexical") }
+                content {
+                    includeGroup("miyucomics.hexical")
+                }
             }
-            maven { // Hexal
+            maven {
+                name = "Hexal"
                 url = uri("https://maven.hexxy.media")
                 content {
                     includeGroup("ram.talia.hexal")

--- a/build.gradle
+++ b/build.gradle
@@ -90,44 +90,103 @@ subprojects {
 
         mavenCentral()
         if (!project.block_external_repositories) {
-            maven {
-                url = "https://maven.realrobotix.me/master/"
-            }
             mavenLocal()
             maven {
                 name = "ParchmentMC"
                 url = "https://maven.parchmentmc.org"
             }
-            maven { url = "https://cursemaven.com" }
-            maven { url = "https://maven.terraformersmc.com/releases/" } // Mod Menu
+            maven {
+                url = "https://cursemaven.com"
+                content { includeGroup("curse.maven") }
+            }
+            maven { // Mod Menu
+                url = "https://maven.terraformersmc.com/releases/"
+                content { includeGroup("com.terraformersmc") }
+            }
             maven {
                 name = 'Kotlin for Forge'
                 url = 'https://thedarkcolour.github.io/KotlinForForge/'
+                content { includeGroup("thedarkcolour") }
             }
             maven {
                 name = 'tterrag maven'
                 url = 'https://maven.tterrag.com/'
+                content {
+                    includeGroup("com.tterrag.registrate")
+                    includeGroup("com.tterrag.registrate_fabric")
+                }
             }
-            maven { url = "https://modmaven.dev/" } // Twilight Forest
-            maven { url = "https://api.modrinth.com/maven" } // LazyDFU, Suggestion Tweaker, Create Big Cannons
-            maven { url = "https://maven.shedaniel.me/" } // Cloth Config, REI
-            maven { url "https://maven.architectury.dev/" }
-            maven { url = "https://maven.createmod.net" } // Create, Ponder, Flywheel
-            maven { url = "https://maven.ithundxr.dev/mirror" } // Registrate
-            maven { url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/" } // ForgeConfigAPIPort
+            maven { // Twilight Forest
+                url = "https://modmaven.dev/"
+                content {
+                    includeGroup("teamtwilight")
+                    includeGroup("teamreborn")
+                }
+            }
+            maven { // LazyDFU, Suggestion Tweaker, Create Big Cannons
+                url = "https://api.modrinth.com/maven"
+                content { includeGroup("maven.modrinth") }
+            }
+            maven { // Cloth Config, REI
+                url = "https://maven.shedaniel.me/"
+                content { includeGroup("me.shedaniel") }
+            }
+            maven {
+                url = "https://maven.architectury.dev/"
+                content { includeGroup("dev.architectury") }
+            }
+            maven { // Create, Ponder, Flywheel
+                url = "https://maven.createmod.net"
+                content {
+                    includeGroup("com.simibubi.create")
+                    includeGroup("net.createmod.ponder")
+                    includeGroup("dev.engine-room.flywheel")
+                }
+            }
+            maven { // Registrate
+                url = "https://maven.ithundxr.dev/mirror"
+                content { includeGroup("com.tterrag.registrate") }
+            }
+            maven { // ForgeConfigAPIPort
+                url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/"
+                content { includeGroup("fuzs.forgeconfigapiport") }
+            }
 
             // mavens for Create Fabric and dependencies
-            maven { url = "https://mvn.devos.one/releases" } // Porting Lib releases
-            maven { url = "https://mvn.devos.one/snapshots/" } // Create and several dependencies
-            maven { url = "https://maven.cafeteria.dev/releases" } // Fake Player API
-            maven { url = "https://maven.jamieswhiteshirt.com/libs-release" } // Reach Entity Attributes
+            maven { // Porting Lib releases
+                url = "https://mvn.devos.one/releases"
+                content { includeGroup("io.github.fabricators_of_create.Porting-Lib") }
+            }
+            maven { // Create and several dependencies
+                url = "https://mvn.devos.one/snapshots/"
+                content {
+                    includeGroup("io.github.tropheusj")
+                    includeGroup("com.simibubi.create")
+                    includeGroup("io.github.fabricators_of_create")
+                    includeGroup("com.tterrag.registrate_fabric")
+                }
+            }
+            maven { // Fake Player API
+                url = "https://maven.cafeteria.dev/releases"
+                content { includeGroup("dev.cafeteria") }
+            }
+            maven { // Reach Entity Attributes
+                url = "https://maven.jamieswhiteshirt.com/libs-release"
+                content { includeGroup("com.jamieswhiteshirt") }
+            }
             maven { // Fabric ASM for Porting Lib
                 url = "https://jitpack.io/"
                 content { includeGroupAndSubgroups("com.github") }
             }
 
-            maven { url = "https://maven.cafeteria.dev/releases" } // Fake Player API
-            maven { url = "https://maven.realrobotix.me/createbigcannons/" } // Create Big Cannons
+            maven { // Create Big Cannons
+                url = "https://maven.realrobotix.me/master/"
+                content { includeGroup("com.rbasamoyai") }
+            }
+            maven {
+                url = "https://maven.realrobotix.me/createbigcannons/"
+                content { includeGroup("com.rbasamoyai") }
+            }
             maven {
                 name = "CC-Tweaked"
                 url = "https://maven.squiddev.cc"
@@ -142,24 +201,33 @@ subprojects {
                     includeGroup("dev.ftb.mods")
                 }
             }
-
-            maven {
-                name = "Forge Config Api Port"
-                url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/"
-            }
             maven { // Hexcasting
                 url = "https://maven.blamejared.com"
+                content {
+                    includeGroup("at.petra-k.hexcasting")
+                    includeGroup("at.petra-k.paucal")
+                    includeGroup("vazkii.patchouli")
+                }
             }
             maven { // Hexical via temporary Maven
                 url = "https://maven.pool.net.eu.org/"
+                content { includeGroup("miyucomics.hexical") }
             }
             maven { // Hexal
                 url = uri("https://maven.hexxy.media")
+                content {
+                    includeGroup("ram.talia.hexal")
+                }
             }
         }
         maven {
             name = "Valkyrien Skies Internal"
             url = project.vs_maven_url ?: 'https://maven.valkyrienskies.org'
+            content {
+                includeGroup("org.valkyrienskies")
+                includeGroup("org.valkyrienskies.core")
+                includeGroup("com.fasterxml.jackson.module")
+            }
             if (project.vs_maven_username && project.vs_maven_password) {
                 credentials {
                     username = project.vs_maven_username

--- a/build.gradle
+++ b/build.gradle
@@ -223,11 +223,6 @@ subprojects {
         maven {
             name = "Valkyrien Skies Internal"
             url = project.vs_maven_url ?: 'https://maven.valkyrienskies.org'
-            content {
-                includeGroup("org.valkyrienskies")
-                includeGroup("org.valkyrienskies.core")
-                includeGroup("com.fasterxml.jackson.module")
-            }
             if (project.vs_maven_username && project.vs_maven_password) {
                 credentials {
                     username = project.vs_maven_username

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -72,12 +72,12 @@ dependencies {
     //Bluemap fabric 1.20.1
     modCompileOnly("curse.maven:bluemap-406463:5555756")
 
-    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:imm_ptl_core:${immptl_version}") { transitive = false }
-    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:q_misc_util:${immptl_version}") { transitive = false }
-    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:build:${immptl_version}") { transitive = false }
-    modCompileOnly("com.rbasamoyai:createbigcannons:${createbigcannons_version}+mc.${minecraft_version}-fabric") { transitive = false }
-    modCompileOnly("com.rbasamoyai:createbigcannons:${createbigcannons_version}+mc.${minecraft_version}-forge") { transitive = false }
-    modCompileOnly("com.rbasamoyai:ritchiesprojectilelib:2.1.0+mc.${minecraft_version}-forge") { transitive = false }
+    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:imm_ptl_core:$immptl_version") { transitive = false }
+    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:q_misc_util:$immptl_version") { transitive = false }
+    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:build:$immptl_version") { transitive = false }
+    modCompileOnly("com.rbasamoyai:createbigcannons:$createbigcannons_version+mc.$minecraft_version-fabric") { transitive = false }
+    modCompileOnly("com.rbasamoyai:createbigcannons:$createbigcannons_version+mc.$minecraft_version-forge") { transitive = false }
+    modCompileOnly("com.rbasamoyai:ritchiesprojectilelib:2.1.0+mc.$minecraft_version-forge") { transitive = false }
 }
 
 architectury {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,26 +1,26 @@
 
 dependencies {
-    implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1"))
+    implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:$mixinextras_version"))
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     // We depend on fabric loader here to use the fabric @Environment annotations
     // Do NOT use other classes from fabric loader
-    modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
+    modImplementation "net.fabricmc:fabric-loader:$fabric_loader_version"
 
-    modCompileOnly "fuzs.forgeconfigapiport:forgeconfigapiport-common:${rootProject.fcap_version}"
+    modCompileOnly("fuzs.forgeconfigapiport:forgeconfigapiport-common:$fcap_version")  { transitive = false }
 
-    modCompileOnly("maven.modrinth:sodium:${sodium_version}")
+    modCompileOnly("maven.modrinth:sodium:$sodium_version")
 
     // vs-core
-    runtimeOnly("org.valkyrienskies.core:impl:${rootProject.vs_core_version}") {
+    runtimeOnly("org.valkyrienskies.core:impl:$vs_core_version") {
         exclude module: "netty-buffer"
         exclude module: "fastutil"
     }
-    implementation("org.valkyrienskies.core:api:${rootProject.vs_core_version}")
-    implementation("org.valkyrienskies.core:internal:${rootProject.vs_core_version}")
-    implementation("org.valkyrienskies.core:util:${rootProject.vs_core_version}")
+    implementation("org.valkyrienskies.core:api:$vs_core_version")
+    implementation("org.valkyrienskies.core:internal:$vs_core_version")
+    implementation("org.valkyrienskies.core:util:$vs_core_version")
 
-    implementation("com.google.guava:guava:31.1-jre")
+    compileOnly("com.google.guava:guava:31.1-jre")
 
     // FTB Stuffs
     //modCompileOnly("dev.ftb.mods:ftb-chunks-forge:2001.3.6") { transitive = false }
@@ -29,16 +29,16 @@ dependencies {
     modCompileOnly("curse.maven:weather-storms-tornadoes-237746:5244118")
 
     // TIS-3d
-    modCompileOnly("maven.modrinth:tis3d:${tis3d_version}")
+    modCompileOnly("maven.modrinth:tis3d:$tis3d_version")
 
     // CC-Tweaked
-    modCompileOnly("cc.tweaked:cc-tweaked-${minecraft_version}-common:${cc_tweaked_version}")
+    modCompileOnly("cc.tweaked:cc-tweaked-$minecraft_version-common:$cc_tweaked_version")
 
     // Dynmap
-    modCompileOnly("maven.modrinth:dynmap:${dynmap_version}")
+    modCompileOnly("maven.modrinth:dynmap:$dynmap_version")
 
     // Hexcasting
-    modCompileOnly("at.petra-k.hexcasting:hexcasting-common-$minecraft_version:$hexcasting_version")
+    modCompileOnly("at.petra-k.hexcasting:hexcasting-common-$minecraft_version:$hexcasting_version") { transitive = false }
 
     // HexTweaks
     modCompileOnly("maven.modrinth:hextweaks:$hextweaks_version")
@@ -56,18 +56,14 @@ dependencies {
     modCompileOnly("curse.maven:entity-model-features-844662:5696901")
     modCompileOnly("curse.maven:entity-texture-features-fabric-568563:5697084")
 
-    // Weather2 1.20.1
-    modCompileOnly("curse.maven:weather-storms-tornadoes-237746:5244118")
-
     //Common create compat,
     //We just use a version from a platform and hope the classes exist on both versions and mixins apply correctly
-    modCompileOnly("com.simibubi.create:create-fabric:${create_fabric_version}")
-        { exclude group: 'com.github.AlphaMode', module: 'fakeconfigtoml' }
-    modCompileOnly("net.fabricmc.fabric-api:fabric-api:${fabric_api_version}")
+    modCompileOnly("com.simibubi.create:create-fabric:$create_fabric_version")
+    modCompileOnly("net.fabricmc.fabric-api:fabric-api:$fabric_api_version") { transitive = false }
     modCompileOnly("curse.maven:vanillin-965702:6446557")
 
-    modCompileOnly("maven.modrinth:create-utilities:${create_utilities_version}")
-    modImplementation("teamreborn:energy:${energy_version}")
+    modCompileOnly("maven.modrinth:create-utilities:$create_utilities_version")
+    modImplementation("teamreborn:energy:$energy_version") { transitive = false }
     // modCompileOnly("io.github.fabricators_of_create:Porting-Lib:${port_lib_version}+${minecraft_version}")
 
     //Very many players
@@ -76,12 +72,12 @@ dependencies {
     //Bluemap fabric 1.20.1
     modCompileOnly("curse.maven:bluemap-406463:5555756")
 
-    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:imm_ptl_core:${immptl_version}")
-    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:q_misc_util:${immptl_version}")
-    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:build:${immptl_version}")
+    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:imm_ptl_core:${immptl_version}") { transitive = false }
+    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:q_misc_util:${immptl_version}") { transitive = false }
+    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:build:${immptl_version}") { transitive = false }
     modCompileOnly("com.rbasamoyai:createbigcannons:${createbigcannons_version}+mc.${minecraft_version}-fabric") { transitive = false }
     modCompileOnly("com.rbasamoyai:createbigcannons:${createbigcannons_version}+mc.${minecraft_version}-forge") { transitive = false }
-    modCompileOnly("com.rbasamoyai:ritchiesprojectilelib:2.1.0+mc.${minecraft_version}-forge")
+    modCompileOnly("com.rbasamoyai:ritchiesprojectilelib:2.1.0+mc.${minecraft_version}-forge") { transitive = false }
 }
 
 architectury {

--- a/common/gradle.properties
+++ b/common/gradle.properties
@@ -2,9 +2,6 @@
 port_lib_version=2.1.1127+1.20
 port_lib_modules = accessors,base,entity,extensions,fake_players,networking,obj_loader,tags,transfer,models,tool_actions,client_events,brewing
 
-# https://modrinth.com/mod/cloth-config/version/8.3.103+fabric
-cloth_config_version = 11.1.106
-
 # https://modrinth.com/mod/sodium/versions
 sodium_version = mc1.20.1-0.5.13-fabric
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -25,9 +25,9 @@ loom {
 }
 
 dependencies {
-    include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.5.0")))
+    include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:$mixinextras_version")))
 
-    modImplementation("net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}")
+    modImplementation("net.fabricmc:fabric-loader:$fabric_loader_version")
 
     common(project(path: ":common", configuration: "namedElements")) {
         transitive = false
@@ -37,34 +37,34 @@ dependencies {
     }
 
     // Depend on the fabric kotlin mod
-    include(modImplementation("net.fabricmc:fabric-language-kotlin:${kotlin_fabric_version}"))
+    include(modImplementation("net.fabricmc:fabric-language-kotlin:$kotlin_fabric_version"))
 
-    include(modImplementation "fuzs.forgeconfigapiport:forgeconfigapiport-fabric:${rootProject.fcap_version}")
+    include(modImplementation "fuzs.forgeconfigapiport:forgeconfigapiport-fabric:$fcap_version")
     modRuntimeOnly("maven.modrinth:forge-config-screens:v8.0.2-1.20.1-Fabric")
 
 
-    modCompileOnly("maven.modrinth:create-utilities:${create_utilities_version}")
-    modCompileOnly("maven.modrinth:sodium:${sodium_version}")
+    modCompileOnly("maven.modrinth:create-utilities:$create_utilities_version")
+    modCompileOnly("maven.modrinth:sodium:$sodium_version")
     // Disable indium until we update sodium to newer versions
     //modRuntimeOnly("maven.modrinth:indium:${indium_version}")
-    modImplementation("maven.modrinth:modmenu:${modmenu_version}")
+    modCompileOnly("maven.modrinth:modmenu:$modmenu_version")
+    modRuntimeOnly("maven.modrinth:modmenu:$modmenu_version")
 
     // Depend on the fabric API
-    modImplementation("net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_api_version}")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:$fabric_api_version")
 
-    modImplementation("teamreborn:energy:${energy_version}") {
-        transitive = false
-    }
+    modCompileOnly("teamreborn:energy:$energy_version") { transitive = false }
+    modRuntimeOnly("teamreborn:energy:$energy_version") { transitive = false }
 
-    implementation("org.valkyrienskies.core:internal:${rootProject.vs_core_version}")
-    implementation("org.valkyrienskies.core:util:${rootProject.vs_core_version}")
-    runtimeOnly("org.valkyrienskies.core:impl:${rootProject.vs_core_version}") {
+    implementation("org.valkyrienskies.core:internal:$vs_core_version")
+    implementation("org.valkyrienskies.core:util:$vs_core_version")
+    runtimeOnly("org.valkyrienskies.core:impl:$vs_core_version") {
         exclude module: "netty-buffer"
         exclude module: "fastutil"
         exclude module: "kotlin-stdlib-jdk8"
     }
     // Shade vs-core
-    shadowCommon("org.valkyrienskies.core:impl:${rootProject.vs_core_version}") {
+    shadowCommon("org.valkyrienskies.core:impl:$vs_core_version") {
         exclude module: "netty-buffer"
         exclude module: "fastutil"
         exclude module: "kotlin-stdlib-jdk8" // Don't shade kotlin-stdlib-jdk8, even though vs-core depends on it
@@ -72,16 +72,16 @@ dependencies {
         exclude module: "jsonschema.module.addon"
     }
 
-    include("com.fasterxml:classmate:1.5.1")
-    implementation("com.fasterxml:classmate:1.5.1")
+    include(implementation("com.fasterxml:classmate:1.5.1"))
 
     // CC Tweaked
     //modRuntimeOnly("cc.tweaked:cc-tweaked-${minecraft_version}-fabric:${cc_tweaked_version}")
     // CC Restitched
-    modCompileOnly("maven.modrinth:cc-tweaked:${cc_tweaked_version}")
+    modCompileOnly("maven.modrinth:cc-tweaked:$cc_tweaked_version")
 
     //Very many players
-    modImplementation("curse.maven:vmp-fabric-552542:4754074")
+    modCompileOnly("curse.maven:vmp-fabric-552542:4754074")
+    modRuntimeOnly("curse.maven:vmp-fabric-552542:4754074")
 
     // EMF compat
     //todo: fix
@@ -89,27 +89,17 @@ dependencies {
     modCompileOnly("curse.maven:entity-texture-features-fabric-568563:5697084")
 
     // Create compat
-    modImplementation("com.simibubi.create:create-fabric:${create_fabric_version}") {
-        exclude group: 'com.github.AlphaMode', module: 'fakeconfigtoml'
-    }
-    modImplementation("com.tterrag.registrate_fabric:Registrate:${registrate_version}")
+    modCompileOnly("com.simibubi.create:create-fabric:$create_fabric_version")
+    modRuntimeOnly("com.simibubi.create:create-fabric:$create_fabric_version")
 
-    //modImplementation("io.github.fabricators_of_create.Porting-Lib:Porting-Lib:$port_lib_version")
-    for (String module in port_lib_modules.split(",")) {
-        modCompileOnly("io.github.fabricators_of_create.Porting-Lib:$module:$port_lib_version")
-    }
     modCompileOnly("curse.maven:vanillin-965702:6446557")
-
-    modCompileOnly("curse.maven:forge-config-api-port-fabric-547434:$config_api_id")
-    modCompileOnly("com.jamieswhiteshirt:reach-entity-attributes:${reach_entity_attributes_version}")
-    modCompileOnly("dev.cafeteria:fake-player-api:${fake_player_api_version}")
-    modCompileOnly("io.github.tropheusj:milk-lib:${milk_lib_version}")
+    modRuntimeOnly("curse.maven:vanillin-965702:6446557")
 
     // Dynmap
-    modCompileOnly("maven.modrinth:dynmap:${dynmap_version}")
+    modCompileOnly("maven.modrinth:dynmap:$dynmap_version")
 
     // Hexcasting
-    modCompileOnly("at.petra-k.hexcasting:hexcasting-fabric-${minecraft_version}:${hexcasting_version}")
+    modCompileOnly("at.petra-k.hexcasting:hexcasting-fabric-$minecraft_version:$hexcasting_version") { transitive = false }
 
     // HexTweaks
     modCompileOnly("maven.modrinth:hextweaks:$hextweaks_version")
@@ -123,9 +113,9 @@ dependencies {
     // Hexal
     modCompileOnly("ram.talia.hexal:hexal-fabric-$minecraft_version:$hexal_version") { transitive = false }
 
-    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:imm_ptl_core:${immptl_version}")
-    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:q_misc_util:${immptl_version}")
-    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:build:${immptl_version}")
+    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:imm_ptl_core:$immptl_version") { transitive = false }
+    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:q_misc_util:$immptl_version") { transitive = false }
+    modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:build:$immptl_version") { transitive = false }
 }
 
 // Copy the VS common access widener to the generated resources folder

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -36,8 +36,6 @@ indium_version = 1.0.31+mc1.20.4
 # https://linkie.shedaniel.me/dependencies?loader=fabric&version=1.19.2
 modmenu_version = 7.1.0
 
-# https://linkie.shedaniel.me/dependencies?loader=fabric&version=1.19.2
-cloth_config_version = 11.1.106
 immptl_version=v3.3.9-mc1.20.1
 
 # https://modrinth.com/mod/hexical/versions

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -59,11 +59,11 @@ configurations {
 }
 
 dependencies {
-    implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1"))
-    implementation(include("io.github.llamalad7:mixinextras-forge:0.4.1"))
+    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:$mixinextras_version"))
+    implementation(include("io.github.llamalad7:mixinextras-forge:$mixinextras_version"))
     annotationProcessor("net.fabricmc:sponge-mixin:0.12.5+mixin.0.8.5") // use fabric mixin so we can write interface injectors (conditionally loaded if mixinbooster is enabled)
 
-    forge "net.minecraftforge:forge:${rootProject.forge_version}"
+    forge "net.minecraftforge:forge:$forge_version"
 
     common(project(path: ":common", configuration: "namedElements")) {
         transitive = false
@@ -73,32 +73,38 @@ dependencies {
     }
 
     //modCompileOnly("curse.maven:rubidium-574856:4024781")
-    modCompileOnly("maven.modrinth:embeddium:${embeddium_version}")
+    modCompileOnly("maven.modrinth:embeddium:$embeddium_version")
 
     modRuntimeOnly("maven.modrinth:forge-config-screens:v8.0.2-1.20.1-Forge")
 
     // Twilight Forest
-    modImplementation("teamtwilight:twilightforest:${twilightforest_version}:universal")
+    modCompileOnly("teamtwilight:twilightforest:$twilightforest_version:universal")
+    modRuntimeOnly("teamtwilight:twilightforest:$twilightforest_version:universal")
 
     // Create compat
-    modImplementation("com.simibubi.create:create-${minecraft_version}:${create_version}:slim") { transitive = false }
-    modImplementation("net.createmod.ponder:Ponder-Forge-${minecraft_version}:${ponder_version}")
-    modImplementation("curse.maven:vanillin-965702:6446560")
-    modCompileOnly("dev.engine-room.flywheel:flywheel-forge-api-${minecraft_version}:${flywheel_version}")
-    modRuntimeOnly("dev.engine-room.flywheel:flywheel-forge-${minecraft_version}:${flywheel_version}")
-    modImplementation("com.tterrag.registrate:Registrate:${registrate_version}")
+    modCompileOnly("com.simibubi.create:create-$minecraft_version:$create_version:slim") { transitive = false }
+    modRuntimeOnly("com.simibubi.create:create-$minecraft_version:$create_version:slim") { transitive = false }
+    modCompileOnly("net.createmod.ponder:Ponder-Forge-$minecraft_version:$ponder_version")
+    modRuntimeOnly("net.createmod.ponder:Ponder-Forge-$minecraft_version:$ponder_version")
+    modCompileOnly("dev.engine-room.flywheel:flywheel-forge-api-$minecraft_version:$flywheel_version")
+    modRuntimeOnly("dev.engine-room.flywheel:flywheel-forge-$minecraft_version:$flywheel_version")
+    modRuntimeOnly("com.tterrag.registrate:Registrate:$registrate_version")
+
+    modCompileOnly("curse.maven:vanillin-965702:6446560")
+    modRuntimeOnly("curse.maven:vanillin-965702:6446560")
 
     // Weather2 1.20.1
-    modImplementation("curse.maven:weather-storms-tornadoes-237746:5244118")
-    modImplementation("curse.maven:coroutil-237749:5096038")
+    modRuntimeOnly("curse.maven:weather-storms-tornadoes-237746:5244118")
+    modRuntimeOnly("curse.maven:coroutil-237749:5096038")
 
     // CC Tweaked
-    modRuntimeOnly("cc.tweaked:cc-tweaked-${minecraft_version}-forge:${cc_tweaked_version}")
+    modRuntimeOnly("cc.tweaked:cc-tweaked-$minecraft_version-forge:$cc_tweaked_version")
 
-    modImplementation("curse.maven:vmp-forge-892037:4657678")
+    modCompileOnly("curse.maven:vmp-forge-892037:4657678")
+    modRuntimeOnly("curse.maven:vmp-forge-892037:4657678")
 
     // OpenComputers 2: Reimagined
-    modCompileOnly("maven.modrinth:oc2r:${oc2r_version}")
+    modCompileOnly("maven.modrinth:oc2r:$oc2r_version")
 
     // EMF compat
     //todo: fix
@@ -106,11 +112,10 @@ dependencies {
     modCompileOnly("curse.maven:entity-texture-features-fabric-568563:5697083")
 
     modCompileOnly("maven.modrinth:create-utilities:0.2.0+1.20.1")
-    modImplementation("teamreborn:energy:${energy_version}") {
-        transitive = false
-    }
+    modCompileOnly("teamreborn:energy:$energy_version") { transitive = false }
+
     // TIS-3d
-    modCompileOnly("maven.modrinth:tis3d:${tis3d_version}")
+    modCompileOnly("maven.modrinth:tis3d:$tis3d_version")
 
     // Modular Routers
     modCompileOnly("curse.maven:mr-250294:4696089")
@@ -122,10 +127,10 @@ dependencies {
     modCompileOnly("maven.modrinth:epic-fight:20.10.3")
 
     // Dynmap
-    modCompileOnly("maven.modrinth:dynmap:${dynmap_version}")
+    modCompileOnly("maven.modrinth:dynmap:$dynmap_version")
 
     // Hexcasting
-    modCompileOnly("at.petra-k.hexcasting:hexcasting-forge-${minecraft_version}:${hexcasting_version}") { transitive = false }
+    modCompileOnly("at.petra-k.hexcasting:hexcasting-forge-$minecraft_version:$hexcasting_version") { transitive = false }
 
     // HexTweaks
     modCompileOnly("maven.modrinth:hextweaks:$hextweaks_version")
@@ -145,53 +150,50 @@ dependencies {
     //modCompileOnly("maven.modrinth:vmp-forge:0.2.0+beta.7.101+1.20.1")
 
     // TerraFirmaCraft
-    modCompileOnly("curse.maven:terrafirmacraft-302973:${tfc_version}")
+    modCompileOnly("curse.maven:terrafirmacraft-302973:$tfc_version")
 
     // Mekanism
-    modCompileOnly ("curse.maven:mekanism-268560:4644795")
+    modCompileOnly("curse.maven:mekanism-268560:4644795")
 
     // Add Kotlin for Forge (3.12.0)
-    forgeRuntimeLibrary("maven.modrinth:kotlin-for-forge:${kotlin_version}")
-
-    // Cloth for config
-    include(modImplementation("me.shedaniel.cloth:cloth-config-forge:${cloth_config_version}"))
+    forgeRuntimeLibrary("maven.modrinth:kotlin-for-forge:$kotlin_version")
 
     // Shade vs-core
-    implementation("org.valkyrienskies.core:util:${rootProject.vs_core_version}")
-    implementation("org.valkyrienskies.core:internal:${rootProject.vs_core_version}") {
+    implementation("org.valkyrienskies.core:util:$vs_core_version")
+    implementation("org.valkyrienskies.core:internal:$vs_core_version") {
         exclude group: 'org.joml', module: 'joml'
     }
-    runtimeOnly("org.valkyrienskies.core:impl:${rootProject.vs_core_version}") {
+    runtimeOnly("org.valkyrienskies.core:impl:$vs_core_version") {
         exclude group: 'org.joml', module: 'joml'
     }
-    forgeRuntimeLibrary shadowCommon("org.valkyrienskies.core:impl:${rootProject.vs_core_version}") {
+    forgeRuntimeLibrary shadowCommon("org.valkyrienskies.core:impl:$vs_core_version") {
         exclude group: 'org.joml', module: 'joml'
         transitive = false
     }
 
 
     // region Manually include every single dependency of vs-core (total meme)
-    forgeRuntimeLibrary include("org.valkyrienskies.core:api:${rootProject.vs_core_version}") {
+    forgeRuntimeLibrary include("org.valkyrienskies.core:api:$vs_core_version") {
         exclude group: 'org.joml', module: 'joml'
         transitive = false
     }
 
-    forgeRuntimeLibrary shadowCommon("org.valkyrienskies.core:internal:${rootProject.vs_core_version}") {
+    forgeRuntimeLibrary shadowCommon("org.valkyrienskies.core:internal:$vs_core_version") {
         exclude group: 'org.joml', module: 'joml'
         transitive = false
     }
 
-    forgeRuntimeLibrary include("org.valkyrienskies.core:util:${rootProject.vs_core_version}") {
+    forgeRuntimeLibrary include("org.valkyrienskies.core:util:$vs_core_version") {
         exclude group: 'org.joml', module: 'joml'
         transitive = false
     }
 
-    forgeRuntimeLibrary shadowCommon("org.valkyrienskies:physics_api_krunch:${rootProject.krunch_version}") {
+    forgeRuntimeLibrary shadowCommon("org.valkyrienskies:physics_api_krunch:$krunch_version") {
         exclude group: 'org.joml', module: 'joml'
         transitive = false
     }
 
-    forgeRuntimeLibrary shadowCommon("org.valkyrienskies:physics_api:${rootProject.krunch_api_version}") {
+    forgeRuntimeLibrary shadowCommon("org.valkyrienskies:physics_api:$krunch_api_version") {
         exclude group: 'org.joml', module: 'joml'
         transitive = false
     }

--- a/forge/gradle.properties
+++ b/forge/gradle.properties
@@ -3,7 +3,6 @@ loom.platform=forge
 kotlin.stdlib.default.dependency=false
 #Deps
 kotlin_version = 4.11.0
-cloth_config_version = 11.1.106
 
 #Compat
 # https://wiki.createmod.net/developers/depend-on-create/forge-1.20.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,9 @@ archives_base_name=valkyrienskies-120
 mod_version=2.4.0
 maven_group=org.valkyrienskies.mod
 
+# https://github.com/LlamaLad7/MixinExtras/releases
+mixinextras_version=0.5.0
+
 # https://www.curseforge.com/minecraft/mc-mods/architectury-api/files/
 architectury_version=9.1.12
 


### PR DESCRIPTION
So, to lower the burden of depending on VS in other projects and to speed up the build time of VS itself, I have refactored, removed, and improved Gradle dependencies and repostories

# Transitive Cleanup
So, the hardest part of depending on VS is the over abundance of transitive dependencies it brings with it. Not every addon or project needs Create pulled from VS nor VMP.

So, to clean this up, I swapped `modImplementation` dependencies for a combination of `modCompileOnly` and `modRuntimeOnly`. This makes such dependencies non-transitive and thus will not show up in projects depending on VS.

I also removed dependencies we no longer need, like Cloth Config, and duplicates, like Weather 2.

# Repository Content Exclusion
Another issue is the build time of VS, which is not helped when all the dependencies are trying to pull from *every* repository. To prevent this, I have acced `content { }` blocks to most, if not all, repositories so searching for the correct repository is ***much*** faster.