### PR TITLE
Small but important frogport fix

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/blockentity/MixinChainConveyorBlockEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/blockentity/MixinChainConveyorBlockEntity.java
@@ -1,7 +1,5 @@
 package org.valkyrienskies.mod.mixin.mod_compat.create.blockentity;
 
-import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.simibubi.create.content.kinetics.chainConveyor.ChainConveyorBlockEntity;
 import com.simibubi.create.content.kinetics.chainConveyor.ChainConveyorPackage;
 import com.simibubi.create.infrastructure.config.AllConfigs;
@@ -10,37 +8,47 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.mod.common.CompatUtil;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
 @Mixin(ChainConveyorBlockEntity.class)
 public class MixinChainConveyorBlockEntity extends BlockEntity {
     // This is related to frogports. Technically it's not frogports pulling the packages from chain conveyors, but
     // rather the conveyors visiting paired frogports and exporting packages to them. Putting packages on the conveyor
     // is handled by frogports, though.
-    @WrapMethod(method = "exportToPort")
-    private boolean cancelExportIfTooFar(ChainConveyorPackage box, BlockPos offset, Operation<Boolean> original) {
+    @Inject(method = "exportToPort", at = @At("HEAD"), cancellable = true)
+    private void cancelExportIfTooFar(ChainConveyorPackage box, BlockPos offset, CallbackInfoReturnable<Boolean> cir) {
         BlockPos targetPos = getBlockPos().offset(offset);
+        if (
+            VSGameUtilsKt.getShipManagingPos(level, worldPosition) == VSGameUtilsKt.getShipManagingPos(level, targetPos)
+        ) return;
         double dist = CompatUtil.INSTANCE.toSameSpaceAs(
             level,
             getBlockPos().getCenter(),
             targetPos.getCenter()
         ).distanceTo(targetPos.getCenter());
-        if (dist <= (double)((Integer) AllConfigs.server().logistics.packagePortRange.get() + 2)) {
-            return original.call(box, offset);
+        if (dist > (double)((Integer) AllConfigs.server().logistics.packagePortRange.get() + 2)) {
+            cir.setReturnValue(false);
         }
-        return false;
     }
 
-    @WrapMethod(method = "notifyPortToAnticipate")
-    private void cancelNotifyIfTooFar(BlockPos offset, Operation<Void> original) {
+    @Inject(method = "notifyPortToAnticipate", at = @At("HEAD"), cancellable = true)
+    private void cancelNotifyIfTooFar(BlockPos offset, CallbackInfo ci) {
         BlockPos targetPos = getBlockPos().offset(offset);
+        if (
+            VSGameUtilsKt.getShipManagingPos(level, worldPosition) == VSGameUtilsKt.getShipManagingPos(level, targetPos)
+        ) return;
         double dist = CompatUtil.INSTANCE.toSameSpaceAs(
             level,
             getBlockPos().getCenter(),
             targetPos.getCenter()
         ).distanceTo(targetPos.getCenter());
-        if (dist <= (double)((Integer) AllConfigs.server().logistics.packagePortRange.get() + 2)) {
-            original.call(offset);
+        if (dist > (double)((Integer) AllConfigs.server().logistics.packagePortRange.get() + 2)) {
+            ci.cancel();
         }
     }
 

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/blockentity/MixinFrogportBlockEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/blockentity/MixinFrogportBlockEntity.java
@@ -16,6 +16,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.valkyrienskies.mod.common.CompatUtil;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
 @Mixin(FrogportBlockEntity.class)
 public abstract class MixinFrogportBlockEntity extends PackagePortBlockEntity {
@@ -30,6 +31,9 @@ public abstract class MixinFrogportBlockEntity extends PackagePortBlockEntity {
     )
     private void cancelIfTooFar(CallbackInfo ci) {
         BlockPos targetPos = getBlockPos().offset(target != null ? target.relativePos : BlockPos.ZERO);
+        if (
+            VSGameUtilsKt.getShipManagingPos(level, worldPosition) == VSGameUtilsKt.getShipManagingPos(level, targetPos)
+        ) return;
         double dist = CompatUtil.INSTANCE.toSameSpaceAs(
             level,
             getBlockPos().getCenter(),


### PR DESCRIPTION
Bypasses all the distance checks if frogport and its target are in the same ship (including in world). Fixes problems with frogports not working in world sometimes (need to investigate further but this will fix regular Create gameplay)