### PR TITLE
More default masses for mod compat

### DIFF
--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/autumnity.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/autumnity.json
@@ -1,0 +1,37 @@
+[
+  {
+    "block": "autumnity:large_pumpkin_slice",
+    "mass": 800.0,
+    "friction": 0.3
+  },
+  {
+    "block": "autumnity:carved_large_pumpkin_slice",
+    "mass": 100.0,
+    "friction": 0.3
+  },
+  {
+    "block": "autumnity:large_jack_o_lantern_slice",
+    "mass": 100.0,
+    "friction": 0.3
+  },
+  {
+    "block": "autumnity:soul_jack_o_lantern",
+    "mass": 100.0,
+    "friction": 0.3
+  },
+  {
+    "block": "autumnity:large_soul_jack_o_lantern_slice",
+    "mass": 100.0,
+    "friction": 0.3
+  },
+  {
+    "block": "autumnity:redstone_jack_o_lantern",
+    "mass": 100.0,
+    "friction": 0.3
+  },
+  {
+    "block": "autumnity:large_redstone_jack_o_lantern_slice",
+    "mass": 100.0,
+    "friction": 0.3
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/biomeswevegone.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/biomeswevegone.json
@@ -1,0 +1,37 @@
+[
+  {
+    "block": "biomeswevegone:mossy_stone",
+    "mass": 2500.0,
+    "friction": 0.6
+  },
+  {
+    "block": "biomeswevegone:mossy_stone_stairs",
+    "mass": 1875.0,
+    "friction": 0.6
+  },
+  {
+    "block": "biomeswevegone:mossy_stone_slab",
+    "mass": 1250.0,
+    "friction": 0.6
+  },
+  {
+    "block": "biomeswevegone:black_ice",
+    "mass": 800.0,
+    "friction": 0.05
+  },
+  {
+    "block": "biomeswevegone:packed_black_ice",
+    "mass": 900.0,
+    "friction": 0.02
+  },
+  {
+    "block": "biomeswevegone:borealis_ice",
+    "mass": 800.0,
+    "friction": 0.05
+  },
+  {
+    "block": "biomeswevegone:packed_borealis_ice",
+    "mass": 900.0,
+    "friction": 0.02
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create.json
@@ -561,23 +561,28 @@
   },
   {
     "block": "create:pulse_repeater",
-    "mass": 300.0,
-    "friction": 0.5
+    "mass": 200.0,
+    "friction": 0.3
   },
   {
     "block": "create:pulse_extender",
-    "mass": 300.0,
-    "friction": 0.5
+    "mass": 200.0,
+    "friction": 0.3
+  },
+  {
+    "block": "create:pulse_timer",
+    "mass": 200.0,
+    "friction": 0.3
   },
   {
     "block": "create:powered_latch",
-    "mass": 300.0,
-    "friction": 0.5
+    "mass": 200.0,
+    "friction": 0.3
   },
   {
     "block": "create:powered_toggle_latch",
-    "mass": 300.0,
-    "friction": 0.5
+    "mass": 200.0,
+    "friction": 0.3
   },
   {
     "block": "create:lectern_controller",

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create.json
@@ -620,16 +620,6 @@
     "friction": 0.65
   },
   {
-    "block": "create:raw_zinc_block",
-    "mass": 7150.0,
-    "friction": 0.65
-  },
-  {
-    "block": "create:zinc_block",
-    "mass": 7150.0,
-    "friction": 0.4
-  },
-  {
     "block": "create:copycat_step",
     "mass": 50.0,
     "friction": 0.5

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create_compressed.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create_compressed.json
@@ -1,0 +1,57 @@
+[
+  {
+    "block": "create_compressed:cogwheel_block",
+    "mass": 3150.0,
+    "friction": 0.4
+  },
+  {
+    "block": "create_compressed:large_cogwheel_block",
+    "mass": 4950.0,
+    "friction": 0.4
+  },
+  {
+    "block": "create_compressed:belt_block",
+    "mass": 450.0,
+    "friction": 0.4
+  },
+  {
+    "block": "create_compressed:shaft_bundle",
+    "mass": 1350.0,
+    "friction": 0.3
+  },
+  {
+    "block": "create_compressed:cinder_flour_pile",
+    "mass": 1500.0,
+    "friction": 0.85
+  },
+  {
+    "block": "create_compressed:copper_sheet_block",
+    "mass": 9000.0,
+    "friction": 0.15
+  },
+  {
+    "block": "create_compressed:iron_sheet_block",
+    "mass": 7850.0,
+    "friction": 0.15
+  },
+  {
+    "block": "create_compressed:gold_sheet_block",
+    "mass": 19300.0,
+    "friction": 0.15
+  },
+  {
+    "block": "create_compressed:crushed_copper_pile",
+    "mass": 9000.0,
+    "friction": 0.9
+  },
+  {
+    "block": "create_compressed:crushed_iron_pile",
+    "mass": 7850.0,
+    "friction": 0.9
+  },
+  {
+    "block": "create_compressed:crushed_gold_pile",
+    "mass": 19300.0,
+    "friction": 0.9
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create_connected.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create_connected.json
@@ -1,0 +1,57 @@
+[
+  {
+    "block": "create_connected:crank_wheel",
+    "mass": 400.0,
+    "friction": 0.7
+  },
+  {
+    "block": "create_connected:large_crank_wheel",
+    "mass": 600.0,
+    "friction": 0.7
+  },
+  {
+    "block": "create_connected:inverted_clutch",
+    "mass": 1100.0,
+    "friction": 0.4
+  },
+  {
+    "block": "create_connected:inverted_gearshift",
+    "mass": 1100.0,
+    "friction": 0.4
+  },
+  {
+    "block": "create_connected:parallel_gearbox",
+    "mass": 1210.0,
+    "friction": 0.4
+  },
+  {
+    "block": "create_connected:shear_pin",
+    "mass": 120.0,
+    "friction": 0.7
+  },
+  {
+    "block": "create_connected:item_silo",
+    "mass": 1050.0,
+    "friction": 0.1
+  },
+  {
+    "block": "create_connected:fluid_vessel",
+    "mass": 5000.0,
+    "friction": 0.4
+  },
+  {
+    "block": "create_connected:creative_fluid_vessel",
+    "mass": 5000.0,
+    "friction": 0.4
+  },
+  {
+    "block": "create_connected:sequenced_pulse_generator",
+    "mass": 200.0,
+    "friction": 0.3
+  },
+  {
+    "block": "create_connected:empty_fan_catalyst",
+    "mass": 3000.0,
+    "friction": 0.2
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create_new_age.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create_new_age.json
@@ -1,0 +1,27 @@
+[
+  {
+    "block": "create_new_age:generator_coil",
+    "mass": 12000.0,
+    "friction": 0.9
+  },
+  {
+    "block": "create_new_age:redstone_magnet",
+    "mass": 1500.0,
+    "friction": 0.4
+  },
+  {
+    "block": "create_new_age:layered_magnet",
+    "mass": 3000.0,
+    "friction": 0.5
+  },
+  {
+    "block": "create_new_age:fluxated_magnetite",
+    "mass": 6000.0,
+    "friction": 0.2
+  },
+  {
+    "block": "create_new_age:netherite_magnet",
+    "mass": 18000.0,
+    "friction": 0.2
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create_vibrant_vaults.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create_vibrant_vaults.json
@@ -1,0 +1,12 @@
+[
+  {
+    "tag": "create_vibrant_vaults:item_vaults",
+    "mass": 1050.0,
+    "friction": 0.1
+  },
+  {
+    "tag": "create_vibrant_vaults:shipping_containers",
+    "mass": 1050.0,
+    "friction": 0.1
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/default/raw_storage_blocks.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/default/raw_storage_blocks.json
@@ -5,6 +5,11 @@
     "friction": 0.8
   },
   {
+    "tag": "forge:storage_blocks/raw_beryllium",
+    "mass": 1850.0,
+    "friction": 0.8
+  },
+  {
     "tag": "forge:storage_blocks/raw_cobalt",
     "mass": 8340.0,
     "friction": 0.8
@@ -25,6 +30,21 @@
     "friction": 0.8
   },
   {
+    "tag": "forge:storage_blocks/raw_magnetite",
+    "mass": 7850.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_neodymium",
+    "mass": 7010.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_nickel",
+    "mass": 8910.0,
+    "friction": 0.8
+  },
+  {
     "tag": "forge:storage_blocks/raw_opal",
     "mass": 2090.0,
     "friction": 0.8
@@ -40,8 +60,18 @@
     "friction": 0.8
   },
   {
+    "tag": "forge:storage_blocks/raw_tantalite",
+    "mass": 16650.0,
+    "friction": 0.8
+  },
+  {
     "tag": "forge:storage_blocks/raw_tin",
     "mass": 7290.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_titanium",
+    "mass": 4510.0,
     "friction": 0.8
   },
   {
@@ -52,6 +82,11 @@
   {
     "tag": "forge:storage_blocks/raw_vanadium",
     "mass": 6100.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_zinc",
+    "mass": 7150.0,
     "friction": 0.8
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/default/raw_storage_blocks.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/default/raw_storage_blocks.json
@@ -1,0 +1,57 @@
+[
+  {
+    "tag": "forge:storage_blocks/raw_aluminum",
+    "mass": 2700.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_cobalt",
+    "mass": 8340.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_iridium",
+    "mass": 22560.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_lead",
+    "mass": 11350.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_lithium",
+    "mass": 530.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_opal",
+    "mass": 2090.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_osmium",
+    "mass": 22590.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_silver",
+    "mass": 10490.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_tin",
+    "mass": 7290.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_uranium",
+    "mass": 19050.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "forge:storage_blocks/raw_vanadium",
+    "mass": 6100.0,
+    "friction": 0.8
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/default/storage_blocks.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/default/storage_blocks.json
@@ -10,13 +10,33 @@
     "friction": 0.2
   },
   {
+    "tag": "forge:storage_blocks/beryllium",
+    "mass": 1850.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/charcoal",
+    "mass": 1500.0,
+    "friction": 0.7
+  },
+  {
     "tag": "forge:storage_blocks/cobalt",
     "mass": 8340.0,
     "friction": 0.2
   },
   {
+    "tag": "forge:storage_blocks/constantan",
+    "mass": 8890.0,
+    "friction": 0.2
+  },
+  {
     "tag": "forge:storage_blocks/electrum",
     "mass": 8650.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/gallium",
+    "mass": 5910.0,
     "friction": 0.2
   },
   {
@@ -40,8 +60,18 @@
     "friction": 0.2
   },
   {
+    "tag": "forge:storage_blocks/neodymium",
+    "mass": 7010.0,
+    "friction": 0.2
+  },
+  {
     "tag": "forge:storage_blocks/neutronium",
     "mass": 250000.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/nickel",
+    "mass": 8910.0,
     "friction": 0.2
   },
   {
@@ -57,7 +87,8 @@
   {
     "tag": "forge:storage_blocks/polyethylene",
     "mass": 920.0,
-    "friction": 1.0
+    "friction": 1.0,
+    "elasticity": 0.5
   },
   {
     "tag": "forge:storage_blocks/silver",
@@ -65,8 +96,18 @@
     "friction": 0.2
   },
   {
+    "tag": "forge:storage_blocks/tantalum",
+    "mass": 16650.0,
+    "friction": 0.2
+  },
+  {
     "tag": "forge:storage_blocks/tin",
     "mass": 7290.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/titanium",
+    "mass": 4510.0,
     "friction": 0.2
   },
   {
@@ -77,6 +118,11 @@
   {
     "tag": "forge:storage_blocks/vanadium",
     "mass": 6100.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/zinc",
+    "mass": 7150.0,
     "friction": 0.2
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/default/storage_blocks.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/default/storage_blocks.json
@@ -1,0 +1,82 @@
+[
+  {
+    "tag": "forge:storage_blocks/aluminum",
+    "mass": 2700.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/annealed_copper",
+    "mass": 9000.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/cobalt",
+    "mass": 8340.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/electrum",
+    "mass": 8650.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/iridium",
+    "mass": 22560.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/lead",
+    "mass": 11350.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/lithium",
+    "mass": 530.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/magnetic_iron",
+    "mass": 7850.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/neutronium",
+    "mass": 250000.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/opal",
+    "mass": 2090.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/osmium",
+    "mass": 22590.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/polyethylene",
+    "mass": 920.0,
+    "friction": 1.0
+  },
+  {
+    "tag": "forge:storage_blocks/silver",
+    "mass": 10490.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/tin",
+    "mass": 7290.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/uranium",
+    "mass": 19050.0,
+    "friction": 0.2
+  },
+  {
+    "tag": "forge:storage_blocks/vanadium",
+    "mass": 6100.0,
+    "friction": 0.2
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/galosphere.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/galosphere.json
@@ -1,0 +1,16 @@
+[
+  {
+    "block": "galosphere:amethyst_stairs",
+    "mass": 1987.5,
+    "friction": 1.0
+  },
+  {
+    "block": "galosphere:amethyst_slab",
+    "mass": 1325.0,
+    "friction": 1.0
+  },
+  {
+    "block": "galosphere:silver_lattice",
+    "mass": 334.0
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/hexcasting.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/hexcasting.json
@@ -1,0 +1,32 @@
+[
+  {
+    "tag": "hexcasting:slate_blocks",
+    "mass": 2910.0,
+    "friction": 0.6
+  },
+  {
+    "tag": "hexcasting:amethyst_blocks",
+    "mass": 2650.0,
+    "friction": 1.0
+  },
+  {
+    "block": "hexcasting:slate_amethyst_tiles",
+    "mass": 2780.0,
+    "friction": 0.8
+  },
+  {
+    "block": "hexcasting:slate_amethyst_bricks",
+    "mass": 2780.0,
+    "friction": 0.8
+  },
+  {
+    "block": "hexcasting:slate_amethyst_bricks_small",
+    "mass": 2780.0,
+    "friction": 0.8
+  },
+  {
+    "block": "hexcasting:slate_amethyst_pillar",
+    "mass": 2780.0,
+    "friction": 0.8
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/immersive_weathering.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/immersive_weathering.json
@@ -1,0 +1,121 @@
+[
+  {
+    "tag": "immersive_weathering:leaf_piles",
+    "mass": 10.0
+  },
+  {
+    "block": "immersive_weathering:cracked_prismarine_bricks",
+    "mass": 2000.0,
+    "friction": 0.7
+  },
+  {
+    "block": "immersive_weathering:prismarine_brick_wall",
+    "mass": 1000.0,
+    "friction": 0.5
+  },
+  {
+    "block": "immersive_weathering:chiseled_prismarine_bricks",
+    "mass": 2000.0,
+    "friction": 0.6
+  },
+  {
+    "block": "immersive_weathering:cracked_prismarine_brick_stairs",
+    "mass": 1500.0,
+    "friction": 0.7
+  },
+  {
+    "block": "immersive_weathering:cracked_prismarine_brick_slab",
+    "mass": 1000.0,
+    "friction": 0.7
+  },
+  {
+    "block": "immersive_weathering:cracked_prismarine_brick_wall",
+    "mass": 1000.0,
+    "friction": 0.7
+  },
+  {
+    "block": "immersive_weathering:dark_prismarine_wall",
+    "mass": 1500.0,
+    "friction": 0.6
+  },
+  {
+    "block": "immersive_weathering:cracked_nether_brick_stairs",
+    "mass": 1500.0,
+    "friction": 0.7
+  },
+  {
+    "block": "immersive_weathering:cracked_nether_brick_slab",
+    "mass": 1000.0,
+    "friction": 0.7
+  },
+  {
+    "block": "immersive_weathering:cracked_nether_brick_wall",
+    "mass": 1000.0,
+    "friction": 0.7
+  },
+  {
+    "block": "immersive_weathering:cracked_polished_blackstone_brick_stairs",
+    "mass": 2625.0,
+    "friction": 0.6
+  },
+  {
+    "block": "immersive_weathering:cracked_polished_blackstone_brick_slab",
+    "mass": 1750.0,
+    "friction": 0.6
+  },
+  {
+    "block": "immersive_weathering:cracked_polished_blackstone_brick_wall",
+    "mass": 1750.0,
+    "friction": 0.6
+  },
+  {
+    "block": "immersive_weathering:frosty_glass",
+    "mass": 2000.0,
+    "friction": 0.05
+  },
+  {
+    "block": "immersive_weathering:frosty_glass_pane",
+    "mass": 250.0,
+    "friction": 0.05
+  },
+  {
+    "block": "immersive_weathering:tinted_glass_pane",
+    "mass": 250.0,
+    "friction": 0.2
+  },
+  {
+    "block": "immersive_weathering:soot",
+    "mass": 10.0,
+    "friction": 0.9
+  },
+  {
+    "block": "immersive_weathering:frost",
+    "mass": 10.0,
+    "friction": 0.05
+  },
+  {
+    "block": "immersive_weathering:icicle",
+    "mass": 560.0,
+    "friction": 0.05
+  },
+  {
+    "block": "immersive_weathering:frosty_grass",
+    "mass": 20.0
+  },
+  {
+    "block": "immersive_weathering:frosty_fern",
+    "mass": 20.0
+  },
+  {
+    "block": "immersive_weathering:dune_grass",
+    "mass": 20.0
+  },
+  {
+    "block": "immersive_weathering:ivy",
+    "mass": 20.0
+  },
+  {
+    "block": "immersive_weathering:weeds",
+    "mass": 20.0
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/mekanism_extras.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/mekanism_extras.json
@@ -1,0 +1,7 @@
+[
+  {
+    "block": "mekanism_extras:lead_coated_glass",
+    "mass": 2650.0,
+    "friction": 0.2
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/mekanismgenerators.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/mekanismgenerators.json
@@ -1,0 +1,7 @@
+[
+  {
+    "block": "mekanismgenerators:reactor_glass",
+    "mass": 2500.0,
+    "friction": 0.2
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/natures_spirit.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/natures_spirit.json
@@ -1,0 +1,321 @@
+[
+  {
+    "tag": "natures_spirit:travertine",
+    "mass": 2600.0,
+    "friction": 0.6
+  },
+  {
+    "tag": "natures_spirit:travertine_stairs",
+    "mass": 1950.0,
+    "friction": 0.6
+  },
+  {
+    "tag": "natures_spirit:travertine_slab",
+    "mass": 1300.0,
+    "friction": 0.6
+  },
+  {
+    "tag": "natures_spirit:cobbled_travertine",
+    "mass": 2500.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "natures_spirit:cobbled_travertine_stairs",
+    "mass": 1875.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "natures_spirit:cobbled_travertine_slab",
+    "mass": 1250.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "natures_spirit:mossy_cobbled_travertine",
+    "mass": 2500.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "natures_spirit:mossy_cobbled_travertine_stairs",
+    "mass": 1875.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "natures_spirit:mossy_cobbled_travertine_slab",
+    "mass": 1250.0,
+    "friction": 0.8
+  },
+  {
+    "tag": "natures_spirit:chiseled_travertine",
+    "mass": 2500.0,
+    "friction": 0.6
+  },
+  {
+    "tag": "natures_spirit:polished_travertine",
+    "mass": 2600.0,
+    "friction": 0.4
+  },
+  {
+    "tag": "natures_spirit:polished_travertine_stairs",
+    "mass": 1950.0,
+    "friction": 0.4
+  },
+  {
+    "tag": "natures_spirit:polished_travertine_slab",
+    "mass": 1300.0,
+    "friction": 0.4
+  },
+  {
+    "tag": "natures_spirit:polished_travertine_wall",
+    "mass": 1300.0,
+    "friction": 0.4
+  },
+  {
+    "tag": "natures_spirit:travertine_bricks",
+    "mass": 2600.0,
+    "friction": 0.5
+  },
+  {
+    "tag": "natures_spirit:cracked_travertine_bricks",
+    "mass": 2600.0,
+    "friction": 0.7
+  },
+  {
+    "tag": "natures_spirit:travertine_brick_stairs",
+    "mass": 1950.0,
+    "friction": 0.5
+  },
+  {
+    "tag": "natures_spirit:travertine_brick_slab",
+    "mass": 1300.0,
+    "friction": 0.5
+  },
+  {
+    "tag": "natures_spirit:travertine_brick_wall",
+    "mass": 1300.0,
+    "friction": 0.5
+  },
+  {
+    "tag": "natures_spirit:mossy_travertine_bricks",
+    "mass": 2600.0,
+    "friction": 0.5
+  },
+  {
+    "tag": "natures_spirit:mossy_travertine_brick_stairs",
+    "mass": 1950.0,
+    "friction": 0.5
+  },
+  {
+    "tag": "natures_spirit:mossy_travertine_brick_slab",
+    "mass": 1300.0,
+    "friction": 0.5
+  },
+  {
+    "tag": "natures_spirit:mossy_travertine_brick_wall",
+    "mass": 1300.0,
+    "friction": 0.5
+  },
+  {
+    "tag": "natures_spirit:travertine_tiles",
+    "mass": 2600.0,
+    "friction": 0.5
+  },
+  {
+    "tag": "natures_spirit:cracked_travertine_tiles",
+    "mass": 2600.0,
+    "friction": 0.7
+  },
+  {
+    "tag": "natures_spirit:travertine_tile_stairs",
+    "mass": 1950.0,
+    "friction": 0.5
+  },
+  {
+    "tag": "natures_spirit:travertine_tile_slab",
+    "mass": 1300.0,
+    "friction": 0.5
+  },
+  {
+    "tag": "natures_spirit:travertine_tile_wall",
+    "mass": 1300.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:sugi_mosaic",
+    "mass": 500.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:sugi_mosaic_stairs",
+    "mass": 375.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:sugi_mosaic_slab",
+    "mass": 250.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:wisteria_mosaic",
+    "mass": 500.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:wisteria_mosaic_stairs",
+    "mass": 375.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:wisteria_mosaic_slab",
+    "mass": 250.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:joshua_mosaic",
+    "mass": 500.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:joshua_mosaic_stairs",
+    "mass": 375.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:joshua_mosaic_slab",
+    "mass": 250.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:coconut_mosaic",
+    "mass": 500.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:coconut_mosaic_stairs",
+    "mass": 375.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:coconut_mosaic_slab",
+    "mass": 250.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:mahogany_mosaic",
+    "mass": 500.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:mahogany_mosaic_stairs",
+    "mass": 375.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:mahogany_mosaic_slab",
+    "mass": 250.0,
+    "friction": 0.5
+  },
+  {
+    "block": "natures_spirit:chert",
+    "mass": 2650.0
+  },
+  {
+    "block": "natures_spirit:chert_stairs",
+    "mass": 1987.5
+  },
+  {
+    "block": "natures_spirit:chert_slab",
+    "mass": 1325.0
+  },
+  {
+    "block": "natures_spirit:polished_chert",
+    "mass": 2650.0
+  },
+  {
+    "block": "natures_spirit:polished_chert_stairs",
+    "mass": 1987.5
+  },
+  {
+    "block": "natures_spirit:polished_chert_slab",
+    "mass": 1325.0
+  },
+  {
+    "block": "natures_spirit:polished_chert_wall",
+    "mass": 1325.0
+  },
+  {
+    "block": "natures_spirit:chert_bricks",
+    "mass": 2650.0
+  },
+  {
+    "block": "natures_spirit:cracked_chert_bricks",
+    "mass": 2650.0
+  },
+  {
+    "block": "natures_spirit:chert_brick_stairs",
+    "mass": 1987.5
+  },
+  {
+    "block": "natures_spirit:chert_brick_slab",
+    "mass": 1325.0
+  },
+  {
+    "block": "natures_spirit:chert_brick_wall",
+    "mass": 1325.0
+  },
+  {
+    "block": "natures_spirit:chert_tiles",
+    "mass": 2650.0
+  },
+  {
+    "block": "natures_spirit:cracked_chert_tiles",
+    "mass": 2650.0
+  },
+  {
+    "block": "natures_spirit:chert_tile_stairs",
+    "mass": 1987.5
+  },
+  {
+    "block": "natures_spirit:chert_tile_slab",
+    "mass": 1325.0
+  },
+  {
+    "block": "natures_spirit:chert_tile_wall",
+    "mass": 1325.0
+  },
+  {
+    "tag": "natures_spirit:kaolin",
+    "mass": 1500.0
+  },
+  {
+    "tag": "natures_spirit:kaolin_stairs",
+    "mass": 1125.0
+  },
+  {
+    "tag": "natures_spirit:kaolin_slabs",
+    "mass": 750.0
+  },
+  {
+    "tag": "natures_spirit:kaolin_bricks",
+    "mass": 1500.0
+  },
+  {
+    "tag": "natures_spirit:kaolin_brick_stairs",
+    "mass": 1125.0
+  },
+  {
+    "tag": "natures_spirit:kaolin_brick_slabs",
+    "mass": 750.0
+  },
+  {
+    "tag": "natures_spirit:chalk",
+    "mass": 2400.0
+  },
+  {
+    "tag": "natures_spirit:chalk_stairs",
+    "mass": 1800.0
+  },
+  {
+    "tag": "natures_spirit:chalk_slabs",
+    "mass": 1200.0
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/occultism.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/occultism.json
@@ -1,0 +1,25 @@
+[
+  {
+    "block": "occultism:otherstone",
+    "mass": 2500.0,
+    "friction": 0.6
+  },
+  {
+    "block": "occultism:otherstone_slab",
+    "mass": 1250.0,
+    "friction": 0.6
+  },
+  {
+    "block": "occultism:otherstone_pedestal",
+    "mass": 2000.0,
+    "friction": 0.6
+  },
+  {
+    "block": "occultism:iesnium_block",
+    "mass": 5400.0
+  },
+  {
+    "block": "occultism:raw_iesnium_block",
+    "mass": 5400.0
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/simplest_compression.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/simplest_compression.json
@@ -1,0 +1,158 @@
+[
+  {
+    "block": "simplest_compression:compressed_cobblestone",
+    "mass": 4800.0,
+    "friction": 0.8
+  },
+  {
+    "block": "simplest_compression:compressed_blackstone",
+    "mass": 7000.0,
+    "friction": 0.7
+  },
+  {
+    "block": "simplest_compression:compressed_cobbled_deepslate",
+    "mass": 5500.0,
+    "friction": 0.8
+  },
+  {
+    "block": "simplest_compression:compressed_basalt",
+    "mass": 6000.0,
+    "friction": 0.6
+  },
+  {
+    "block": "simplest_compression:compressed_calcite",
+    "mass": 5400.0,
+    "friction": 0.5
+  },
+  {
+    "block": "simplest_compression:compressed_clay",
+    "mass": 3000.0,
+    "friction": 0.4
+  },
+  {
+    "block": "simplest_compression:compressed_diorite",
+    "mass": 5000.0,
+    "friction": 0.6
+  },
+  {
+    "block": "simplest_compression:compressed_dirt",
+    "mass": 2500.0,
+    "friction": 0.6
+  },
+  {
+    "block": "simplest_compression:compressed_dripstone_block",
+    "mass": 5400.0,
+    "friction": 0.5
+  },
+  {
+    "block": "simplest_compression:compressed_end_stone",
+    "mass": 2000.0,
+    "friction": 0.6
+  },
+  {
+    "block": "simplest_compression:compressed_granite",
+    "mass": 5000.0,
+    "friction": 0.6
+  },
+  {
+    "block": "simplest_compression:compressed_gravel",
+    "mass": 3000.0,
+    "friction": 0.7
+  },
+  {
+    "block": "simplest_compression:compressed_netherrack",
+    "mass": 2000.0,
+    "friction": 0.4
+  },
+  {
+    "tag": "simplest_compression:compressed_sand",
+    "mass": 3000.0,
+    "friction": 0.4
+  },
+  {
+    "block": "simplest_compression:compressed_tuff",
+    "mass": 3600.0,
+    "friction": 0.7
+  },
+  {
+    "block": "simplest_compression:compressed_andesite",
+    "mass": 5000.0,
+    "friction": 0.6
+  },
+  {
+    "block": "simplest_compression:compressed_sandstone",
+    "mass": 4800.0,
+    "friction": 0.6
+  },
+  {
+    "block": "simplest_compression:compressed_red_sandstone",
+    "mass": 4800.0,
+    "friction": 0.6
+  },
+  {
+    "block": "simplest_compression:compressed_red_sand",
+    "mass": 3000.0,
+    "friction": 0.4
+  },
+  {
+    "block": "simplest_compression:compressed_deepslate",
+    "mass": 5800.0,
+    "friction": 0.5
+  },
+  {
+    "block": "simplest_compression:compressed_soul_sand",
+    "mass": 2000.0,
+    "friction": 0.9
+  },
+  {
+    "block": "simplest_compression:compressed_soul_soil",
+    "mass": 2000.0,
+    "friction": 0.8
+  },
+  {
+    "block": "simplest_compression:compressed_prismarine",
+    "mass": 4000.0,
+    "friction": 0.8
+  },
+  {
+    "block": "simplest_compression:compressed_snow_block",
+    "mass": 500.0,
+    "friction": 0.2
+  },
+  {
+    "block": "simplest_compression:compressed_stone",
+    "mass": 5000.0,
+    "friction": 0.6
+  },
+  {
+    "block": "simplest_compression:compressed_smooth_basalt",
+    "mass": 6000.0,
+    "friction": 0.5
+  },
+  {
+    "block": "simplest_compression:compressed_magma_block",
+    "mass": 6000.0,
+    "friction": 0.4
+  },
+  {
+    "block": "simplest_compression:compressed_obsidian",
+    "mass": 10000.0,
+    "friction": 0.8
+  },
+  {
+    "block": "simplest_compression:compressed_mud",
+    "mass": 2500.0,
+    "friction": 0.9
+  },
+  {
+    "block": "simplest_compression:compressed_packed_mud",
+    "mass": 3000.0,
+    "friction": 0.7
+  },
+  {
+    "block": "simplest_compression:compressed_moss_block",
+    "mass": 500.0,
+    "friction": 0.5,
+    "elasticity": 0.05
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/twilightforest.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/twilightforest.json
@@ -1,0 +1,7 @@
+[
+  {
+    "block": "twilightforest:fiery_block",
+    "mass": 7900.0,
+    "friction": 0.1
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/vinery.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/vinery.json
@@ -1,0 +1,27 @@
+[
+  {
+    "block": "vinery:dark_cherry_floorboard",
+    "mass": 500.0,
+    "friction": 0.5
+  },
+  {
+    "block": "vinery:coarse_dirt_slab",
+    "mass": 750.0,
+    "friction": 0.7
+  },
+  {
+    "block": "vinery:dirt_slab",
+    "mass": 625.0,
+    "friction": 0.6
+  },
+  {
+    "block": "vinery:grass_slab",
+    "mass": 625.0,
+    "friction": 0.5
+  },
+  {
+    "block": "vinery:dirt_path_slab",
+    "mass": 575.0,
+    "friction": 0.5
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/witherstormmod.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/witherstormmod.json
@@ -1,0 +1,90 @@
+[
+  {
+    "block": "witherstormmod:tainted_dust_block",
+    "mass": 1350.0,
+    "friction": 0.4
+  },
+  {
+    "block": "witherstormmod:tainted_dirt",
+    "mass": 1250.0,
+    "friction": 0.6
+  },
+  {
+    "block": "witherstormmod:tainted_stone",
+    "mass": 2500.0,
+    "friction": 0.6
+  },
+  {
+    "block": "witherstormmod:tainted_stone_stairs",
+    "mass": 1875.0,
+    "friction": 0.6
+  },
+  {
+    "block": "witherstormmod:tainted_stone_slab",
+    "mass": 1250.0,
+    "friction": 0.6
+  },
+  {
+    "block": "witherstormmod:tainted_stone_button",
+    "mass": 30.0
+  },
+  {
+    "block": "witherstormmod:tainted_stone_pressure_plate",
+    "mass": 100.0
+  },
+  {
+    "block": "witherstormmod:tainted_cobblestone",
+    "mass": 2400.0,
+    "friction": 0.8
+  },
+  {
+    "block": "witherstormmod:tainted_cobblestone_stairs",
+    "mass": 1800.0,
+    "friction": 0.8
+  },
+  {
+    "block": "witherstormmod:tainted_cobblestone_slab",
+    "mass": 1200.0,
+    "friction": 0.8
+  },
+  {
+    "block": "witherstormmod:tainted_cobblestone_wall",
+    "mass": 1200.0,
+    "friction": 0.8
+  },
+  {
+    "block": "witherstormmod:tainted_sandstone",
+    "mass": 2400.0,
+    "friction": 0.6
+  },
+  {
+    "block": "witherstormmod:tainted_sandstone_slab",
+    "mass": 1200.0,
+    "friction": 0.6
+  },
+  {
+    "block": "witherstormmod:tainted_sandstone_stairs",
+    "mass": 1800.0,
+    "friction": 0.6
+  },
+  {
+    "block": "witherstormmod:tainted_sandstone_wall",
+    "mass": 1200.0,
+    "friction": 0.6
+  },
+  {
+    "block": "witherstormmod:tainted_glass",
+    "mass": 2000.0,
+    "friction": 0.2
+  },
+  {
+    "block": "witherstormmod:tainted_glass_pane",
+    "mass": 250.0,
+    "friction": 0.2
+  },
+  {
+    "block": "witherstormmod:tainted_pumpkin",
+    "mass": 800.0,
+    "friction": 0.3
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/witherstormmod.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/witherstormmod.json
@@ -73,6 +73,41 @@
     "friction": 0.6
   },
   {
+    "block": "witherstormmod:tainted_cut_sandstone",
+    "mass": 2400.0,
+    "friction": 0.6
+  },
+  {
+    "block": "witherstormmod:tainted_cut_sandstone_slab",
+    "mass": 1200.0,
+    "friction": 0.6
+  },
+  {
+    "block": "witherstormmod:tainted_chiseled_sandstone",
+    "mass": 2400.0,
+    "friction": 0.6
+  },
+  {
+    "block": "witherstormmod:tainted_smooth_sandstone",
+    "mass": 2400.0,
+    "friction": 0.5
+  },
+  {
+    "block": "witherstormmod:tainted_smooth_sandstone_stairs",
+    "mass": 1800.0,
+    "friction": 0.5
+  },
+  {
+    "block": "witherstormmod:tainted_smooth_sandstone_slab",
+    "mass": 1200.0,
+    "friction": 0.5
+  },
+  {
+    "block": "witherstormmod:tainted_smooth_sandstone_wall",
+    "mass": 1200.0,
+    "friction": 0.5
+  },
+  {
     "block": "witherstormmod:tainted_glass",
     "mass": 2000.0,
     "friction": 0.2
@@ -86,5 +121,9 @@
     "block": "witherstormmod:tainted_pumpkin",
     "mass": 800.0,
     "friction": 0.3
+  },
+  {
+    "block": "witherstormmod:tainted_mushroom",
+    "mass": 10.0
   }
 ]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/woodworks.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/woodworks.json
@@ -1,0 +1,6 @@
+[
+  {
+    "tag": "woodworks:leaf_piles",
+    "mass": 10.0
+  }
+]

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/natural/plants.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/natural/plants.json
@@ -129,11 +129,6 @@
     "friction": 0.3
   },
   {
-    "block": "minecraft:carved_pumpkin",
-    "mass": 400.0,
-    "friction": 0.3
-  },
-  {
     "block": "minecraft:warped_fungus",
     "mass": 20.0
   },


### PR DESCRIPTION
# ⚒️ Pull Request Offering

---
## 🧾 What This PR Does

Updates the default block masses to include blocks from more mods

- Changed Create redstone components to have the same values as the vanilla repeater and comparator
- Added the Pulse Timer from Create
- Removed redundant carved pumpkin mass in `natural/plants.json` that got overridden by the one in `functional/deco.json`
- Added support for: Autumnity, Cracker's Wither Storm Mod, Create Compressed, Create Connected, Create New Age, Create Vibrant Vaults, Galosphere, Hexcasting, Immersive Weathering, [Let's Do] Vinery, Mekanism Extras, Mekanism Generators, Nature's Spirit, Occultism, Oh The Biomes We've Gone, Woodworks (and thus leaf piles from Autumnity). Compatibility is currently not yet entirely complete for every mod, but that is also the case for existing mods like Create.
- Added masses for blocks in the tag `forge:storage_blocks/(raw_)material`

## 🔍 How This Was Tested
- [ ] GameTest framework  
- [x] Singleplayer / Server  
- [x] Logs looked sane  
- [x] The vibes felt right *(sometimes you really do just have to vibe it)*


## ⚠️ Breaking Changes
- [ ] Yes (describe)  
- [x] No  (are you *really* sure?)

---

## 🧪 GameTest Oath
- [ ] Please include at least one `@GameTest`  
or  
- [x] PR does not require a `@GameTest`   
  - [x] True if this change is only a data/config/docs/logs change  
  - [x] Also True *if* you can make a good case on why you shouldn't have to add one

---

## 🜏 Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- No worlds shall be harmed in the making or merging of this PR 💀
