### PR TITLE
Fixed Ship Ambit for bound spell circles, HexTweaks computer environm…

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/hexcasting/MixinOpTeleport$Spell.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/hexcasting/MixinOpTeleport$Spell.java
@@ -1,0 +1,24 @@
+package org.valkyrienskies.mod.mixin.mod_compat.hexcasting;
+
+import at.petrak.hexcasting.api.casting.eval.CastingEnvironment;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.valkyrienskies.mod.api.ValkyrienSkies;
+
+@Mixin(targets = "at.petrak.hexcasting.common.casting.actions.spells.great.OpTeleport$Spell")
+public class MixinOpTeleport$Spell {
+    @Shadow @Final private Entity teleportee;
+
+    @WrapOperation(method = "cast(Lat/petrak/hexcasting/api/casting/eval/CastingEnvironment;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;length()D"))
+    private double hexxyskies$modifyLength(Vec3 instance, Operation<Double> original, @Local(argsOnly = true) CastingEnvironment env) {
+        Vec3 target = ValkyrienSkies.positionToWorld(env.getWorld(), teleportee.position().add(instance));
+        return original.call(target.subtract(teleportee.position()));
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/hexcasting/MixinOpTeleport.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/hexcasting/MixinOpTeleport.java
@@ -1,0 +1,18 @@
+package org.valkyrienskies.mod.mixin.mod_compat.hexcasting;
+
+import at.petrak.hexcasting.common.casting.actions.spells.great.OpTeleport;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.valkyrienskies.mod.api.ValkyrienSkies;
+
+@Mixin(OpTeleport.class)
+public class MixinOpTeleport {
+    @ModifyVariable(method = "teleportRespectSticky", at = @At("STORE"), name = "target")
+    private Vec3 hexxyskies$modifyTarget(Vec3 target, @Local(argsOnly = true) ServerLevel world) {
+        return ValkyrienSkies.positionToWorld(world, target);
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/hexcasting/README.md
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/hexcasting/README.md
@@ -6,6 +6,8 @@ This section adds necessary Mixins for Hexcasting compatibility
 ### Hexcasting
 - `MixinOpEntityRaycast` ensures raycasts targetting Shipyard entities are properly checked by transforming the hitbox AABB exists in Worldspace
 - `MixinHexAdditionalRenderers` allows (Greater) Sentinels to render on Ships with correct position and scale
+- `MixinOpTeleport` no longer sends Entities into the Shipyard but their relative Ship position instead
+- `MixinOpTeleport$Spell` fixes the distance it uses to calculate how much of an inventory is dumped (feature of the spell)
 ### Hexal
 - `MixinOpLink` and `MixinOpLinkOthers` fix distance checks for their respective spell
 - `MixinRenderHelper` transform the source and sink positions for the line of particles

--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/ShipAmbit.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/ShipAmbit.kt
@@ -5,7 +5,6 @@ import at.petrak.hexcasting.api.casting.eval.CastingEnvironmentComponent.HasEdit
 import at.petrak.hexcasting.api.casting.eval.CastingEnvironmentComponent.IsVecInRange
 import at.petrak.hexcasting.api.casting.eval.CastingEnvironmentComponent.Key
 import at.petrak.hexcasting.api.casting.eval.env.CircleCastEnv
-import net.beholderface.ephemera.api.toVec3i
 import net.minecraft.core.BlockPos
 import net.minecraft.world.phys.Vec3
 import org.valkyrienskies.core.api.util.GameTickOnly
@@ -13,6 +12,7 @@ import org.valkyrienskies.mod.api.positionToShip
 import org.valkyrienskies.mod.api.positionToWorld
 import org.valkyrienskies.mod.common.getLoadedShipManagingPos
 import org.valkyrienskies.mod.common.util.toJOML
+import org.valkyrienskies.mod.compat.hexcasting.hextweaks.HexTweaksCompat
 import java.util.UUID
 
 open class AmbitRemapping(val env: CastingEnvironment) : IsVecInRange, HasEditPermissionsAt {
@@ -51,12 +51,18 @@ open class AmbitRemapping(val env: CastingEnvironment) : IsVecInRange, HasEditPe
     }
 
     open fun getCasterPosition(): Vec3? {
-        env.castingEntity?.position()?.let { return it }
+        try { // Since there is no X-Plat way to test if a mod is loaded
+            return HexTweaksCompat.getComputerPosition(env)
+        } catch (_: ClassNotFoundException) {}
 
-        if (env is CircleCastEnv)
-            return env.impetus?.blockPos?.center
-
-        return null
+        return when (env) {
+            is CircleCastEnv -> {
+                env.impetus?.blockPos?.center
+            }
+            else -> {
+                env.caster?.position() ?: env.castingEntity?.position()
+            }
+        }
     }
 }
 

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -193,6 +193,8 @@
     "mod_compat.ftb_chunks.MixinClaimedChunkManagerImpl",
     "mod_compat.hexcasting.MixinHexAdditionalRenderers",
     "mod_compat.hexcasting.MixinOpEntityRaycast",
+    "mod_compat.hexcasting.MixinOpTeleport",
+    "mod_compat.hexcasting.MixinOpTeleport$Spell",
     "mod_compat.hexcasting.ephemera.MixinOpNetworkTeleport",
     "mod_compat.hexcasting.hexal.MixinOpLink",
     "mod_compat.hexcasting.hexal.MixinOpLinkOthers",


### PR DESCRIPTION
…ents, and fixed the Greater Teleport spell

# ⚒️ Pull Request Offering

> _We shall not introduce more regressions  \
> Lest we face eternal digressions_

---
## 🧾 What This PR Does
- Added `MixinTeleport` to transform the target position to World Space
- Added `MixinOpTeleport$Spell` to fix the distance used to calculate inventory dropping (feature of the Greater Teleport spell)
- Fixed `ShipAmbit` for bound spell circles and HexTweaks computer-bound casting envrionments by testing for them first before targeting the base `caster` or `castingEntity`


## 🔍 How This Was Tested
- [ ] GameTest framework  
- [X] Singleplayer / Server  
- [ ] Logs looked sane  
- [ ] The vibes felt right *(sometimes you really do just have to vibe it)*


## ⚠️ Breaking Changes
- [ ] Yes (describe)  
- [X] No  (are you *really* sure?) ***yes***

---

## 🧪 GameTest Oath
- [ ] Please include at least one `@GameTest`  
or  
- [X] PR does not require a `@GameTest`   
  - [ ] True if this change is only a data/config/docs/logs change  
  - [X] Also True *if* you can make a good case on why you shouldn't have to add one
  
I dont know how to gametest for Hexcasting but I did test the fix myself in-game

---

## 🗝️ Additional Notes
Steps to Test the Greater Teleport Fix:
1) Grab the Media Cube, any Staff, and an amethyst dust
2) Run `/hexcasting perWorldPatterns give hexcasting:teleport/great` to obtain the randomly generated Greater Teleport scroll
3) Make yourself a platform at (0, 0, 0) (for ease of testing since the spell takes in a delta, not a position)
4) Create a 3x3 wall and place the Scroll in the middle and use the amethyst dust on it to show its correct drawing path
5) Create a 2 block tall Ship (can be anywhere within 32 blocks of the player)
6) While looking at the top block of the Ship, enter the Staff menu by right clicking, draw the first pattern as seen in the image and then draw the full Raycasting Mantra beginning again with the first pattern (since its hard to see the beginning and end of patterns on the Staff menu, I put them on Scrolls for ease of viewing)
7) Exit the Staff menu and break the top block on the Ship
8) Position yourself on top of the block at (0, 0, 0) looking where you can see the Greater Teleport scroll for reference
9) Eat the Media Cube to auto-unlock everything (sorry for the toast and achievement spam)
10) Re-enter the Staff menu and draw the Greater Teleport pattern

***Do NOT get rid of the Cube, thats your mana source for testing!!!!!***

<img width="1379" height="377" alt="Raycast Mantra" src="https://github.com/user-attachments/assets/1d6f6ada-3748-4776-beb6-600eae10e6bb" />

This should put you on top of the Ship on the corner of the bottom block, congrats!

---

## 🜏 Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- No worlds shall be harmed in the making or merging of this PR 💀

This just fixes two bugs with Greater Teleport and the Ambit to target Ships

For context, I did not include the testing procedure for bound Spell Circles because its more complicated but it *does* work
