### PR TITLE
Fix distance checks that seem to return wrong values both when dragge…

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
@@ -42,7 +42,7 @@ import org.valkyrienskies.mod.common.ValkyrienSkiesMod.ASSEMBLE_BLACKLIST
 import org.valkyrienskies.mod.common.entity.ShipMountedToData
 import org.valkyrienskies.mod.common.entity.ShipMountedToDataProvider
 import org.valkyrienskies.mod.common.util.DimensionIdProvider
-import org.valkyrienskies.mod.common.util.EntityDragger.serversideEyePosition
+import org.valkyrienskies.mod.common.util.EntityDragger.serversidePosition
 import org.valkyrienskies.mod.common.util.MinecraftPlayer
 import org.valkyrienskies.mod.common.util.set
 import org.valkyrienskies.mod.common.util.toJOML
@@ -126,10 +126,10 @@ val Player.playerWrapper get() = (this as PlayerDuck).vs_getPlayer()
  * Like [Entity.squaredDistanceTo] except the destination is transformed into world coordinates if it is a ship
  */
 fun Entity.squaredDistanceToInclShips(x: Double, y: Double, z: Double): Double {
-    val eyePos = if (getShipMountedTo(this) != null) getShipMountedToData(
+    val pos = if (getShipMountedTo(this) != null) getShipMountedToData(
         this, null
-    )!!.mountPosInShip.toMinecraft() else this.serversideEyePosition()
-    return level().squaredDistanceBetweenInclShips(x, y, z, eyePos.x, eyePos.y - 1.0, eyePos.z)
+    )!!.mountPosInShip.toMinecraft() else this.serversidePosition()
+    return level().squaredDistanceBetweenInclShips(x, y, z, pos.x, pos.y, pos.z)
 }
 
 /**

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
@@ -175,6 +175,18 @@ object EntityDragger {
     }
 
     /**
+     * Checks if the entity is a ServerPlayer and has a [serverRelativePlayerPosition] set. If it does, returns that, which is in ship space; otherwise, returns worldspace entity position.
+     */
+    fun Entity.serversidePosition(): Vec3 {
+        if (this is ServerPlayer && this is IEntityDraggingInformationProvider && this.draggingInformation.isEntityBeingDraggedByAShip()) {
+            if (this.draggingInformation.serverRelativePlayerPosition != null) {
+                return this.draggingInformation.serverRelativePlayerPosition!!.toMinecraft()
+            }
+        }
+        return this.position()
+    }
+
+    /**
      * Checks if the entity is a ServerPlayer and has a [serverRelativePlayerPosition] set. If it does, returns that, which is in ship space; otherwise, returns worldspace eye position.
      */
     fun Entity.serversideEyePosition(): Vec3 {


### PR DESCRIPTION
Reported as a bug with Create's linked controllers and not being able to interact with lectern controllers unless standing really close. Turns out all of the entity-to-position distance calculations are broken when dragged by ships? and vanilla ones too, wtf

Fixed by not using eye position in these checks that don't have anything to do with eye position in vanilla

but now I'm curious
1) why do normal distance checks (squaredDistanceToInclShips which is used by the mixin into the squaredDistanceToInclShips mixin) use EntityDragger#serversideEyePosition
2) why do they - 1.0 later, it isn't even the eye offset for player
3) why does serversideEyePosition return normal eyePosition (which is position + some value, it's a vanilla thing) if not on ship, but if dragged it returns position without any eyeslop