### PR TITLE
Fix Hexical version in gradle.properties

### DIFF
--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -41,4 +41,4 @@ cloth_config_version = 11.1.106
 immptl_version=v3.3.9-mc1.20.1
 
 # https://modrinth.com/mod/hexical/versions
-hexical_version=2.0.0
+hexical_version=2.0.0+e5118cdd


### PR DESCRIPTION
Version 2.0.0 isn't on Pool's maven, he specified another one should be used