### PR TITLE
Compat with Hypertubes and a minor bug fix

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/block_placement/MixinBlockItem.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/block_placement/MixinBlockItem.java
@@ -38,9 +38,8 @@ public abstract class MixinBlockItem {
         final Operation<BlockState> original, final BlockPlaceContext ctx
     ) {
         if (ctx == null || ctx.getPlayer() == null) {
-            return null;
+            return original.call(this, ctx);
         }
-
         return PlayerUtil.transformPlayerTemporarily(
             ctx.getPlayer(),
             ctx.getLevel(),

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/hypertube/MixinBezierConnection.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/hypertube/MixinBezierConnection.java
@@ -1,0 +1,35 @@
+package org.valkyrienskies.mod.mixin.mod_compat.hypertube;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.createmod.catnip.animation.LerpedFloat;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+
+@Pseudo
+@Mixin(targets = "com/pedrorok/hypertube/core/connection/BezierConnection", remap = false)
+public abstract class MixinBezierConnection {
+    @Unique
+    private final static float MAX_REASONABLE_DISTANCE = 1000F;
+
+    @Shadow
+    public float distance() { return 0; }
+
+    // The mod always tries to calculate and render the curve, even if it is ridiculously long. That results in OOM.
+    @WrapOperation(method = "getValidation", at = @At(value = "INVOKE", target = "Lcom/pedrorok/hypertube/core/connection/BezierConnection;getMaxAngleBezierAngle()F"))
+    private float cancelLongBezierCalculation(@Coerce Object instance, Operation<Float> original) {
+        if (distance() > MAX_REASONABLE_DISTANCE) return 0;
+        return original.call(instance);
+    }
+
+    @WrapMethod(method = "drawPath")
+    private void cancelLongDrawPath(LerpedFloat animation, boolean isValid, Operation<Void> original) {
+        if (distance() > MAX_REASONABLE_DISTANCE) return;
+        original.call(animation, isValid);
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/hypertube/MixinBezierTextureRenderer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/hypertube/MixinBezierTextureRenderer.java
@@ -1,0 +1,49 @@
+package org.valkyrienskies.mod.mixin.mod_compat.hypertube;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import com.mojang.blaze3d.vertex.PoseStack;
+import java.util.List;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Matrix4f;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Pseudo
+@Mixin(targets = "com/pedrorok/hypertube/client/BezierTextureRenderer")
+public class MixinBezierTextureRenderer {
+    // Many rendering calculations here happen in floats, sometimes with narrowing casts.
+    // We mitigate that by offsetting the first curve node to zero. Pose is adjusted as well.
+    @Unique
+    private Vec3 vs$coordOffset;
+
+    @Inject(method = "renderBezierConnection", at = @At(value = "INVOKE", target = "Lcom/pedrorok/hypertube/client/BezierTextureRenderer;calculateAndCacheGeometry(Ljava/util/List;)Ljava/util/List;"))
+    private void pushTransform(BlockPos blockPosInitial, @Coerce Object connection, PoseStack ms,
+        MultiBufferSource bufferSource, int packedLight, int packedOverlay, CallbackInfo ci,
+        @Local Level level,
+        @Local Vec3 pos, @Local(name = "pose") LocalRef<Matrix4f> poseStackLocalRef
+    ) {
+        if (level != null && VSGameUtilsKt.isBlockInShipyard(level, pos)) {
+            ms.popPose();
+            ms.pushPose();
+            vs$coordOffset = pos;
+            poseStackLocalRef.set(ms.last().pose());
+        } else vs$coordOffset = null;
+    }
+
+    @Inject(method = "calculateAndCacheGeometry", at = @At(value = "NEW", target = "com/pedrorok/hypertube/client/TubeRing"))
+    private void offsetCenters(List<Vec3> points, CallbackInfoReturnable cir,
+        @Local(name = "currentPoint") LocalRef<Vec3> currentPoint) {
+        if (vs$coordOffset != null) currentPoint.set(currentPoint.get().subtract(vs$coordOffset));
+    }
+}

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -297,6 +297,8 @@
     "mod_compat.create.client.gui.menu.MixinClipboardScreen",
     "mod_compat.etf.MixinBlockEntity",
     "mod_compat.flywheel_renderer.MixinViewArea",
+    "mod_compat.hypertube.MixinBezierConnection",
+    "mod_compat.hypertube.MixinBezierTextureRenderer",
     "mod_compat.immersive_portals.MixinMyBuiltChunkStorage",
     "mod_compat.immersive_portals.MixinVisibleSectionDiscovery",
     "mod_compat.optifine.RenderChunkInfoAccessorOptifine",


### PR DESCRIPTION
Fixes a crash when attempting to render a looooong bezier curve (happens when building a hypertube and accidentally hovering on other ship / world). Also fixes ship hypertube rendering

Before:
<img width="599" height="364" alt="image" src="https://github.com/user-attachments/assets/edbe9757-b7de-4265-9630-4be21d0ff592" />
After:
<img width="768" height="409" alt="image" src="https://github.com/user-attachments/assets/924f10fd-ae25-4690-926d-09f675c632ca" />

Tested out of dev. Does not include new dependencies. Both mixins are clientside.
Also includes a one line fix for my block placement mixin, credits to Niels and Ruby.