### PR TITLE
Make command param not useless

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
@@ -575,7 +575,7 @@ object VSCommands {
         val r = ShipArgument.getShips(context, "ships").toList() as List<ServerShip>
 
         val deletedShips = r.map {
-            ship -> ShipAssembler.deleteShip(context.source.level, ship, deleteBlocks = true, dropBlocks = false)
+            ship -> ShipAssembler.deleteShip(context.source.level, ship, deleteBlocks, dropBlocks = false)
         }
 
         context.source.sendVSMessage(


### PR DESCRIPTION
Zaaf failed to see the very obvious function parameter :P so this is a quick fix.

Basically, makes the `deleteBlocks` boolean param of `/vs delete` work again, and sets the default back to not-deleting the blocks (because its laggy and rarely needed).