### PR TITLE
Fix Polish translations for Valkyrien Skies

### DIFF
--- a/common/src/main/resources/assets/valkyrienskies/lang/pl_pl.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/pl_pl.json
@@ -3,7 +3,7 @@
 
   "tooltip.valkyrienskies.mass": "Masa",
   "category.valkyrienskies.driving": "Sterowanie",
-  "key.valkyrienskies.ship_cruise": "Rejs",
+  "key.valkyrienskies.ship_cruise": "Wnoszenie",
   "key.valkyrienskies.ship_down": "Opadanie",
 
   "block.valkyrienskies.test_chair": "Krzesło Debugowe",
@@ -17,8 +17,8 @@
   "item.valkyrienskies.ship_assembler": "Konstruktor Statku",
   "item.valkyrienskies.area_assembler": "Konstruktor Obszaru",
   "item.valkyrienskies.connection_checker": "Sprawdzacz Połączeń",
-  "item.valkyrienskies.physics_entity_creator": "Kreator Jednostki Fizycznej",
-  "entity.valkyrienskies.vs_physics_entity": "Jednostka Fizyczna",
+  "item.valkyrienskies.physics_entity_creator": "Kreator Bytu Fizycznego",
+  "entity.valkyrienskies.vs_physics_entity": "Byt Fizyczny",
 
   "argument.valkyrienskies.ship.no_found": "Nie znaleziono statku",
   "argument.valkyrienskies.ship.multiple_found": "Znaleziono wiele statków",


### PR DESCRIPTION
``"key.valkyrienskies.ship_cruise": "Rejs"`` Word "Rejs" is incorrect here it means something like trip but not moving up. "Wznoszenie" which means "Going up" is better here.

``"item.valkyrienskies.physics_entity_creator": "Kreator Jednostki Fizycznej" "entity.valkyrienskies.vs_physics_entity": "Jednostka Fizyczna"`` "Jednostka" means unit like inch or kilogram it sometime can mean "ship" but here it makes it even more confusing. Since in Minecraft it's standard to translate "entity" to "byt" it fits here more. Notice that even here in  ``"command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship może być uruchomione tylko przez byty!"`` word "byt" is used as entity.