### PR TITLE
Fixed Create deployers not placing blocks inside ships

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/MixinDeployerHandler.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create/MixinDeployerHandler.java
@@ -22,6 +22,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.world.RaycastUtilsKt;
+import org.valkyrienskies.mod.mixin.accessors.entity.EntityAccessor;
 import org.valkyrienskies.mod.mixinducks.mod_compat.create.IDeployerBehavior;
 import org.valkyrienskies.mod.mixinducks.mod_compat.create.IDeployerBehavior.WorkingMode;
 
@@ -92,17 +93,54 @@ public abstract class MixinDeployerHandler {
             method = "activateInner",
             at = @At(
                     value = "INVOKE",
+                    target = "Lcom/simibubi/create/content/kinetics/deployer/DeployerFakePlayer;setPos(DDD)V"
+            )
+    )
+    private static void setPos(DeployerFakePlayer player, double x, double y, double z, Operation<Void> original,
+                               @Share("mode") LocalBooleanRef original_behaviour) {
+        if (!original_behaviour.get() && VSGameUtilsKt.isBlockInShipyard(player.level(), x, y, z)) {
+            final EntityAccessor accessor = (EntityAccessor) (Object) player;
+            accessor.setPosNoUpdates(new Vec3(x, y, z));
+            accessor.setBlockPosition(BlockPos.containing(x, y, z));
+            return;
+        }
+        original.call(player, x, y, z);
+    }
+
+    @WrapOperation(
+            method = "activateInner",
+            at = @At(
+                    value = "INVOKE",
                     target = "Lnet/minecraft/server/level/ServerLevel;clip(Lnet/minecraft/world/level/ClipContext;)Lnet/minecraft/world/phys/BlockHitResult;"
             )
     )
-    private static BlockHitResult clip(ServerLevel instance, ClipContext clipContext, Operation<BlockHitResult> original, @Local(argsOnly = true, ordinal = 0) Vec3 vec, @Local(argsOnly = true, ordinal = 1) Vec3 extensionVector, @Share("mode") LocalBooleanRef original_behaviour) {
-        if(original_behaviour.get()) {
-            BlockHitResult result = RaycastUtilsKt.clipIncludeShips(instance, clipContext, true);
+    private static BlockHitResult clip(ServerLevel instance, ClipContext clipContext, Operation<BlockHitResult> original,
+                                       @Local(argsOnly = true, ordinal = 0) Vec3 vec,
+                                       @Local(argsOnly = true, ordinal = 0) BlockPos clickedPos,
+                                       @Local(argsOnly = true, ordinal = 1) Vec3 extensionVector,
+                                       @Share("mode") LocalBooleanRef original_behaviour) {
+        if (original_behaviour.get()) {
+            final BlockHitResult result = RaycastUtilsKt.clipIncludeShips(instance, clipContext, false);
             if (result.getType() == HitResult.Type.MISS) {
-                return RaycastUtilsKt.clipIncludeShips(instance, new ClipContext(clipContext.getFrom(), VSGameUtilsKt.toWorldCoordinates(instance, vec.add(extensionVector.scale(5 / 2f - 1 / 64f))), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, null), true);
+                return RaycastUtilsKt.clipIncludeShips(instance,
+                        new ClipContext(
+                                clipContext.getFrom(),
+                                VSGameUtilsKt.toWorldCoordinates(instance,
+                                        vec.add(extensionVector.scale(5 / 2f - 1 / 64f))),
+                                ClipContext.Block.OUTLINE,
+                                ClipContext.Fluid.NONE,
+                                null
+                        ),
+                        false
+                );
             }
-            return RaycastUtilsKt.clipIncludeShips(instance, clipContext, true);
+            return result;
         }
+
+        if (VSGameUtilsKt.isBlockInShipyard(instance, clickedPos)) {
+            return RaycastUtilsKt.vanillaClip(instance, clipContext);
+        }
+
         return original.call(instance, clipContext);
     }
 


### PR DESCRIPTION
# ⚒️ Pull Request Offering
## 🧾 What This PR Does
Fixes a bug that prevented Create deployers from placing blocks when set to "Current ship" mode:

In ship mode, Create repositions a DeployerFakePlayer into shipyard coordinates; VS’s shipyard safety logic moves players back to world-space, breaking deployer interactions. This PR bypasses that for the deployer fake player during activateInner.
Adjusts deployer raycasting so BlockHitResult.location and getBlockPos() stay in the same coordinate space for ship hits.


## 🔍 How This Was Tested
- [ ] GameTest framework  
- [x] Singleplayer / Server  
- [x] Logs looked sane  
- [x] The vibes felt right *(sometimes you really do just have to vibe it)*


## ⚠️ Breaking Changes
- [ ] Yes (describe)  
- [x] No  (are you *really* sure?)

---

## 🧪 GameTest Oath
- [ ] Please include at least one `@GameTest`  
or  
- [x] PR does not require a `@GameTest`   
  - [ ] True if this change is only a data/config/docs/logs change  
  - [x] Also True *if* you can make a good case on why you shouldn't have to add one

Reason: this is a Create-compat mixin; an automated GameTest would require Create’s deployer + a shipyard context in the test runtime.

---

## 🗝️ Additional Notes
- Scope is narrow: only affects Create deployer activation, only when targeting shipyard positions in ship mode; normal player behavior is unchanged.

---

## 🜏 Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- No worlds shall be harmed in the making or merging of this PR 💀
