### PR TITLE
Reduce copycat mass to 50kg

### DIFF
--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/copiescats.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/copiescats.json
@@ -1,34 +1,34 @@
 [
   {
     "block": "copiescats:copycat_ten",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copiescats:copycat_four",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copiescats:copycat_six",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copiescats:copycat_slab",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copiescats:copycat_two",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copiescats:copycat_twelve",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copiescats:copycat_fourteen",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copiescats:copycat_sixteen",
-    "mass": 500.0
+    "mass": 50.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/copycatsplus.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/copycatsplus.json
@@ -1,98 +1,98 @@
 [
   {
     "block": "copycats:copycat_layer",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_slab",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_beam",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_vertical_step",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_half_panel",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_stairs",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_fence",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_fence_gate",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_trapdoor",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_wall",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_board",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_box",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_catwalk",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_byte",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_block",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_half_layer",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_slice",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_vertical_slice",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_wooden_button",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_stone_button",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_wooden_pressure_plate",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_stone_pressure_plate",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_heavy_weighted_pressure_plate",
-    "mass": 500.0
+    "mass": 50.0
   },
   {
     "block": "copycats:copycat_light_weighted_pressure_plate",
-    "mass": 500.0
+    "mass": 50.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create.json
@@ -631,7 +631,7 @@
   },
   {
     "block": "create:copycat_panel",
-    "mass": 25.0,
+    "mass": 50.0,
     "friction": 0.5
   },
   {


### PR DESCRIPTION
Copycats used to be 1000kg (the default value) on VS 2.3, which was too heavy. VS addition set the default value (and so, copycats too) to 100kg. Some people used datapacks to make copycats 10kg. 

Currently in VS 2.4 copycats are 500kg, which is still rather heavy. This PR makes them 50kg, which seems a good middle ground between VS additions old value and custom datapacks. This applies to copycats+, and copies and cats.

Additionally, the VS config currently has **100kg** set as the default. The intention was to set it to **1000kg** with the 2.4 weight re-balance, but this seems to have gotten lost along the way. This pr **does not fix that**, as I believe the perfect value is still being discussed.