### PR TITLE
Add no collision property

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
@@ -354,7 +354,7 @@ object MassDatapackResolver : BlockStateInfoProvider {
                         voxelShape = blockState.getCollisionShape(dummyBlockGetter, BlockPos.ZERO)
                     }
 
-                    val collisionShape: SolidBlockShape = if (voxelShapeToCollisionShapeMap.contains(voxelShape)) {
+                    var collisionShape: SolidBlockShape = if (voxelShapeToCollisionShapeMap.contains(voxelShape)) {
                         voxelShapeToCollisionShapeMap[voxelShape]!!
                     } else if (generatedCollisionShapesMap.contains(voxelShape)) {
                         if (generatedCollisionShapesMap[voxelShape] != null) {
@@ -370,6 +370,14 @@ object MassDatapackResolver : BlockStateInfoProvider {
 
                     val vsBlockStateInfo = map[BuiltInRegistries.BLOCK.getKey(blockState.block)]
 
+                    // If overrideNoCollision is set to true in datapack, force it to have no collision shape
+                    collisionShape = if (vsBlockStateInfo?.noCollisionOverride ?: false) {
+                        // Won't ever be null with an empty list
+                        vsCore.solidShapeUtils.generateShapeFromBoxes(mutableListOf())!!
+                    } else {
+                        collisionShape
+                    }
+
                     // Create new solid block state
                     var solidState = vsCore.newSolidStateBuilder()
                         .shape(collisionShape)
@@ -384,12 +392,8 @@ object MassDatapackResolver : BlockStateInfoProvider {
                         null
                     }
 
-                    // If overrideNoCollision is set to true in datapack, force it to use air block state
-                    if ((vsBlockStateInfo?.noCollisionOverride ?: false)) {
-                        vsCore.blockTypes.airState
-                    } else {
-                        VsiBlockState(solidState, fluidState)
-                    }
+                    VsiBlockState(solidState, fluidState)
+
                 }
             }
             mcBlockStateToVs[blockState] = vsBlockState

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
@@ -46,6 +46,7 @@ private data class VSBlockStateInfo(
     val friction: Double,
     val elasticity: Double,
     val type: VsiBlockType?,
+    val noCollisionOverride: Boolean?,
 )
 
 object MassDatapackResolver : BlockStateInfoProvider {
@@ -111,7 +112,7 @@ object MassDatapackResolver : BlockStateInfoProvider {
                             add(
                                 VSBlockStateInfo(
                                     BuiltInRegistries.BLOCK.getKey(it.value()), tagInfo.priority, tagInfo.mass, tagInfo.friction,
-                                    tagInfo.elasticity, tagInfo.type
+                                    tagInfo.elasticity, tagInfo.type, tagInfo.noCollisionOverride
                                 )
                             )
                         }
@@ -145,13 +146,15 @@ object MassDatapackResolver : BlockStateInfoProvider {
 
             val priority = element.asJsonObject["priority"]?.asInt ?: decideDefaultPriority(origin)
 
+            val overrideNoCollision = element.asJsonObject["no_collision"]?.asBoolean
+
             if (tag != null) {
-                addToBeAddedTags(VSBlockStateInfo(ResourceLocation(tag), priority, weight, friction, elasticity, null))
+                addToBeAddedTags(VSBlockStateInfo(ResourceLocation(tag), priority, weight, friction, elasticity, null, overrideNoCollision))
             } else {
                 val block = element.asJsonObject["block"]?.asString
                     ?: throw IllegalArgumentException("No block or tag in file $origin")
 
-                add(VSBlockStateInfo(ResourceLocation(block), priority, weight, friction, elasticity, null))
+                add(VSBlockStateInfo(ResourceLocation(block), priority, weight, friction, elasticity, null, overrideNoCollision))
             }
         }
     }
@@ -368,7 +371,7 @@ object MassDatapackResolver : BlockStateInfoProvider {
                     val vsBlockStateInfo = map[BuiltInRegistries.BLOCK.getKey(blockState.block)]
 
                     // Create new solid block state
-                    val solidState = vsCore.newSolidStateBuilder()
+                    var solidState = vsCore.newSolidStateBuilder()
                         .shape(collisionShape)
                         .elasticity(vsBlockStateInfo?.elasticity ?: VSGameConfig.SERVER.defaultBlockElasticity)
                         .friction(vsBlockStateInfo?.friction ?: VSGameConfig.SERVER.defaultBlockFriction)
@@ -381,7 +384,12 @@ object MassDatapackResolver : BlockStateInfoProvider {
                         null
                     }
 
-                    VsiBlockState(solidState, fluidState)
+                    // If overrideNoCollision is set to true in datapack, force it to use air block state
+                    if ((vsBlockStateInfo?.noCollisionOverride ?: false)) {
+                        vsCore.blockTypes.airState
+                    } else {
+                        VsiBlockState(solidState, fluidState)
+                    }
                 }
             }
             mcBlockStateToVs[blockState] = vsBlockState

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
@@ -371,11 +371,9 @@ object MassDatapackResolver : BlockStateInfoProvider {
                     val vsBlockStateInfo = map[BuiltInRegistries.BLOCK.getKey(blockState.block)]
 
                     // If overrideNoCollision is set to true in datapack, force it to have no collision shape
-                    collisionShape = if (vsBlockStateInfo?.noCollisionOverride ?: false) {
+                    if (vsBlockStateInfo?.noCollisionOverride ?: false) {
                         // Won't ever be null with an empty list
-                        vsCore.solidShapeUtils.generateShapeFromBoxes(mutableListOf())!!
-                    } else {
-                        collisionShape
+                        collisionShape = vsCore.solidShapeUtils.generateShapeFromBoxes(mutableListOf())!!
                     }
 
                     // Create new solid block state

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create.json
@@ -547,6 +547,7 @@
   {
     "block": "create:redstone_link",
     "mass": 100.0,
+    "no_collision": true,
     "friction": 0.4
   },
   {

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/compat/create.json
@@ -432,7 +432,8 @@
   {
     "block": "create:track",
     "mass": 1500.0,
-    "friction": 0.5
+    "friction": 0.5,
+    "no_collision": true
   },
   {
     "block": "create:fake_track",

--- a/common/src/main/resources/data/valkyrienskies/vs_mass/natural/tree.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_mass/natural/tree.json
@@ -26,6 +26,7 @@
   {
     "tag": "minecraft:leaves",
     "mass": 200.0,
+    "no_collision": true,
     "elasticity": 0.15
   }
 ]


### PR DESCRIPTION
## What This PR Does 
- Feature
- Data/config update

## How This Was Tested
- [ ] GameTest framework  
- [x] Singleplayer / Server  
- [ ] Logs looked normal


## Breaking Changes
- [ ] Yes (describe)  
- [x] No  (are you *really* sure?)
---

## GameTest Oath
- [ ] Please include at least one `@GameTest`  
or  
- [x] PR does not require a `@GameTest`   
  - [ ] True if this change is only a data/config/docs/logs change  
  - [x] Also True *if* you can make a good case on why you shouldn't have to add one
- -> I would have to add a gametest for the entire datapack (block properties) system, and I am not up for that

## Additional Notes
This does make a VS Core bug where blocks with no collision do not expand the ships AABB more noticeable. Affects of this include:
- Not being able to target the no collision block if looking at it and not any other block in the ship AABB
<img width="1453" height="786" alt="image" src="https://github.com/user-attachments/assets/19491607-5324-49cd-b81d-1796c099c02e" />
<img width="1438" height="786" alt="image" src="https://github.com/user-attachments/assets/f4409c8b-e13e-46a2-8a83-c3cd4c8f82c2" />

- Being rubber banded back when walking into the out-of-AABB block and only it [see video]
- Being unable to move onto the block outside the AABB when shifting [see video]
- Being unable to move when shifted on the block outside the AABB [see video]
- The out-of-AABB block not rendering if no other part of the ship is in view [see video]

https://github.com/user-attachments/assets/1337fd30-07f8-420a-b5cd-25849c35e314

(Video was taken with a datapack that made podzol no collision)

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- No worlds shall be harmed in the making or merging of this PR 💀
