### PR TITLE
Disable worldgen in shipyard with Terra installed

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -83,6 +83,9 @@ dependencies {
     //Very many players
     modImplementation("curse.maven:vmp-fabric-552542:4754074")
 
+    // Terra
+    modCompileOnly("maven.modrinth:terra:6.3.1-BETA-fabric")
+
     // EMF compat
     //todo: fix
     modCompileOnly("curse.maven:entity-model-features-844662:5696901")

--- a/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/compat/terra/MixinMinecraftChunkGeneratorWrapper.java
+++ b/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/compat/terra/MixinMinecraftChunkGeneratorWrapper.java
@@ -1,0 +1,93 @@
+package org.valkyrienskies.mod.fabric.mixin.compat.terra;
+
+import com.dfsek.terra.mod.generation.MinecraftChunkGeneratorWrapper;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import net.minecraft.core.Holder;
+import net.minecraft.server.level.WorldGenRegion;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.LevelHeightAccessor;
+import net.minecraft.world.level.NoiseColumn;
+import net.minecraft.world.level.StructureManager;
+import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.biome.BiomeManager;
+import net.minecraft.world.level.biome.BiomeSource;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import net.minecraft.world.level.levelgen.GenerationStep.Carving;
+import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
+import net.minecraft.world.level.levelgen.NoiseSettings;
+import net.minecraft.world.level.levelgen.RandomState;
+import net.minecraft.world.level.levelgen.blending.Blender;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.valkyrienskies.mod.common.VS2ChunkAllocator;
+
+@Mixin(MinecraftChunkGeneratorWrapper.class)
+public abstract class MixinMinecraftChunkGeneratorWrapper extends ChunkGenerator {
+    @Shadow
+    @Final
+    private Holder<NoiseGeneratorSettings> settings;
+
+    @Inject(method = "getBaseColumn", at = @At("HEAD"), cancellable = true)
+    private void preGetBaseColumn(int i, int j, LevelHeightAccessor levelHeightAccessor, RandomState randomState, CallbackInfoReturnable<NoiseColumn> cir) {
+        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(i, j)) {
+            final NoiseSettings noiseSettings = this.settings.value().noiseSettings();
+            final int k = Math.max(noiseSettings.minY(), levelHeightAccessor.getMinBuildHeight());
+            cir.setReturnValue(new NoiseColumn(k, new BlockState[0]));
+            cir.cancel();
+        }
+    }
+
+    @Inject(method = "buildSurface", at = @At("HEAD"), cancellable = true)
+    private void preBuildSurface(WorldGenRegion worldGenRegion, StructureManager structureManager, RandomState randomState, ChunkAccess chunkAccess, CallbackInfo ci) {
+        final ChunkPos chunkPos = chunkAccess.getPos();
+        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "applyCarvers", at = @At("HEAD"), cancellable = true)
+    private void preApplyCarvers(WorldGenRegion worldGenRegion, long l, RandomState randomState, BiomeManager biomeManager, StructureManager structureManager, ChunkAccess chunkAccess, Carving carving, CallbackInfo ci) {
+        final ChunkPos chunkPos = chunkAccess.getPos();
+        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "fillFromNoise", at = @At("HEAD"), cancellable = true)
+    private void preFillFromNoise(Executor executor, Blender blender, RandomState randomState, StructureManager structureManager, ChunkAccess chunkAccess, CallbackInfoReturnable<CompletableFuture<ChunkAccess>> cir) {
+        final ChunkPos chunkPos = chunkAccess.getPos();
+        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)) {
+            cir.setReturnValue(CompletableFuture.completedFuture(chunkAccess));
+            cir.cancel();
+        }
+    }
+
+    @Inject(method = "spawnOriginalMobs", at = @At("HEAD"), cancellable = true)
+    private void preSpawnOriginalMobs(WorldGenRegion worldGenRegion, CallbackInfo ci) {
+        final ChunkPos chunkPos = worldGenRegion.getCenter();
+        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "applyBiomeDecoration", at = @At("HEAD"), cancellable = true)
+    private void preApplyBiomeDecoration(WorldGenLevel worldGenLevel, ChunkAccess chunkAccess, StructureManager structureManager, CallbackInfo callbackInfo) {
+        final ChunkPos chunkPos = chunkAccess.getPos();
+        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)) {
+            callbackInfo.cancel();
+        }
+    }
+
+    // Dummy
+    public MixinMinecraftChunkGeneratorWrapper(BiomeSource biomeSource) {
+        super(biomeSource);
+    }
+}

--- a/fabric/src/main/resources/valkyrienskies-fabric.mixins.json
+++ b/fabric/src/main/resources/valkyrienskies-fabric.mixins.json
@@ -6,6 +6,7 @@
   "mixins": [
     "compat.create.MixinBlockBreakingKineticTileEntity",
     "compat.create.MixinControlledContraptionEntity",
+    "compat.terra.MixinMinecraftChunkGeneratorWrapper",
     "entity.MixinContainerEntity",
     "feature.explosions.ClipContextMixin",
     "feature.fix_tp_ships_cross_dimension.MixinLevelChunk",


### PR DESCRIPTION
# ⚒️ Pull Request Offering

> _We shall not introduce more regressions  \
> Lest we face eternal digressions_

---
## 🧾 What This PR Does
- Bug fix: VS2 has mixins to disable vanilla worldgen but this does not apply to mod chunk generators. One example is Terra.

## 🔍 How This Was Tested
- [ ] GameTest framework  
- [x] Singleplayer / Server  
- [ ] Logs looked sane  
- [x] The vibes felt right *(sometimes you really do just have to vibe it)*


## ⚠️ Breaking Changes
- [x] Yes (describe)
- [ ] No  (are you *really* sure?)
> No but I'm not *really* sure
---

## 🧪 GameTest Oath
- [ ] Please include at least one `@GameTest`  
or  
- [x] PR does not require a `@GameTest`   
  - [ ] True if this change is only a data/config/docs/logs change  
  - [x] Also True *if* you can make a good case on why you shouldn't have to add one

> PRs without a new GameTest **will not be merged**  (If they are determined to be required) \
> _unless explicitly exempted by a maintainer._

> as if you merge my PRs anyway
---

## 🗝️ Additional Notes
Anything else reviewers might need to know:
performance concerns, edge cases, forbidden knowledge, etc. 💀
> what is this even
---

## 🜏 Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- No worlds shall be harmed in the making or merging of this PR 💀
