### PR TITLE
Fix player falling through ships when shipyard chunks for that ship have recently been chunkloaded.

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinPlayer.java
@@ -1,0 +1,48 @@
+package org.valkyrienskies.mod.mixin.feature.spawn_player_on_ship;
+
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.valkyrienskies.mod.common.ValkyrienSkiesMod;
+import org.valkyrienskies.mod.common.networking.PacketChangeKnownShips;
+import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck;
+
+@Mixin(Player.class)
+public abstract class MixinPlayer extends LivingEntity implements PlayerKnownShipsDuck {
+
+    @Unique
+    private final LongSet vs_knownShips = new LongOpenHashSet();
+
+    protected MixinPlayer(EntityType<? extends LivingEntity> entityType,
+        Level level) {
+        super(entityType, level);
+    }
+
+    @Override
+    public void vs_addKnownShip(long shipId) {
+        vs_knownShips.add(shipId);
+        if (level().isClientSide) {
+            var packet = new PacketChangeKnownShips(true, shipId);
+            ValkyrienSkiesMod.getVsCore().getSimplePacketNetworking().sendToServer(packet);
+        }
+    }
+
+    @Override
+    public void vs_removeKnownShip(long shipId) {
+        vs_knownShips.remove(shipId);
+        if (level().isClientSide) {
+            var packet = new PacketChangeKnownShips(false, shipId);
+            ValkyrienSkiesMod.getVsCore().getSimplePacketNetworking().sendToServer(packet);
+        }
+    }
+
+    @Override
+    public boolean vs_isKnownShip(long shipId) {
+        return vs_knownShips.contains(shipId);
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixinducks/feature/tickets/PlayerKnownShipsDuck.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixinducks/feature/tickets/PlayerKnownShipsDuck.java
@@ -1,0 +1,11 @@
+package org.valkyrienskies.mod.mixinducks.feature.tickets;
+
+public interface PlayerKnownShipsDuck {
+
+    void vs_addKnownShip(long shipId);
+
+    void vs_removeKnownShip(long shipId);
+
+    boolean vs_isKnownShip(long shipId);
+
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/ValkyrienSkiesMod.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/ValkyrienSkiesMod.kt
@@ -44,6 +44,7 @@ import org.valkyrienskies.mod.common.util.ShipSettings
 import org.valkyrienskies.mod.common.util.SplitHandler
 import org.valkyrienskies.mod.common.util.SplittingDisablerAttachment
 import org.valkyrienskies.mod.mixinducks.client.world.ClientChunkCacheDuck
+import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck
 import java.util.ServiceLoader
 import java.util.concurrent.ConcurrentHashMap
 
@@ -163,6 +164,10 @@ object ValkyrienSkiesMod {
             val level = Minecraft.getInstance().level
             if (level != null) {
                 (level.getChunkSource() as ClientChunkCacheDuck).`vs$removeShip`(event.ship)
+            }
+            val player = Minecraft.getInstance().player
+            if (player is PlayerKnownShipsDuck) {
+                player.vs_removeKnownShip(event.ship.id)
             }
         }
     }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/SeamlessChunksManager.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/SeamlessChunksManager.kt
@@ -20,6 +20,7 @@ import org.valkyrienskies.mod.common.networking.PacketStopChunkUpdates
 import org.valkyrienskies.mod.common.util.toMinecraft
 import org.valkyrienskies.mod.common.vsCore
 import org.valkyrienskies.mod.mixinducks.feature.seamless_copy.SeamlessCopyClientPacketListenerDuck
+import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck
 import org.valkyrienskies.mod.util.logger
 import java.util.Queue
 import java.util.concurrent.ConcurrentHashMap
@@ -64,6 +65,10 @@ class SeamlessChunksManager(private val listener: ClientPacketListener) {
         if (!packets.isNullOrEmpty()) {
             logger.debug("Executing ${packets.size} deferred updates for ship ID=${ship.id} at ${ship.chunkClaim}")
             dispatchQueuedPackets(packets)
+        }
+        val player = Minecraft.getInstance().player
+        if (player is PlayerKnownShipsDuck) {
+            player.vs_addKnownShip(ship.id)
         }
     }
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/PacketChangeKnownShips.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/PacketChangeKnownShips.kt
@@ -1,0 +1,11 @@
+package org.valkyrienskies.mod.common.networking
+
+import org.valkyrienskies.core.impl.networking.simple.SimplePacket
+
+/**
+ * This packet is used to let the server know which ships the player can see on their client
+ */
+data class PacketChangeKnownShips(
+    val add: Boolean,
+    val shipID: Long,
+): SimplePacket

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/VSGamePackets.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/VSGamePackets.kt
@@ -12,6 +12,7 @@ import org.joml.Vector3d
 import org.valkyrienskies.core.api.attachment.getAttachment
 import org.valkyrienskies.core.api.ships.LoadedServerShip
 import org.valkyrienskies.mod.api.SeatedControllingPlayer
+import org.valkyrienskies.mod.api.shipWorld
 import org.valkyrienskies.mod.common.entity.ShipMountingEntity
 import org.valkyrienskies.mod.common.entity.handling.VSEntityManager
 import org.valkyrienskies.mod.common.getLoadedShipManagingPos
@@ -22,6 +23,7 @@ import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider
 import org.valkyrienskies.mod.common.util.MinecraftPlayer
 import org.valkyrienskies.mod.common.util.toMinecraft
 import org.valkyrienskies.mod.common.vsCore
+import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck
 import org.valkyrienskies.mod.mixinducks.world.entity.PlayerDuck
 
 object VSGamePackets {
@@ -34,6 +36,7 @@ object VSGamePackets {
         PacketEntityShipMotion::class.register()
         PacketMobShipRotation::class.register()
         PacketPlayerShipMotion::class.register()
+        PacketChangeKnownShips::class.register()
     }
 
     fun registerHandlers() = with(vsCore.simplePacketNetworking) {
@@ -248,6 +251,18 @@ object VSGamePackets {
 
                 if ((player.level() as ServerLevel).shipObjectWorld.allShips.getById(motion.shipID) != null) {
                     entity.setPos(player.level().toWorldCoordinates(Vec3(motion.x, motion.y, motion.z)))
+                }
+            }
+        }
+
+
+        PacketChangeKnownShips::class.registerServerHandler { ships, iPlayer ->
+            val player = (iPlayer as MinecraftPlayer).player as PlayerKnownShipsDuck
+            if (!ships.add || iPlayer.player.level().shipWorld?.loadedShips?.contains(ships.shipID) == true) {
+                if (ships.add) {
+                    player.vs_addKnownShip(ships.shipID)
+                } else {
+                    player.vs_removeKnownShip(ships.shipID)
                 }
             }
         }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityShipCollisionUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityShipCollisionUtils.kt
@@ -19,6 +19,7 @@ import org.valkyrienskies.mod.common.getLoadedShipManagingPos
 import org.valkyrienskies.mod.common.getShipsIntersecting
 import org.valkyrienskies.mod.common.shipObjectWorld
 import org.valkyrienskies.mod.common.vsCore
+import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck
 import org.valkyrienskies.mod.util.BugFixUtil
 
 object EntityShipCollisionUtils {
@@ -37,6 +38,9 @@ object EntityShipCollisionUtils {
             val aabb = entity.boundingBox.toJOML()
             return level.getShipsIntersecting(aabb)
                 .all { ship ->
+                    if (entity is PlayerKnownShipsDuck && !entity.vs_isKnownShip(ship.id)) {
+                        return true
+                    }
                     val aabbInShip = AABBd(aabb).transform(ship.worldToShip)
                     areAllChunksLoaded(ship, aabbInShip, level)
                 }

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -86,6 +86,7 @@
     "feature.thrown_velocity.MixinPlayer",
     "feature.thrown_velocity.MixinProjectile",
     "feature.tick_ship_chunks.MixinChunkMap",
+    "feature.spawn_player_on_ship.MixinPlayer",
     "feature.wave_spawning.MixinRaid",
     "feature.wave_spawning.MixinRaids",
     "feature.wave_spawning.MixinVillageSiege",


### PR DESCRIPTION
# ⚒️ Pull Request Offering

> _We shall not introduce more regressions  \
> Lest we face eternal digressions_

---
## 🧾 What This PR Does
- Fixes bug where player falls through the ship when shipyard chunks were recently chunkloaded (probably affects a lot of mods with teleportation devices unless they have explicit Valkyrien Skies compatibility).
- Essentially it makes the function which checks if a player is colliding with an unloaded ship more reliable, at the cost of adding a new packet.
- Closes #1563


## 🔍 How This Was Tested
- [ ] GameTest framework  
- [x] Singleplayer / Server  
- [ ] Logs looked sane  
- [ ] The vibes felt right *(sometimes you really do just have to vibe it)*


## ⚠️ Breaking Changes
- [ ] Yes (describe)  
- [ ] No  (are you *really* sure?)
- [x] Depends on your definition of "breaking change"
- You could make the argument that it breaks backwards compatibility with older versions of Valkyrien Skies (if you connect to a newer server with older client you'd get stuck on ships and if you connect with newer client to an older server you'd get kicked because you're sending an invalid packet). I personally don't consider that a breaking change since that would make any change which is required on both sides a breaking change no matter how small. In my head, a breaking change would be something like Create 0.5 to Create 6. 
---

## 🧪 GameTest Oath
- [ ] Please include at least one `@GameTest`  
or  
- [x] PR does not require a `@GameTest`   
  - [ ] True if this change is only a data/config/docs/logs change  
  - [x] Also True *if* you can make a good case on why you shouldn't have to add one
- Umm... Where is the gametest framework?????

> PRs without a new GameTest **will not be merged**  (If they are determined to be required) \
> _unless explicitly exempted by a maintainer._

---

## 🗝️ Additional Notes
This adds a new packet, and stores a set of ship ids on every player to keep track of what ships are loaded clientside, which unfortunately adds some overhead. I made sure to use a LongSet to keep the overhead to a minimum. Don't worry, I did make sure to only add ship ids to the set that actually exist, so hackers won't be able to use this to fill the set with garbage data. It also only allows players to modify themselves.

---

## 🜏 Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- No worlds shall be harmed in the making or merging of this PR 💀
