### PR TITLE
restore weights to balance for 1000kg water

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
@@ -309,7 +309,7 @@ object MassDatapackResolver : BlockStateInfoProvider {
         )
 
         val generatedCollisionShapesMap = HashMap<VoxelShape, SolidBlockShape?>()
-        val liquidMaterialToDensityMap = mapOf(Fluids.WATER to Pair(100.0, 0.3), Fluids.LAVA to Pair(1000.0, 1.0), Fluids.FLOWING_WATER to Pair(1000.0, 0.3), Fluids.FLOWING_LAVA to Pair(10000.0, 1.0))
+        val liquidMaterialToDensityMap = mapOf(Fluids.WATER to Pair(1000.0, 0.3), Fluids.LAVA to Pair(10000.0, 1.0), Fluids.FLOWING_WATER to Pair(1000.0, 0.3), Fluids.FLOWING_LAVA to Pair(10000.0, 1.0))
 
         val fluidStateToBlockTypeMap = HashMap<FluidState, LiquidState>()
 

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/copper.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/copper.json
@@ -1,162 +1,162 @@
 [
   {
     "block": "minecraft:copper_block",
-    "mass": 900.0,
+    "mass": 9000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:cut_copper",
-    "mass": 225.0,
+    "mass": 2250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:cut_copper_stairs",
-    "mass": 168.75,
+    "mass": 1687.5,
     "friction": 0.2
   },
   {
     "block": "minecraft:cut_copper_slab",
-    "mass": 112.5,
+    "mass": 1125.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:exposed_copper",
-    "mass": 900.0,
+    "mass": 9000.0,
     "friction": 0.25
   },
   {
     "block": "minecraft:exposed_cut_copper",
-    "mass": 225.0,
+    "mass": 2250.0,
     "friction": 0.25
   },
   {
     "block": "minecraft:exposed_cut_copper_stairs",
-    "mass": 168.75,
+    "mass": 1687.5,
     "friction": 0.25
   },
   {
     "block": "minecraft:exposed_cut_copper_slab",
-    "mass": 112.5,
+    "mass": 1125.0,
     "friction": 0.25
   },
   {
     "block": "minecraft:weathered_copper",
-    "mass": 900.0,
+    "mass": 9000.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:weathered_cut_copper",
-    "mass": 225.0,
+    "mass": 2250.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:weathered_cut_copper_stairs",
-    "mass": 168.75,
+    "mass": 1687.5,
     "friction": 0.3
   },
   {
     "block": "minecraft:weathered_cut_copper_slab",
-    "mass": 112.5,
+    "mass": 1125.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:oxidized_copper",
-    "mass": 900.0,
+    "mass": 9000.0,
     "friction": 0.35
   },
   {
     "block": "minecraft:oxidized_cut_copper",
-    "mass": 225.0,
+    "mass": 2250.0,
     "friction": 0.35
   },
   {
     "block": "minecraft:oxidized_cut_copper_stairs",
-    "mass": 168.75,
+    "mass": 1687.5,
     "friction": 0.35
   },
   {
     "block": "minecraft:oxidized_cut_copper_slab",
-    "mass": 112.5,
+    "mass": 1125.0,
     "friction": 0.35
   },
   {
     "block": "minecraft:waxed_copper_block",
-    "mass": 900.0,
+    "mass": 9000.0,
     "friction": 0.15
   },
   {
     "block": "minecraft:waxed_cut_copper",
-    "mass": 225.0,
+    "mass": 2250.0,
     "friction": 0.15
   },
   {
     "block": "minecraft:waxed_cut_copper_stairs",
-    "mass": 168.75,
+    "mass": 1687.5,
     "friction": 0.15
   },
   {
     "block": "minecraft:waxed_cut_copper_slab",
-    "mass": 112.5,
+    "mass": 1125.0,
     "friction": 0.15
   },
   {
     "block": "minecraft:waxed_exposed_copper",
-    "mass": 900.0,
+    "mass": 9000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:waxed_exposed_cut_copper",
-    "mass": 225.0,
+    "mass": 2250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:waxed_exposed_cut_copper_stairs",
-    "mass": 168.75,
+    "mass": 1687.5,
     "friction": 0.2
   },
   {
     "block": "minecraft:waxed_exposed_cut_copper_slab",
-    "mass": 112.5,
+    "mass": 1125.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:waxed_weathered_copper",
-    "mass": 900.0,
+    "mass": 9000.0,
     "friction": 0.25
   },
   {
     "block": "minecraft:waxed_weathered_cut_copper",
-    "mass": 225.0,
+    "mass": 2250.0,
     "friction": 0.25
   },
   {
     "block": "minecraft:waxed_weathered_cut_copper_stairs",
-    "mass": 168.75,
+    "mass": 1687.5,
     "friction": 0.25
   },
   {
     "block": "minecraft:waxed_weathered_cut_copper_slab",
-    "mass": 112.5,
+    "mass": 1125.0,
     "friction": 0.25
   },
   {
     "block": "minecraft:waxed_oxidized_copper",
-    "mass": 900.0,
+    "mass": 9000.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:waxed_oxidized_cut_copper",
-    "mass": 225.0,
+    "mass": 2250.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:waxed_oxidized_cut_copper_stairs",
-    "mass": 168.75,
+    "mass": 1687.5,
     "friction": 0.3
   },
   {
     "block": "minecraft:waxed_oxidized_cut_copper_slab",
-    "mass": 112.5,
+    "mass": 1125.0,
     "friction": 0.3
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/brick.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/brick.json
@@ -1,22 +1,22 @@
 [
   {
     "block": "minecraft:bricks",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:brick_stairs",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:brick_slab",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:brick_wall",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.6
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/mud.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/mud.json
@@ -1,32 +1,32 @@
 [
   {
     "block": "minecraft:mud",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.9
   },
   {
     "block": "minecraft:packed_mud",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:mud_bricks",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:mud_brick_stairs",
-    "mass": 112.5,
+    "mass": 1120.5,
     "friction": 0.7
   },
   {
     "block": "minecraft:mud_brick_slab",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:mud_brick_wall",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.7
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/netherrack.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/netherrack.json
@@ -1,62 +1,62 @@
 [
   {
     "block": "minecraft:netherrack",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:nether_bricks",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:cracked_nether_bricks",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:nether_brick_stairs",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:nether_brick_slab",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:nether_brick_wall",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:nether_brick_fence",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:chiseled_nether_bricks",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:red_nether_bricks",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:red_nether_brick_stairs",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:red_nether_brick_slab",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:red_nether_brick_wall",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.6
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/prismarine.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/prismarine.json
@@ -1,57 +1,57 @@
 [
   {
     "block": "minecraft:sea_lantern",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:prismarine",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:prismarine_stairs",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:prismarine_slab",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:prismarine_wall",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:prismarine_bricks",
-    "mass": 300.0,
+    "mass": 3000.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:prismarine_brick_stairs",
-    "mass": 225.0,
+    "mass": 2250.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:prismarine_brick_slab",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:dark_prismarine",
-    "mass": 300.0,
+    "mass": 3000.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:dark_prismarine_stairs",
-    "mass": 225.0,
+    "mass": 2250.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:dark_prismarine_slab",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.6
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/purpur.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/purpur.json
@@ -1,22 +1,22 @@
 [
   {
     "block": "minecraft:purpur_block",
-    "mass": 10.0,
+    "mass": 100.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:purpur_pillar",
-    "mass": 10.0,
+    "mass": 100.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:purpur_stairs",
-    "mass": 7.5,
+    "mass": 75.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:purpur_slab",
-    "mass": 5.0,
+    "mass": 50.0,
     "friction": 0.6
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/quartz.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/quartz.json
@@ -1,47 +1,47 @@
 [
   {
     "block": "minecraft:quartz_block",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:quartz_stairs",
-    "mass": 180.0,
+    "mass": 1800.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:quartz_slab",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:chiseled_quartz_block",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:quartz_bricks",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:quartz_pillar",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:smooth_quartz",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:smooth_quartz_stairs",
-    "mass": 180.0,
+    "mass": 1800.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:smooth_quartz_slab",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.3
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/sandstone.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/deco/sandstone.json
@@ -1,102 +1,102 @@
 [
   {
     "block": "minecraft:sandstone",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:sandstone_stairs",
-    "mass": 180.0,
+    "mass": 1800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:sandstone_slab",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:sandstone_wall",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:chiseled_sandstone",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:smooth_sandstone",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:smooth_sandstone_stairs",
-    "mass": 180.0,
+    "mass": 1800.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:smooth_sandstone_slab",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:cut_sandstone",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:cut_sandstone_slab",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:red_sandstone",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:red_sandstone_stairs",
-    "mass": 180.0,
+    "mass": 1800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:red_sandstone_slab",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:red_sandstone_wall",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:chiseled_red_sandstone",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:smooth_red_sandstone",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:smooth_red_sandstone_stairs",
-    "mass": 180.0,
+    "mass": 1800.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:smooth_red_sandstone_slab",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:cut_red_sandstone",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:cut_red_sandstone_slab",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.6
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/iron.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/iron.json
@@ -1,31 +1,31 @@
 [
   {
     "block": "minecraft:iron_block",
-    "mass": 785.0,
+    "mass": 7850.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:iron_bars",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:iron_door",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.35
   },
   {
     "block": "minecraft:iron_trapdoor",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.35
   },
   {
     "block": "minecraft:heavy_weighted_pressure_plate",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "minecraft:chain",
-    "mass": 5.0,
+    "mass": 50.0,
     "friction": 0.7
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/andesite.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/andesite.json
@@ -1,37 +1,37 @@
 [
   {
     "block": "minecraft:andesite",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:andesite_stairs",
-    "mass": 187.5,
+    "mass": 1875.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:andesite_slab",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:andesite_wall",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:polished_andesite",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:polished_andesite_stairs",
-    "mass": 187.5,
+    "mass": 1875.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:polished_andesite_slab",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.4
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/basalt.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/basalt.json
@@ -1,17 +1,17 @@
 [
   {
     "block": "minecraft:basalt",
-    "mass": 300.0,
+    "mass": 3000.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:smooth_basalt",
-    "mass": 300.0,
+    "mass": 3000.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:polished_basalt",
-    "mass": 300.0,
+    "mass": 3000.0,
     "friction": 0.4
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/blackstone.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/blackstone.json
@@ -1,85 +1,85 @@
 [
   {
     "block": "minecraft:blackstone",
-    "mass": 350.0,
+    "mass": 3500.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:gilded_blackstone",
-    "mass": 360.0,
+    "mass": 3600.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:blackstone_stairs",
-    "mass": 262.5,
+    "mass": 2625.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:blackstone_slab",
-    "mass": 175.0,
+    "mass": 1750.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:blackstone_wall",
-    "mass": 175.0,
+    "mass": 1750.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:chiseled_polished_blackstone",
-    "mass": 350.0,
+    "mass": 3500.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:polished_blackstone",
-    "mass": 350.0,
+    "mass": 3500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:polished_blackstone_stairs",
-    "mass": 262.5,
+    "mass": 2625.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:polished_blackstone_slab",
-    "mass": 175.0,
+    "mass": 1750.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:polished_blackstone_wall",
-    "mass": 175.0,
+    "mass": 1750.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:polished_blackstone_pressure_plate",
-    "mass": 20.0
+    "mass": 200.0
   },
   {
     "block": "minecraft:polished_blackstone_button",
-    "mass": 5.0
+    "mass": 40.0
   },
   {
     "block": "minecraft:polished_blackstone_bricks",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:cracked_polished_blackstone_bricks",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:polished_blackstone_brick_stairs",
-    "mass": 262.5,
+    "mass": 2625.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:polished_blackstone_brick_slab",
-    "mass": 175.0,
+    "mass": 1750.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:polished_blackstone_brick_wall",
-    "mass": 175.0,
+    "mass": 1750.0,
     "friction": 0.4
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/cobble.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/cobble.json
@@ -1,42 +1,42 @@
 [
   {
     "block": "minecraft:cobblestone",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:cobblestone_stairs",
-    "mass": 180.0,
+    "mass": 1800.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:cobblestone_slab",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:cobblestone_wall",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:mossy_cobblestone",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:mossy_cobblestone_stairs",
-    "mass": 180.0,
+    "mass": 1800.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:mossy_cobblestone_slab",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:mossy_cobblestone_wall",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.8
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/deepslate.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/deepslate.json
@@ -1,107 +1,107 @@
 [
   {
     "block": "minecraft:deepslate",
-    "mass": 290.0,
+    "mass": 2900.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:cobbled_deepslate",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:cobbled_deepslate_stairs",
-    "mass": 206.25,
+    "mass": 2060.25,
     "friction": 0.8
   },
   {
     "block": "minecraft:cobbled_deepslate_slab",
-    "mass": 137.5,
+    "mass": 1375.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:cobbled_deepslate_wall",
-    "mass": 135.0,
+    "mass": 1350.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:chiseled_deepslate",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:polished_deepslate",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.35
   },
   {
     "block": "minecraft:polished_deepslate_stairs",
-    "mass": 206.25,
+    "mass": 2062.5,
     "friction": 0.35
   },
   {
     "block": "minecraft:polished_deepslate_slab",
-    "mass": 137.5,
+    "mass": 1375.0,
     "friction": 0.35
   },
   {
     "block": "minecraft:polished_deepslate_wall",
-    "mass": 135.0,
+    "mass": 1350.0,
     "friction": 0.45
   },
   {
     "block": "minecraft:deepslate_bricks",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:cracked_deepslate_bricks",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:deepslate_brick_stairs",
-    "mass": 206.25,
+    "mass": 2062.5,
     "friction": 0.5
   },
   {
     "block": "minecraft:deepslate_brick_slab",
-    "mass": 137.5,
+    "mass": 1375.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:deepslate_brick_wall",
-    "mass": 135.0,
+    "mass": 1350.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:deepslate_tiles",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:cracked_deepslate_tiles",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:deepslate_tile_stairs",
-    "mass": 206.25,
+    "mass": 2062.5,
     "friction": 0.6
   },
   {
     "block": "minecraft:deepslate_tile_slab",
-    "mass": 137.5,
+    "mass": 1375.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:deepslate_tile_wall",
-    "mass": 135.0,
+    "mass": 1350.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:reinforced_deepslate",
-    "mass": 400.0,
+    "mass": 4000.0,
     "friction": 0.7
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/diorite.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/diorite.json
@@ -1,37 +1,37 @@
 [
   {
     "block": "minecraft:diorite",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:diorite_stairs",
-    "mass": 187.5,
+    "mass": 1875.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:diorite_slab",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:diorite_wall",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:polished_diorite",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:polished_diorite_stairs",
-    "mass": 187.5,
+    "mass": 1875.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:polished_diorite_slab",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.4
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/endstone.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/endstone.json
@@ -1,27 +1,27 @@
 [
   {
     "block": "minecraft:end_stone",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:end_stone_bricks",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:end_stone_brick_stairs",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:end_stone_brick_slab",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:end_stone_brick_wall",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/granite.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/granite.json
@@ -1,37 +1,37 @@
 [
   {
     "block": "minecraft:granite",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:granite_stairs",
-    "mass": 187.5,
+    "mass": 1875.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:granite_slab",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:granite_wall",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:polished_granite",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:polished_granite_stairs",
-    "mass": 187.5,
+    "mass": 1875.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:polished_granite_slab",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.4
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/smooth_stone.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/smooth_stone.json
@@ -1,12 +1,12 @@
 [
   {
     "block": "minecraft:smooth_stone",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:smooth_stone_slab",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.4
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/stone.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/stone.json
@@ -1,25 +1,25 @@
 [
   {
     "block": "minecraft:stone",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stone_stairs",
-    "mass": 187.5,
+    "mass": 1875.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stone_slab",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stone_pressure_plate",
-    "mass": 10.0
+    "mass": 100.0
   },
   {
     "block": "minecraft:stone_button",
-    "mass": 0.5
+    "mass": 30.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/stone_bricks.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/stone/stone_bricks.json
@@ -1,52 +1,52 @@
 [
   {
     "block": "minecraft:stone_bricks",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:cracked_stone_bricks",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:stone_brick_stairs",
-    "mass": 187.5,
+    "mass": 1875.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:stone_brick_slab",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:stone_brick_wall",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:chiseled_stone_bricks",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:mossy_stone_bricks",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:mossy_stone_brick_stairs",
-    "mass": 187.5,
+    "mass": 1875.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:mossy_stone_brick_slab",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:mossy_stone_brick_wall",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.3
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/valuables.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/valuables.json
@@ -1,46 +1,46 @@
 [
   {
     "block": "minecraft:coal_block",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:gold_block",
-    "mass": 1930.0,
+    "mass": 19300.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:light_weighted_pressure_plate",
-    "mass": 100.0
+    "mass": 1000.0
   },
   {
     "block": "minecraft:redstone_block",
-    "mass": 300.0,
+    "mass": 3000.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:emerald_block",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:lapis_block",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:diamond_block",
-    "mass": 350.0,
+    "mass": 3500.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:netherite_block",
-    "mass": 8968.0,
+    "mass": 89680.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:amethyst_block",
-    "mass": 265.0,
+    "mass": 2650.0,
     "friction": 1.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/acacia.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/acacia.json
@@ -1,37 +1,37 @@
 [
   {
     "block": "minecraft:acacia_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:acacia_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stripped_acacia_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:stripped_acacia_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:acacia_planks",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:acacia_stairs",
-    "mass": 37.5,
+    "mass": 375.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:acacia_slab",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.5
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/bamboo.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/bamboo.json
@@ -1,42 +1,42 @@
 [
   {
     "block": "minecraft:bamboo_block",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stripped_bamboo_block",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:bamboo_planks",
-    "mass": 40.0,
+    "mass": 400.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:bamboo_mosaic",
-    "mass": 40.0,
+    "mass": 400.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:bamboo_mosaic_slab",
-    "mass": 20.0,
+    "mass": 200.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:bamboo_slab",
-    "mass": 20.0,
+    "mass": 200.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:bamboo_stairs",
-    "mass": 30.0,
+    "mass": 300.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:bamboo_mosaic_stairs",
-    "mass": 30.0,
+    "mass": 300.0,
     "friction": 0.5
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/birch.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/birch.json
@@ -1,37 +1,37 @@
 [
   {
     "block": "minecraft:birch_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:birch_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stripped_birch_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:stripped_birch_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:birch_planks",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:birch_stairs",
-    "mass": 37.5,
+    "mass": 375.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:birch_slab",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.5
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/cherry.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/cherry.json
@@ -1,37 +1,37 @@
 [
   {
     "block": "minecraft:cherry_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:cherry_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stripped_cherry_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:stripped_cherry_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:cherry_planks",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:cherry_stairs",
-    "mass": 37.5,
+    "mass": 375.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:cherry_slab",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.5
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/crimson.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/crimson.json
@@ -1,37 +1,37 @@
 [
   {
     "block": "minecraft:crimson_stem",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:crimson_hyphae",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stripped_crimson_stem",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:stripped_crimson_hyphae",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:crimson_planks",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:crimson_stairs",
-    "mass": 37.5,
+    "mass": 375.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:crimson_slab",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.5
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/dark_oak.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/dark_oak.json
@@ -1,37 +1,37 @@
 [
   {
     "block": "minecraft:dark_oak_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:dark_oak_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stripped_dark_oak_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:stripped_dark_oak_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:dark_oak_planks",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:dark_oak_stairs",
-    "mass": 37.5,
+    "mass": 375.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:dark_oak_slab",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.5
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/default.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/default.json
@@ -1,56 +1,56 @@
 [
   {
     "tag": "minecraft:logs",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "tag": "minecraft:planks",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "tag": "minecraft:wooden_stairs",
-    "mass": 37.5,
+    "mass": 375.0,
     "friction": 0.5
   },
   {
     "tag": "minecraft:wooden_slabs",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.5
   },
   {
     "tag": "minecraft:wooden_doors",
-    "mass": 10.0
+    "mass": 100.0
   },
 
   {
     "tag": "minecraft:wooden_trapdoors",
-    "mass": 50.0
+    "mass": 100.0
   },
   {
     "tag": "minecraft:fence_gates",
-    "mass": 5.0
+    "mass": 100.0
   },
   {
     "tag": "minecraft:fences",
-    "mass": 50.0
+    "mass": 100.0
   },
   {
     "tag": "minecraft:wooden_pressure_plates",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "tag": "minecraft:wooden_buttons",
-    "mass": 0.25
+    "mass": 2.5
   },
   {
     "tag": "minecraft:signs",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "tag": "minecraft:all_hanging_signs",
-    "mass": 20.0,
+    "mass": 100.0,
     "friction": 0.5
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/jungle.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/jungle.json
@@ -1,37 +1,37 @@
 [
   {
     "block": "minecraft:jungle_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:jungle_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stripped_jungle_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:stripped_jungle_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:jungle_planks",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:jungle_stairs",
-    "mass": 37.5,
+    "mass": 375.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:jungle_slab",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.5
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/mangrove.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/mangrove.json
@@ -1,37 +1,37 @@
 [
   {
     "block": "minecraft:mangrove_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:mangrove_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stripped_mangrove_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:stripped_mangrove_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:mangrove_planks",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:mangrove_stairs",
-    "mass": 37.5,
+    "mass": 375.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:mangrove_slab",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.5
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/oak.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/oak.json
@@ -1,37 +1,37 @@
 [
   {
     "block": "minecraft:oak_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:oak_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stripped_oak_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:stripped_oak_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:oak_planks",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:oak_stairs",
-    "mass": 37.5,
+    "mass": 375.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:oak_slab",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.5
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/spruce.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/spruce.json
@@ -1,37 +1,37 @@
 [
   {
     "block": "minecraft:spruce_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:spruce_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stripped_spruce_log",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:stripped_spruce_wood",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:spruce_planks",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:spruce_stairs",
-    "mass": 37.5,
+    "mass": 375.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:spruce_slab",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.5
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/warped.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/building/wood/warped.json
@@ -1,37 +1,37 @@
 [
   {
     "block": "minecraft:warped_stem",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:warped_hyphae",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stripped_warped_stem",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:stripped_warped_hyphae",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:warped_planks",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:warped_stairs",
-    "mass": 37.5,
+    "mass": 375.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:warped_slab",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.5
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/colored/candle.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/colored/candle.json
@@ -1,92 +1,92 @@
 [
   {
     "block": "minecraft:candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:white_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:orange_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:magenta_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:light_blue_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:yellow_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:lime_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:pink_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:gray_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:light_gray_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:cyan_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:purple_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:blue_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:brown_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:green_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:red_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:black_candle",
-    "mass": 0.2,
+    "mass": 2.0,
     "friction": 0.1
   },
   {
     "tag": "minecraft:candle_cakes",
-    "mass": 6.0,
+    "mass": 60.0,
     "friction": 0.1
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/colored/concrete.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/colored/concrete.json
@@ -1,82 +1,82 @@
 [
   {
     "block": "minecraft:white_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:orange_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:magenta_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:light_blue_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:yellow_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:lime_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:pink_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:gray_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:light_gray_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:cyan_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:purple_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:blue_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:brown_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:green_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:red_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:black_concrete",
-    "mass": 240.0,
+    "mass": 2400.0,
     "friction": 0.4
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/colored/concrete_powder.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/colored/concrete_powder.json
@@ -1,82 +1,82 @@
 [
   {
     "block": "minecraft:white_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:orange_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:magenta_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:light_blue_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:yellow_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:lime_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:pink_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:gray_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:light_gray_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:cyan_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:purple_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:blue_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:brown_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:green_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:red_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:black_concrete_powder",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.6
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/colored/glass.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/colored/glass.json
@@ -1,92 +1,92 @@
 [
   {
     "block": "minecraft:tinted_glass",
-    "mass": 220.0,
+    "mass": 2200.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:white_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:orange_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:magenta_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:light_blue_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:yellow_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:lime_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:pink_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:gray_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:light_gray_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:cyan_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:purple_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:blue_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:brown_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:green_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:red_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:black_stained_glass",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/colored/glass_pane.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/colored/glass_pane.json
@@ -1,87 +1,87 @@
 [
   {
     "block": "minecraft:glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:white_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:orange_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:magenta_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:light_blue_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:yellow_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:lime_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:pink_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:gray_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:light_gray_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:cyan_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:purple_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:blue_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:brown_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:green_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:red_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:black_stained_glass_pane",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/colored/glazed_terracotta.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/colored/glazed_terracotta.json
@@ -1,82 +1,82 @@
 [
   {
     "block": "minecraft:white_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:orange_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:magenta_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:light_blue_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:yellow_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:lime_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:pink_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:gray_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:light_gray_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:cyan_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:purple_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:blue_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:brown_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:green_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:red_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:black_glazed_terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/colored/tagged.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/colored/tagged.json
@@ -1,34 +1,34 @@
 [
   {
     "tag": "minecraft:wool",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.6,
     "elasticity": 0.5
   },
   {
     "tag": "minecraft:carpets",
-    "mass": 2.0,
+    "mass": 20.0,
     "friction": 0.6,
     "elasticity": 0.05
   },
   {
     "tag": "minecraft:terracotta",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.6
   },
   {
     "tag": "minecraft:shulker_boxes",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.1
   },
   {
     "tag": "minecraft:beds",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.6,
     "elasticity": 0.5
   },
   {
     "tag": "minecraft:banners",
-    "mass": 3.0
+    "mass": 30.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/computercraft.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/computercraft.json
@@ -1,50 +1,50 @@
 [
   {
     "block": "computercraft:computer_advanced",
-    "mass": 1535.0
+    "mass": 15350.0
   },
   {
     "block": "computercraft:turtle_advanced",
-    "mass": 1575.0
+    "mass": 15750.0
   },
   {
     "block": "computercraft:monitor_advanced",
-    "mass": 1525.0
+    "mass": 15250.0
   },
   {
     "block": "computercraft:wireless_modem_advanced",
-    "mass": 1525.0
+    "mass": 15250.0
   },
   {
     "block": "computercraft:computer_normal",
-    "mass": 315.0
+    "mass": 3150.0
   },
   {
     "block": "computercraft:turtle_normal",
-    "mass": 360.0
+    "mass": 3600.0
   },
   {
     "block": "computercraft:monitor_normal",
-    "mass": 320.0
+    "mass": 3200.0
   },
   {
     "block": "computercraft:wired_modem_full",
-    "mass": 330.0
+    "mass": 3300.0
   },
   {
     "block": "computercraft:cable",
-    "mass": 15.0
+    "mass": 150.0
   },
   {
     "block": "computercraft:printer",
-    "mass": 315.0
+    "mass": 3150.0
   },
   {
     "block": "computercraft:speaker",
-    "mass": 200.0
+    "mass": 2000.0
   },
   {
     "block": "computercraft:disk_drive",
-    "mass": 330.0
+    "mass": 3300.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/copiescats.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/copiescats.json
@@ -1,34 +1,34 @@
 [
   {
     "block": "copiescats:copycat_ten",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copiescats:copycat_four",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copiescats:copycat_six",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copiescats:copycat_slab",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copiescats:copycat_two",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copiescats:copycat_twelve",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copiescats:copycat_fourteen",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copiescats:copycat_sixteen",
-    "mass": 50.0
+    "mass": 500.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/copycatsplus.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/copycatsplus.json
@@ -1,98 +1,98 @@
 [
   {
     "block": "copycats:copycat_layer",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_slab",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_beam",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_vertical_step",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_half_panel",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_stairs",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_fence",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_fence_gate",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_trapdoor",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_wall",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_board",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_box",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_catwalk",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_byte",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_block",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_half_layer",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_slice",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_vertical_slice",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_wooden_button",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_stone_button",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_wooden_pressure_plate",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_stone_pressure_plate",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_heavy_weighted_pressure_plate",
-    "mass": 50.0
+    "mass": 500.0
   },
   {
     "block": "copycats:copycat_light_weighted_pressure_plate",
-    "mass": 50.0
+    "mass": 500.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create.json
@@ -1,642 +1,642 @@
 [
   {
     "block": "create:shaft",
-    "mass": 15.0,
+    "mass": 150.0,
     "friction": 0.3
   },
   {
     "block": "create:brass_block",
-    "mass": 860.0,
+    "mass": 8600.0,
     "friction": 0.2
   },
   {
     "block": "create:andesite_casing",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.4
   },
   {
     "block": "create:brass_casing",
-    "mass": 145.0,
+    "mass": 1450.0,
     "friction": 0.4
   },
   {
     "block": "create:train_casing",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.4
   },
   {
     "block": "create:copper_casing",
-    "mass": 175.0,
+    "mass": 1750.0,
     "friction": 0.4
   },
   {
     "block": "create:cogwheel",
-    "mass": 35.0,
+    "mass": 350.0,
     "friction": 0.7
   },
   {
     "block": "create:large_cogwheel",
-    "mass": 55.0,
+    "mass": 550.0,
     "friction": 0.7
   },
   {
     "block": "create:andesite_encased_shaft",
-    "mass": 90.0,
+    "mass": 900.0,
     "friction": 0.4
   },
   {
     "block": "create:brass_encased_shaft",
-    "mass": 160.0,
+    "mass": 1600.0,
     "friction": 0.4
   },
   {
     "block": "create:andesite_encased_cogwheel",
-    "mass": 110.0,
+    "mass": 1100.0,
     "friction": 0.4
   },
   {
     "block": "create:andesite_encased_large_cogwheel",
-    "mass": 130.0,
+    "mass": 1300.0,
     "friction": 0.4
   },
   {
     "block": "create:brass_encased_cogwheel",
-    "mass": 180.0,
+    "mass": 1800.0,
     "friction": 0.4
   },
   {
     "block": "create:brass_encased_large_cogwheel",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.4
   },
   {
     "block": "create:gearbox",
-    "mass": 121.0,
+    "mass": 1210.0,
     "friction": 0.4
   },
   {
     "block": "create:clutch",
-    "mass": 110.0,
+    "mass": 1100.0,
     "friction": 0.4
   },
   {
     "block": "create:gearshift",
-    "mass": 110.0,
+    "mass": 1100.0,
     "friction": 0.4
   },
   {
     "block": "create:encased_chain_drive",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.4
   },
   {
     "block": "create:belt",
-    "mass": 5.0,
+    "mass": 50.0,
     "friction": 0.77
   },
   {
     "block": "create:creative_motor",
-    "mass": 10.0,
+    "mass": 100.0,
     "friction": 0.8
   },
   {
     "block": "create:water_wheel",
-    "mass": 437.5,
+    "mass": 4375.0,
     "friction": 0.5
   },
   {
     "block": "create:encased_fan",
-    "mass": 235.0,
+    "mass": 2350.0,
     "friction": 0.4
   },
   {
     "block": "create:nozzle",
-    "mass": 10.0,
+    "mass": 100.0,
     "friction": 0.7
   },
   {
     "block": "create:turntable",
-    "mass": 10.0,
+    "mass": 100.0,
     "friction": 0.3
   },
   {
     "block": "create:millstone",
-    "mass": 400.0,
+    "mass": 4000.0,
     "friction": 0.5
   },
   {
     "block": "create:crushing_wheel",
-    "mass": 500.0,
+    "mass": 5000.0,
     "friction": 0.9
   },
   {
     "block": "create:mechanical_press",
-    "mass": 110.0,
+    "mass": 1100.0,
     "friction": 0.4
   },
   {
     "block": "create:mechanical_mixer",
-    "mass": 110.0,
+    "mass": 1100.0,
     "friction": 0.4
   },
   {
     "block": "create:basin",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.25
   },
   {
     "block": "create:blaze_burner",
-    "mass": 225.0,
+    "mass": 2250.0,
     "friction": 0.6
   },
   {
     "block": "create:depot",
-    "mass": 30.0,
+    "mass": 300.0,
     "friction": 0.4
   },
   {
     "block": "create:weighted_ejector",
-    "mass": 350.0,
+    "mass": 3500.0,
     "friction": 0.4
   },
   {
     "block": "create:chute",
-    "mass": 245.0,
+    "mass": 2450.0,
     "friction": 0.4
   },
   {
     "block": "create:smart_chute",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.35
   },
   {
     "block": "create:speedometer",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "block": "create:stressometer",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.5
   },
   {
     "block": "create:metal_girder",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.1
   },
   {
     "block": "create:metal_girder_encased_shaft",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.1
   },
   {
     "block": "create:fluid_pipe",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.4
   },
   {
     "block": "create:smart_fluid_pipe",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "create:glass_fluid_pipe",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.4
   },
   {
     "block": "create:encased_fluid_pipe",
-    "mass": 225.0,
+    "mass": 2250.0,
     "friction": 0.5
   },
   {
     "block": "create:mechanical_pump",
-    "mass": 85,
+    "mass": 850.0,
     "friction": 0.4
   },
   {
     "block": "create:fluid_valve",
-    "mass": 65.0,
+    "mass": 650.0,
     "friction": 0.4
   },
   {
     "block": "create:fluid_tank",
-    "mass": 500.0,
+    "mass": 5000.0,
     "friction": 0.4
   },
   {
     "block": "create:creative_fluid_tank",
-    "mass": 500.0,
+    "mass": 5000.0,
     "friction": 0.4
   },
   {
     "block": "create:hose_pulley",
-    "mass": 42.0,
+    "mass": 420.0,
     "friction": 0.5
   },
   {
     "block": "create:item_drain",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.4
   },
   {
     "block": "create:spout",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.4
   },
   {
     "block": "create:portable_fluid_interface",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.6
   },
   {
     "block": "create:portable_item_interface",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.6
   },
   {
     "block": "create:steam_engine",
-    "mass": 300.0,
+    "mass": 3000.0,
     "friction": 0.8
   },
   {
     "block": "create:steam_whistle",
-    "mass": 20.0,
+    "mass": 200.0,
     "friction": 0.3
   },
   {
     "block": "create:steam_whistle_extension",
-    "mass": 20.0,
+    "mass": 200.0,
     "friction": 0.3
   },
   {
     "block": "create:powered_shaft",
-    "mass": 15.0,
+    "mass": 150.0,
     "friction": 0.5
   },
   {
     "block": "create:mechanical_piston",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.5
   },
   {
     "block": "create:sticky_mechanical_piston",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.5
   },
   {
     "block": "create:piston_extension_pole",
-    "mass": 10.0,
+    "mass": 100.0,
     "friction": 0.3
   },
   {
     "block": "create:mechanical_piston_head",
-    "mass": 35.0,
+    "mass": 350.0,
     "friction": 0.5
   },
   {
     "block": "create:gantry_carriage",
-    "mass": 160.0,
+    "mass": 1600.0,
     "friction": 0.5
   },
   {
     "block": "create:gantry_shaft",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.9
   },
   {
     "block": "create:windmill_bearing",
-    "mass": 255.0,
+    "mass": 2550.0,
     "friction": 0.4
   },
   {
     "block": "create:mechanical_bearing",
-    "mass": 155.0,
+    "mass": 1550.0,
     "friction": 0.4
   },
   {
     "block": "create:clockwork_bearing",
-    "mass": 195.0,
+    "mass": 1950.0,
     "friction": 0.4
   },
   {
     "block": "create:rope_pulley",
-    "mass": 145.0,
+    "mass": 1450.0,
     "friction": 0.5
   },
   {
     "block": "create:rope",
-    "mass": 8.0,
+    "mass": 80.0,
     "friction": 0.9
   },
   {
     "block": "create:pulley_magnet",
-    "mass": 89.0,
+    "mass": 890.0,
     "friction": 0.2
   },
   {
     "block": "create:cart_assembler",
-    "mass": 145.0,
+    "mass": 1450.0,
     "friction": 0.5
   },
   {
     "block": "create:controller_rail",
-    "mass": 84.0,
+    "mass": 840.0,
     "friction": 0.4
   },
   {
     "block": "create:minecart_anchor",
-    "mass": 145.0,
+    "mass": 1450.0,
     "friction": 0.4
   },
   {
     "block": "create:linear_chassis",
-    "mass": 90.0,
+    "mass": 900.0,
     "friction": 0.4
   },
   {
     "block": "create:secondary_linear_chassis",
-    "mass": 90.0,
+    "mass": 900.0,
     "friction": 0.4
   },
   {
     "block": "create:radial_chassis",
-    "mass": 90.0,
+    "mass": 900.0,
     "friction": 0.4
   },
   {
     "block": "create:sticker",
-    "mass": 115.0,
+    "mass": 1150.0,
     "friction": 0.95
   },
   {
     "block": "create:mechanical_drill",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.2
   },
   {
     "block": "create:mechanical_saw",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.2
   },
   {
     "block": "create:deployer",
-    "mass": 185.0,
+    "mass": 1850.0,
     "friction": 0.5
   },
   {
     "block": "create:redstone_contact",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.8
   },
   {
     "block": "create:mechanical_harvester",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.2
   },
   {
     "block": "create:mechanical_plough",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.2
   },
   {
     "block": "create:seat",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.3
   },
   {
     "block": "create:mechanical_crafter",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.4
   },
   {
     "block": "create:sequenced_gearshift",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.4
   },
   {
     "block": "create:flywheel",
-    "mass": 785.0,
+    "mass": 7850.0,
     "friction": 0.77
   },
   {
     "block": "create:rotation_speed_controller",
-    "mass": 380.0,
+    "mass": 3800.0,
     "friction": 0.4
   },
   {
     "block": "create:mechanical_arm",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.7
   },
   {
     "block": "create:track",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.5
   },
   {
     "block": "create:fake_track",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.5
   },
   {
     "block": "create:track_station",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.5
   },
   {
     "block": "create:track_signal",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.4
   },
   {
     "block": "create:track_observer",
-    "mass": 75.0,
+    "mass": 750.0,
     "friction": 0.4
   },
   {
     "block": "create:small_bogey",
-    "mass": 90.0,
+    "mass": 900.0,
     "friction": 0.4
   },
   {
     "block": "create:large_bogey",
-    "mass": 180.0,
+    "mass": 1800.0,
     "friction": 0.4
   },
   {
     "block": "create:contraption_controls",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.2
   },
   {
     "block": "create:controls",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.2
   },
   {
     "block": "create:train_door",
-    "mass": 105.0,
+    "mass": 1050.0,
     "friction": 0.5
   },
   {
     "block": "create:train_trapdoor",
-    "mass": 55,
+    "mass": 550.0,
     "friction": 0.1
   },
   {
     "block": "create:item_vault",
-    "mass": 105,
+    "mass": 1050.0,
     "friction": 0.1
   },
   {
     "block": "create:andesite_funnel",
-    "mass": 20.0,
+    "mass": 200.0,
     "friction": 0.4
   },
   {
     "block": "create:andesite_belt_funnel",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.77
   },
   {
     "block": "create:brass_funnel",
-    "mass": 40.0,
+    "mass": 400.0,
     "friction": 0.4
   },
   {
     "block": "create:brass_belt_funnel",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.77
   },
   {
     "block": "create:andesite_tunnel",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.4
   },
   {
     "block": "create:brass_tunnel",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.4
   },
   {
     "block": "create:content_observer",
-    "mass": 105.0,
+    "mass": 1050.0,
     "friction": 0.4
   },
   {
     "block": "create:stockpile_switch",
-    "mass": 105.0,
+    "mass": 1050.0,
     "friction": 0.4
   },
   {
     "block": "create:display_link",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.4
   },
   {
     "block": "create:display_board",
-    "mass": 10.0,
+    "mass": 100.0,
     "friction": 0.5
   },
   {
     "block": "create:nixie_tube",
-    "mass": 15,
+    "mass": 150.0,
     "friction": 0.4
   },
   {
     "block": "create:redstone_link",
-    "mass": 10.0,
+    "mass": 100.0,
     "friction": 0.4
   },
   {
     "block": "create:analog_lever",
-    "mass": 1.0,
+    "mass": 10.0,
     "friction": 0.1
   },
   {
     "block": "create:placard",
-    "mass": 45.0,
+    "mass": 450.0,
     "friction": 0.4
   },
   {
     "block": "create:pulse_repeater",
-    "mass": 30.0,
+    "mass": 300.0,
     "friction": 0.5
   },
   {
     "block": "create:pulse_extender",
-    "mass": 30.0,
+    "mass": 300.0,
     "friction": 0.5
   },
   {
     "block": "create:powered_latch",
-    "mass": 30.0,
+    "mass": 300.0,
     "friction": 0.5
   },
   {
     "block": "create:powered_toggle_latch",
-    "mass": 30.0,
+    "mass": 300.0,
     "friction": 0.5
   },
   {
     "block": "create:lectern_controller",
-    "mass": 15.0,
+    "mass": 150.0,
     "friction": 0.4
   },
   {
     "block": "create:copper_backtank",
-    "mass": 5,
+    "mass": 50.0,
     "friction": 0.3
   },
   {
     "block": "create:toolbox",
-    "mass": 15.0,
+    "mass": 150.0,
     "friction": 0.4
   },
   {
     "block": "create:peculiar_bell",
-    "mass": 15.0,
+    "mass": 150.0,
     "friction": 0.4
   },
   {
     "block": "create:haunted_bell",
-    "mass": 15.0,
+    "mass": 150.0,
     "friction": 0.4
   },
   {
     "block": "create:zinc_ore",
-    "mass": 430.0,
+    "mass": 4300.0,
     "friction": 0.6
   },
   {
     "block": "create:deepslate_zinc_ore",
-    "mass": 450.0,
+    "mass": 4500.0,
     "friction": 0.65
   },
   {
     "block": "create:raw_zinc_block",
-    "mass": 715.0,
+    "mass": 7150.0,
     "friction": 0.65
   },
   {
     "block": "create:zinc_block",
-    "mass": 715.0,
+    "mass": 7150.0,
     "friction": 0.4
   },
   {
     "block": "create:copycat_step",
-    "mass": 5.0,
+    "mass": 50.0,
     "friction": 0.5
   },
   {
     "block": "create:copycat_panel",
-    "mass": 2.5,
+    "mass": 25.0,
     "friction": 0.5
   },
   {
     "tag": "create:windmill_sails",
-    "mass": 5.0,
+    "mass": 50.0,
     "friction": 0.75
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/createtweakedcontrollers.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/createtweakedcontrollers.json
@@ -1,6 +1,6 @@
 [
     {
       "block": "create_tweaked_controllers:tweaked_lectern_controller",
-      "mass": 15.0
+      "mass": 150.0
     }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/steelarmorblocks.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/steelarmorblocks.json
@@ -1,1486 +1,1486 @@
 [
   {
     "block": "s_a_b:doublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:steelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:hardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:lightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:steelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:lightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:steelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:lightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:steelarmorstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:steelwl",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:armorwl",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:sandbag",
-    "mass": 624.0
+    "mass": 6240.0
   },
   {
     "block": "s_a_b:blacksteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:redsteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:greensteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:bluesteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:cyansteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:brownsteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:graysteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:whitesteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:lightgraysteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:lightbluesteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:magentasteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:yellowsteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:pinksteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:purplesteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:orangesteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:limesteelblock",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:blackhardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:redhardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:greenhardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:bluehardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:cyanhardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:brownhardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:grayhardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:lightgrayhardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:lightbluehardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:magentahardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:yellowhardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:pinkhardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:purplehardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:orangehardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:limehardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:whitehardsteelblock",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:blacklightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:redlightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:greenlightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:bluelightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:cyanlightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:brownlightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:graylightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightgraylightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightbluelightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:magentalightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:yellowlightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:pinklightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:purplelightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:orangelightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:limelightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:whitelightsteelblock",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:blackdoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:reddoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:greendoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:bluedoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:cyandoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:browndoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:graydoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:lightgraydoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:lightbluedoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:magentadoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:yellowdoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:pinkdoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:purpledoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:orangedoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:limedoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:whitedoublesteelblock",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:blacklightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:redlightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:greenlightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:bluelightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:cyanlightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:brownlightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:graylightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightgraylightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightbluelightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:magentalightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:yellowlightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:pinklightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:purplelightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:orangelightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:limelightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:whitelightsteelvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:blacksteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:redsteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:greensteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:bluesteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:cyansteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:brownsteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:graysteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:lightgraysteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:lightbluesteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:magentasteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:yellowsteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:pinksteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:purplesteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:orangesteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:limesteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:whitesteelvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:blacklightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:redlightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:greenlightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:bluelightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:cyanlightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:brownlightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:graylightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightgraylightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightbluelightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:magentalightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:yellowlightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:pinklightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:purplelightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:orangelightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:limelightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:whitelightsteelslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:blacksteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:redsteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:greensteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:bluesteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:cyansteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:brownsteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:graysteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:lightgraysteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:lightbluesteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:magentasteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:yellowsteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:pinksteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:purplesteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:orangesteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:limesteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:whitesteelslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:blacklightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:redlightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:greenlightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:bluelightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:cyanlightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:brownlightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:graylightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:lightgraylightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:lightbluelightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:magentalightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:yellowlightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:pinklightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:purplelightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:orangelightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:limelightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:whitelightsteelstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:blacksteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:redsteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:greensteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:bluesteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:cyansteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:brownsteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:graysteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:lightgraysteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:lightbluesteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:magentasteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:yellowsteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:pinksteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:purplesteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:orangesteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:limesteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:whitesteelstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:steelblockcolored_29",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelblockcolored_31",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelblockcolored_32",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelblockcolored_33",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelblockcoloredparade",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:doublesteelblockcolored_29",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:doublesteelblockcolored_31",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:doublesteelblockcolored_32",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:doublesteelblockcolored_33",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:doublesteelblockcoloredparade",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:lightsteelblockcolored_29",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightsteelblockcolored_31",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightsteelblockcolored_32",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightsteelblockcolored_33",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightsteelblockcoloredparade",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:hardsteelblockcolored_29",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:hardsteelblockcolored_31",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:hardsteelblockcolored_32",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:hardsteelblockcolored_33",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:hardsteelblockcoloredparade",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:steelvslabcolored_29",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelvslabcolored_31",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelvslabcolored_32",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelvslabcolored_33",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelvslabcoloredparade",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:lightsteelvslabcolored_29",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelvslabcolored_31",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelvslabcolored_32",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelvslabcolored_33",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelvslabcoloredparade",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:steelslabcolored_29",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelslabcolored_31",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelslabcolored_32",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelslabcolored_33",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelslabcoloredparade",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:lightsteelslabcolored_29",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelslabcolored_31",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelslabcolored_32",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelslabcolored_33",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelslabcoloredparade",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:steelstairscolored_29",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:steelstairscolored_31",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:steelstairscolored_32",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:steelstairscolored_33",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:steelstairscoloredparade",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:lightsteelstairscolored_29",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:lghtsteelstairscolored_31",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:lghtsteelstairscolored_32",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:lghtsteelstairscolored_33",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:lghtsteelstairscoloredparade",
-    "mass": 3234.0
+    "mass": 32340.0
   },
   {
     "block": "s_a_b:doublesteelblockshipbottom",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:steelblockshipbottom",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:hardsteelblockshipbottom",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:lightsteelblockshipbottom",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:doublesteelblock_4bo",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:steelblock_4bo",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:hardsteelblock_4bo",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:lightsteelblock_4bo",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:doublesteelblockgelb",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:steelblockgelb",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:hardsteelblockgelb",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:lightsteelblockgelb",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:doublesteelblockpanzergrau",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:steelblockpanzergrau",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:hardsteelblockpanzergrau",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:lightsteelblockpanzergrau",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:doublesteelblockrotbraun",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:steelblockrotbraun",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:hardsteelblockrotbraun",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:lightsteelblockrotbraun",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:steelslabshipbottom",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelvslabshipbottom",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelstairsshipbottom",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:lightsteelslabshipbottom",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelvslabshipbottom",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelstairsshipbottom",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:steelslab_4bo",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelvslab_4bo",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelstairs_4bo",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:lightsteelslab_4bo",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelvslab_4bo",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelstairs_4bo",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:steelslabgelb",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelvslabgelb",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelstairsgelb",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:lightsteelslabgelb",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelvslabgelb",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelstairsgelb",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:steelslabpanzergrau",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelvslabpanzergrau",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelstairspanzergrau",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:lightsteelslabpanzergrau",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelvslabpanzergrau",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelstairspanzergrau",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:steelslabrotbraun",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelvslabrotbraun",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelstairsrotbraun",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:lightsteelslabrotbraun",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelvslabrotbraun",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:lightsteelstairsrotbraun",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:steelwl_29",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelwl_31",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelwl_32",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelwl_33",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelwlblack",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelwlgray",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:lightwl_29",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightwl_31",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightwl_32",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightwl_33",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightwlblack",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightwlgray",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:armorwl_29",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:armorwl_31",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:armorwl_32",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:armorwl_33",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:armorwlblack",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:armorwlgray",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:lightsteelblockcamoplains",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightsteelcamoforest",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightsteelcamosnow",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightsteelcamodesert",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightsteelcamomesa",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightsteelcamoswamp",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightsteelcamojungle",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:lightsteelcamotaiga",
-    "mass": 392.0
+    "mass": 3920.0
   },
   {
     "block": "s_a_b:steelblockcamoplains",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelblockcamoforest",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelblockcamosnow",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelblockcamodesert",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelblockcamomesa",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelblockcamoswamp",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelblockcamojungle",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:steelblockcamotaiga",
-    "mass": 1176.0
+    "mass": 11760.0
   },
   {
     "block": "s_a_b:doublesteelblockcamoplains",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:doublesteelblockcamoforest",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:doublesteelblockcamosnow",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:doublesteelblockcamodesert",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:doublesteelblockcamomesa",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:doublesteelblockcamoswamp",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:doublesteelblockcamojungle",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:doublesteelblockcamotaiga",
-    "mass": 2744.0
+    "mass": 27440.0
   },
   {
     "block": "s_a_b:hardsteelblockcamoplains",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:hardsteelblockcamoforest",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:hardsteelblockcamosnow",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:hardsteelblockcamodesert",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:hardsteelblockcamomesa",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:hardsteelblockcamoswamp",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:hardsteelblockcamojungle",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:hardsteelblockcamotaiga",
-    "mass": 4312.0
+    "mass": 43120.0
   },
   {
     "block": "s_a_b:iightsteelcamoplainsslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamoplainsvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamoplainsstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:iightsteelcamoforestslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamoforestvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamoforeststairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:iightsteelcamosnowslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamosnowvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamosnowstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:iightsteelcamodesertslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamodesertvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamodesertstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:iightsteelcamomesaslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamomesavslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamomesastairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:iightsteelcamoswampslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamoswampvslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamoswampstairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:iightsteelcamojungleslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamojunglevslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamojunglestairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:iightsteelcamotaigaslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamotaigavslab",
-    "mass": 196.0
+    "mass": 1960.0
   },
   {
     "block": "s_a_b:iightsteelcamotaigastairs",
-    "mass": 294.0
+    "mass": 2940.0
   },
   {
     "block": "s_a_b:steelcamoplainsslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamoplainsvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamoplainsstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:steelcamoforestslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamoforestvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamoforeststairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:steelcamosnowslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamosnowvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamosnowstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:steelcamodesertslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamodesertvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamodesertstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:steelcamomesaslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamomesavslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamomesastairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:steelcamoswampslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamoswampvslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamoswampstairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:steelcamojungleslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamojunglevslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamojunglestairs",
-    "mass": 882.0
+    "mass": 8820.0
   },
   {
     "block": "s_a_b:steelcamotaigaslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamotaigavslab",
-    "mass": 588.0
+    "mass": 5880.0
   },
   {
     "block": "s_a_b:steelcamotaigastairs",
-    "mass": 882.0
+    "mass": 8820.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/functional/crafting_stations.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/functional/crafting_stations.json
@@ -1,69 +1,69 @@
 [
   {
     "block": "minecraft:crafting_table",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:stonecutter",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:cartography_table",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:fletching_table",
-    "mass": 90.0,
+    "mass": 900.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:smithing_table",
-    "mass": 180.0,
+    "mass": 1800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:grindstone",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:loom",
-    "mass": 40.0
+    "mass": 400.0
   },
   {
     "block": "minecraft:furnace",
-    "mass": 280.0,
+    "mass": 2800.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:smoker",
-    "mass": 280.0,
+    "mass": 2800.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:blast_furnace",
-    "mass": 300.0,
+    "mass": 3000.0,
     "friction": 0.5
   },
   {
     "tag": "minecraft:campfires",
-    "mass": 60.0
+    "mass": 600.0
   },
   {
     "tag": "minecraft:anvil",
-    "mass": 700.0,
+    "mass": 7000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:enchanting_table",
-    "mass": 160.0
+    "mass": 1600.0
   },
   {
     "block": "minecraft:brewing_stand",
-    "mass": 80.0
+    "mass": 800.0
   }
 
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/functional/deco.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/functional/deco.json
@@ -1,171 +1,171 @@
 [
   {
     "block": "minecraft:torch",
-    "mass": 0.5
+    "mass": 5.0
   },
   {
     "block": "minecraft:wall_torch",
-    "mass": 0.5
+    "mass": 5.0
   },
   {
     "block": "minecraft:soul_torch",
-    "mass": 0.5
+    "mass": 5.0
   },
   {
     "block": "minecraft:soul_wall_torch",
-    "mass": 0.5
+    "mass": 5.0
   },
   {
     "block": "minecraft:lantern",
-    "mass": 2.5
+    "mass": 25.0
   },
   {
     "block": "minecraft:soul_lantern",
-    "mass": 2.5
+    "mass": 25.0
   },
   {
     "block": "minecraft:end_rod",
-    "mass": 10.0,
+    "mass": 100.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:glowstone",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:shroomlight",
-    "mass": 80.0
+    "mass": 800.0
   },
   {
     "block": "minecraft:ochre_froglight",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.07,
     "elasticity": 0.8
   },
   {
     "block": "minecraft:verdant_froglight",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.07,
     "elasticity": 0.8
   },
   {
     "block": "minecraft:pearlescent_froglight",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.07,
     "elasticity": 0.8
   },
   {
     "block": "minecraft:crying_obsidian",
-    "mass": 500.0,
+    "mass": 5000.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:glow_lichen",
-    "mass": 0.10
+    "mass": 1.0
   },
   {
     "block": "minecraft:magma_block",
-    "mass": 300.0,
+    "mass": 3000.0,
     "friction": 0.4
   },
   {
     "tag": "minecraft:flower_pots",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:decorated_pot",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.35
   },
   {
     "block": "minecraft:bookshelf",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:chiseled_bookshelf",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:skeleton_skull",
-    "mass": 2.5,
+    "mass": 25.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:wither_skeleton_skull",
-    "mass": 2.5,
+    "mass": 25.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:zombie_head",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:player_head",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:creeper_head",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:dragon_head",
-    "mass": 7.5
+    "mass": 75.0
   },
   {
     "block": "minecraft:skeleton_wall_skull",
-    "mass": 2.5,
+    "mass": 25.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:wither_skeleton_wall_skull",
-    "mass": 2.5,
+    "mass": 25.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:zombie_wall_head",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:player_wall_head",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:creeper_wall_head",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:dragon_wall_head",
-    "mass": 7.5
+    "mass": 75.0
   },
   {
     "block": "minecraft:piglin_head",
-    "mass": 0.5
+    "mass": 50.0
   },
   {
     "block": "minecraft:piglin_wall_head",
-    "mass": 0.5
+    "mass": 50.0
   },
   {
     "block": "minecraft:dragon_egg",
-    "mass": 500.0,
+    "mass": 5000.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:carved_pumpkin",
-    "mass": 10.0,
+    "mass": 100.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:jack_o_lantern",
-    "mass": 10.0,
+    "mass": 105.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:hay_block",
-    "mass": 20.0,
+    "mass": 200.0,
     "friction": 0.6,
     "elasticity": 0.3
   }

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/functional/misc.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/functional/misc.json
@@ -1,116 +1,116 @@
 [
   {
     "block": "minecraft:beacon",
-    "mass": 400.0,
+    "mass": 4000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:conduit",
-    "mass": 75.0
+    "mass": 750.0
   },
   {
     "block": "minecraft:lodestone",
-    "mass": 445.0,
+    "mass": 4450.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:ladder",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:scaffolding",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:bee_nest",
-    "mass": 40.0,
+    "mass": 400.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:beehive",
-    "mass": 40.0,
+    "mass": 400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:suspicious_sand",
-    "mass": 160.0,
+    "mass": 1600.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:suspicious_gravel",
-    "mass": 160.0,
+    "mass": 1600.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:ender_chest",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:respawn_anchor",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:infested_stone",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:infested_cobblestone",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:infested_stone_bricks",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:infested_mossy_stone_bricks",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:infested_cracked_stone_bricks",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:infested_chiseled_stone_bricks",
-    "mass": 275.0,
+    "mass": 2750.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:infested_deepslate",
-    "mass": 305.0,
+    "mass": 3050.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:end_portal_frame",
-    "mass": 300.0,
+    "mass": 3000.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:cake",
-    "mass": 5.0,
+    "mass": 50.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:sponge",
-    "mass": 15.0,
+    "mass": 150.0,
     "friction": 0.6,
     "elasticity": 0.2
   },
   {
     "block": "minecraft:wet_sponge",
-    "mass": 115.0,
+    "mass": 1150.0,
     "friction": 0.3,
     "elasticity": 0.6
   },
   {
     "block": "minecraft:cobweb",
-    "mass": 0.01,
+    "mass": 0.1,
     "friction": 1.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/natural/dirt.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/natural/dirt.json
@@ -1,42 +1,42 @@
 [
   {
     "block": "minecraft:grass_block",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:podzol",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:mycelium",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:dirt_path",
-    "mass": 115.0,
+    "mass": 1150.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:dirt",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:coarse_dirt",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:rooted_dirt",
-    "mass": 120.0,
+    "mass": 1200.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:farmland",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.6
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/natural/misc.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/natural/misc.json
@@ -1,132 +1,132 @@
 [
   {
     "block": "minecraft:dripstone_block",
-    "mass": 270.0,
+    "mass": 2700.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:pointed_dripstone",
-    "mass": 190.0,
+    "mass": 1900.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:budding_amethyst",
-    "mass": 265.0,
+    "mass": 2650.0,
     "friction": 1.0
   },
   {
     "block": "minecraft:ice",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.05
   },
   {
     "block": "minecraft:packed_ice",
-    "mass": 90.0,
+    "mass": 900.0,
     "friction": 0.02
   },
   {
     "block": "minecraft:blue_ice",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.0
   },
   {
     "block": "minecraft:snow",
-    "mass": 2.5,
-    "friction": 0.2
-  },
-  {
-    "block": "minecraft:snow_block",
     "mass": 25.0,
     "friction": 0.2
   },
   {
+    "block": "minecraft:snow_block",
+    "mass": 250.0,
+    "friction": 0.2
+  },
+  {
     "block": "minecraft:crimson_nylium",
-    "mass": 118.0
+    "mass": 1180.0
   },
   {
     "block": "minecraft:warped_nylium",
-    "mass": 118.0
+    "mass": 1180.0
   },
   {
     "block": "minecraft:soul_sand",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.9
   },
   {
     "block": "minecraft:soul_soil",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:bone_block",
-    "mass": 200.0,
+    "mass": 2000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:small_amethyst_bud",
-    "mass": 10.0,
+    "mass": 100.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:medium_amethyst_bud",
-    "mass": 30.0,
+    "mass": 300.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:large_amethyst_bud",
-    "mass": 60.0,
+    "mass": 600.0,
     "friction": 0.9
   },
   {
     "block": "minecraft:amethyst_cluster",
-    "mass": 90.0,
+    "mass": 900.0,
     "friction": 0.9
   },
   {
     "tag": "minecraft:nylium",
-    "mass": 118.0,
+    "mass": 1180.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:frogspawn",
-    "mass": 1.0,
+    "mass": 10.0,
     "friction": 0.03
   },
   {
     "block": "minecraft:sculk_catalyst",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:sculk_vein",
-    "mass": 5.0,
+    "mass": 50.0,
     "friction": 0.2,
     "elasticity": 0.03
   },
   {
     "block": "minecraft:sculk",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.2,
     "elasticity": 0.3
   },
   {
     "block": "minecraft:sniffer_egg",
-    "mass": 95.0,
+    "mass": 950.0,
     "friction": 0.1
   },
   {
     "block": "minecraft:dried_kelp_block",
-    "mass": 40.0,
+    "mass": 400.0,
     "friction": 0.6,
     "elasticity": 0.3
   },
   {
     "block": "minecraft:honeycomb_block",
-    "mass": 90.0,
+    "mass": 900.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:turtle_egg",
-    "mass": 1.0
+    "mass": 10.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/natural/ore.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/natural/ore.json
@@ -1,112 +1,112 @@
 [
   {
     "block": "minecraft:coal_ore",
-    "mass": 245.0,
+    "mass": 2450.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:deepslate_coal_ore",
-    "mass": 271.5,
+    "mass": 2715.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:iron_ore",
-    "mass": 315.0,
+    "mass": 3150.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:deepslate_iron_ore",
-    "mass": 345.0,
+    "mass": 3450.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:copper_ore",
-    "mass": 325.0,
+    "mass": 3250.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:deepslate_copper_ore",
-    "mass": 355.0,
+    "mass": 3550.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:gold_ore",
-    "mass": 445.0,
+    "mass": 4450.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:deepslate_gold_ore",
-    "mass": 470.0,
+    "mass": 4700.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:redstone_ore",
-    "mass": 195.0,
+    "mass": 1950.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:deepslate_redstone_ore",
-    "mass": 222.5,
+    "mass": 2225.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:emerald_ore",
-    "mass": 260.0,
+    "mass": 2600.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:deepslate_emerald_ore",
-    "mass": 285.5,
+    "mass": 2855.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:lapis_ore",
-    "mass": 270.0,
+    "mass": 2700.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:deepslate_lapis_ore",
-    "mass": 295.0,
+    "mass": 2950.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:diamond_ore",
-    "mass": 270.0,
+    "mass": 2700.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:deepslate_diamond_ore",
-    "mass": 295.0,
+    "mass": 2950.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:nether_gold_ore",
-    "mass": 225.0,
+    "mass": 2250.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:nether_quartz_ore",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:ancient_debris",
-    "mass": 315.0,
+    "mass": 3150.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:raw_iron_block",
-    "mass": 785.0,
+    "mass": 7850.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:raw_copper_block",
-    "mass": 900.0,
+    "mass": 9000.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:raw_gold_block",
-    "mass": 1930.0,
+    "mass": 19300.0,
     "friction": 0.8
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/natural/plants.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/natural/plants.json
@@ -1,274 +1,274 @@
 [
   {
     "tag": "minecraft:small_flowers",
-    "mass": 1.0
-  },
-  {
-    "tag": "minecraft:tall_flowers",
-    "mass": 2.0
-  },
-  {
-    "block": "minecraft:grass",
-    "mass": 2.0
-  },
-  {
-    "block": "minecraft:tall_grass",
-    "mass": 2.0
-  },
-  {
-    "block": "minecraft:fern",
-    "mass": 2.0
-  },
-  {
-    "block": "minecraft:large_fern",
-    "mass": 2.0
-  },
-  {
-    "block": "minecraft:lily_pad",
-    "mass": 2.0
-  },
-  {
-    "block": "minecraft:vine",
-    "mass": 2.0
-  },
-  {
-    "block": "minecraft:cocoa",
-    "mass": 5.0
-  },
-  {
-    "block": "minecraft:wheat",
-    "mass": 2.0
-  },
-  {
-    "block": "minecraft:beetroots",
-    "mass": 2.0
-  },
-  {
-    "block": "minecraft:carrots",
-    "mass": 2.0
-  },
-  {
-    "block": "minecraft:potatoes",
-    "mass": 2.0
-  },
-  {
-    "block": "minecraft:sweet_berry_bush",
-    "mass": 5.0
-  },
-  {
-    "block": "minecraft:sugar_cane",
     "mass": 10.0
   },
   {
+    "tag": "minecraft:tall_flowers",
+    "mass": 20.0
+  },
+  {
+    "block": "minecraft:grass",
+    "mass": 20.0
+  },
+  {
+    "block": "minecraft:tall_grass",
+    "mass": 20.0
+  },
+  {
+    "block": "minecraft:fern",
+    "mass": 20.0
+  },
+  {
+    "block": "minecraft:large_fern",
+    "mass": 20.0
+  },
+  {
+    "block": "minecraft:lily_pad",
+    "mass": 20.0
+  },
+  {
+    "block": "minecraft:vine",
+    "mass": 20.0
+  },
+  {
+    "block": "minecraft:cocoa",
+    "mass": 50.0
+  },
+  {
+    "block": "minecraft:wheat",
+    "mass": 20.0
+  },
+  {
+    "block": "minecraft:beetroots",
+    "mass": 20.0
+  },
+  {
+    "block": "minecraft:carrots",
+    "mass": 20.0
+  },
+  {
+    "block": "minecraft:potatoes",
+    "mass": 20.0
+  },
+  {
+    "block": "minecraft:sweet_berry_bush",
+    "mass": 50.0
+  },
+  {
+    "block": "minecraft:sugar_cane",
+    "mass": 100.0
+  },
+  {
     "block": "minecraft:bamboo_sapling",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:bamboo",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:kelp",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:kelp_plant",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:seagrass",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:sea_pickle",
-    "mass": 2.0,
+    "mass": 20.0,
     "elasticity": 0.1
   },
   {
     "tag": "minecraft:coral_blocks",
-    "mass": 15.0,
+    "mass": 150.0,
     "friction": 0.7
   },
   {
     "tag": "minecraft:corals",
-    "mass": 5.0,
+    "mass": 50.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:dead_bush",
-    "mass": 10.0
+    "mass": 100.0
   },
   {
     "block": "minecraft:cactus",
-    "mass": 60.0
+    "mass": 600.0
   },
   {
     "block": "minecraft:melon_stem",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:attached_melon_stem",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:melon",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:pumpkin_stem",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:attached_pumpkin_stem",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:pumpkin",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:carved_pumpkin",
-    "mass": 40.0,
+    "mass": 400.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:warped_fungus",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:nether_sprouts",
-    "mass": 1.0
+    "mass": 10.0
   },
   {
     "block": "minecraft:warped_roots",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:twisting_vines",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:twisting_vines_plant",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "block": "minecraft:crimson_fungus",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:nether_wart",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:crimson_roots",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:weeping_vines",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:weeping_vines_plant",
-    "mass": 5.0
+    "mass": 50.0
   },
   {
     "tag": "minecraft:wart_blocks",
-    "mass": 60.0,
+    "mass": 600.0,
     "elasticity": 0.1
   },
   {
     "block": "minecraft:chorus_plant",
-    "mass": 30.0,
+    "mass": 300.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:chorus_flower",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:brown_mushroom_block",
-    "mass": 40.0,
+    "mass": 400.0,
     "friction": 0.2,
     "elasticity": 0.1
   },
   {
     "block": "minecraft:red_mushroom_block",
-    "mass": 40.0,
+    "mass": 400.0,
     "friction": 0.2,
     "elasticity": 0.1
   },
   {
     "block": "minecraft:brown_mushroom",
-    "mass": 1.0
+    "mass": 10.0
   },
   {
     "block": "minecraft:red_mushroom",
-    "mass": 1.0
+    "mass": 10.0
   },
   {
     "block": "minecraft:azalea",
-    "mass": 12.0,
+    "mass": 120.0,
     "elasticity": 0.1
   },
   {
     "block": "minecraft:flowering_azalea",
-    "mass": 12.0,
+    "mass": 120.0,
     "elasticity": 0.1
   },
   {
     "block": "minecraft:big_dripleaf",
-    "mass": 0.80,
+    "mass": 8.0,
     "friction": 0.3,
     "elasticity": 0.3
   },
   {
     "block": "minecraft:big_dripleaf_stem",
-    "mass": 0.40
+    "mass": 4.0
   },
   {
     "block": "minecraft:small_dripleaf",
-    "mass": 0.30
+    "mass": 3.0
   },
   {
     "block": "minecraft:cave_vines",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:cave_vines_plant",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:spore_blossom",
-    "mass": 1.20
+    "mass": 12.0
   },
   {
     "block": "minecraft:moss_block",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.5,
     "elasticity": 0.05
   },
   {
     "block": "minecraft:moss_carpet",
-    "mass": 1.5,
+    "mass": 15.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:hanging_roots",
-    "mass": 0.40
+    "mass": 4.0
   },
   {
     "block": "minecraft:pink_petals",
-    "mass": 0.1
+    "mass": 1.0
   },
   {
     "block": "minecraft:torchflower_crop",
-    "mass": 2.0
+    "mass": 20.0
   },
   {
     "block": "minecraft:pitcher_crop",
-    "mass": 2.0
+    "mass": 20.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/natural/stone_ish.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/natural/stone_ish.json
@@ -1,32 +1,32 @@
 [
   {
     "block": "minecraft:clay",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.4
   },
   {
     "tag": "minecraft:sand",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:gravel",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:tuff",
-    "mass": 180.0,
+    "mass": 1800.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:calcite",
-    "mass": 270.0,
+    "mass": 2700.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:obsidian",
-    "mass": 500.0,
+    "mass": 5000.0,
     "friction": 0.8
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/natural/tree.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/natural/tree.json
@@ -1,31 +1,31 @@
 [
   {
     "block": "minecraft:mangrove_roots",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:muddy_mangrove_roots",
-    "mass": 150.0,
+    "mass": 1500.0,
     "friction": 0.8
   },
   {
     "block": "minecraft:mushroom_stem",
-    "mass": 60.0,
+    "mass": 600.0,
     "friction": 0.2,
     "elasticity": 0.1
   },
   {
     "tag": "minecraft:saplings",
-    "mass": 15.0
+    "mass": 150.0
   },
   {
     "block": "minecraft:mangrove_propagule",
-    "mass": 15.0
+    "mass": 150.0
   },
   {
     "tag": "minecraft:leaves",
-    "mass": 20.0,
+    "mass": 200.0,
     "elasticity": 0.15
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/redstone/blocks.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/redstone/blocks.json
@@ -1,157 +1,157 @@
 [
   {
     "block": "minecraft:target",
-    "mass": 20.0,
+    "mass": 200.0,
     "elasticity": 0.3
   },
   {
     "block": "minecraft:calibrated_sculk_sensor",
-    "mass": 25.0,
+    "mass": 250.0,
     "friction": 0.9,
     "elasticity": 0.3
   },
   {
     "block": "minecraft:sculk_shrieker",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.2,
     "elasticity": 0.3
   },
   {
     "block": "minecraft:lectern",
-    "mass": 15.0
+    "mass": 150.0
   },
   {
     "block": "minecraft:daylight_detector",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:lightning_rod",
-    "mass": 180.0,
+    "mass": 1800.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:piston",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:sticky_piston",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:piston_head",
-    "mass": 0.1,
+    "mass": 1.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:moving_piston",
-    "mass": 0.1,
+    "mass": 1.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:slime_block",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 1.0,
     "elasticity": 1.0
   },
   {
     "block": "minecraft:honey_block",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 1.0
   },
   {
     "block": "minecraft:dispenser",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:dropper",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:hopper",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:chest",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:barrel",
-    "mass": 40.0,
+    "mass": 400.0,
     "friction": 0.4
   },
   {
     "block": "minecraft:trapped_chest",
-    "mass": 105.0
+    "mass": 1050.0
   },
   {
     "block": "minecraft:jukebox",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:observer",
-    "mass": 250.0,
+    "mass": 2500.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:note_block",
-    "mass": 100.0,
+    "mass": 1000.0,
     "friction": 0.6
   },
   {
     "block": "minecraft:composter",
-    "mass": 35.0,
+    "mass": 350.0,
     "friction": 0.5
   },
   {
     "block": "minecraft:cauldron",
-    "mass": 540.0,
+    "mass": 5400.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:water_cauldron",
-    "mass": 590.0,
+    "mass": 5900.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:rail",
-    "mass": 35.0,
+    "mass": 350.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:powered_rail",
-    "mass": 80.0,
+    "mass": 800.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:detector_rail",
-    "mass": 40.0,
+    "mass": 400.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:activator_rail",
-    "mass": 35.0,
+    "mass": 350.0,
     "friction": 0.7
   },
   {
     "block": "minecraft:tnt",
-    "mass": 125.0
+    "mass": 1250.0
   },
   {
     "block": "minecraft:redstone_lamp",
-    "mass": 125.0,
+    "mass": 1250.0,
     "friction": 0.2
   },
   {
     "block": "minecraft:bell",
-    "mass": 50.0,
+    "mass": 500.0,
     "friction": 0.2
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/redstone/components.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/redstone/components.json
@@ -1,32 +1,32 @@
 [
   {
     "block": "minecraft:redstone_wire",
-    "mass": 0.5
+    "mass": 5.0
   },
   {
     "block": "minecraft:redstone_torch",
-    "mass": 0.5
+    "mass": 5.0
   },
   {
     "block": "minecraft:repeater",
-    "mass": 20.0,
+    "mass": 200.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:comparator",
-    "mass": 20.0,
+    "mass": 200.0,
     "friction": 0.3
   },
   {
     "block": "minecraft:lever",
-    "mass": 1.0
+    "mass": 10.0
   },
   {
     "block": "minecraft:tripwire_hook",
-    "mass": 0.5
+    "mass": 5.0
   },
   {
     "block": "minecraft:tripwire",
-    "mass": 0.1
+    "mass": 1.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/unobtainable.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/unobtainable.json
@@ -1,35 +1,35 @@
 [
   {
     "block": "minecraft:light",
-    "mass": 0.01
+    "mass": 0.1
   },
   {
     "block": "minecraft:barrier",
-    "mass": 0.01
+    "mass": 0.1
   },
   {
     "block": "minecraft:command_block",
-    "mass": 0.01
+    "mass": 0.1
   },
   {
     "block": "minecraft:chain_command_block",
-    "mass": 0.01
+    "mass": 0.1
   },
   {
     "block": "minecraft:repeating_command_block",
-    "mass": 0.01
+    "mass": 0.1
   },
   {
     "block": "minecraft:structure_block",
-    "mass": 0.01
+    "mass": 0.1
   },
   {
     "tag": "minecraft:fire",
-    "mass": 0.01
+    "mass": 0.1
   },
   {
     "tag": "minecraft:portals",
-    "mass": 0.01
+    "mass": 0.1
   },
   {
     "block": "minecraft:bedrock",


### PR DESCRIPTION
# ⚒️ Pull Request Offering
---
## 🧾 What This PR Does
- Restores water to be 1,000kg and lava to be 10,000kg
- Updates block masses to be consistent with water that is 1,000kg in weight, as it was in VS 2.3


## 🔍 How This Was Tested
- [ ] GameTest framework  
- [X] Singleplayer / Server  
- [ ] Logs looked sane  
- [X] The vibes felt right *(sometimes you really do just have to vibe it)*


## ⚠️ Breaking Changes
- [ ] Yes (describe)  
- [X] No  (are you *really* sure?)

---

## 🧪 GameTest Oath
- No gametest because only data was changed

---

## 🗝️ Additional Notes
Anything else reviewers might need to know:
performance concerns, edge cases, forbidden knowledge, etc. 💀

---

## 🜏 Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- No worlds shall be harmed in the making or merging of this PR 💀
