### PR TITLE
More fixes and improvements for Connectible Chains compat

### DIFF
--- a/common/src/main/resources/data/connectiblechains/vs_entities/chain_collision.json
+++ b/common/src/main/resources/data/connectiblechains/vs_entities/chain_collision.json
@@ -1,0 +1,3 @@
+{
+  "handler": "valkyrienskies:shipyard"
+}

--- a/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/compat/connectiblechains/MixinChainCollisionEntity.java
+++ b/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/compat/connectiblechains/MixinChainCollisionEntity.java
@@ -1,0 +1,30 @@
+package org.valkyrienskies.mod.fabric.mixin.compat.connectiblechains;
+
+import com.github.legoatoom.connectiblechains.entity.ChainCollisionEntity;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Mixin(ChainCollisionEntity.class)
+public abstract class MixinChainCollisionEntity extends Entity {
+
+    // Collisions with shipyard entities (bar contraptions, maybe) are very weird and can even lock your camera.
+    // These entities aren't any special, they are just invisible boxes of sub-block size, slightly larger on Y axis.
+    // This mixin will not be necessary in the case collisions become stable.
+    @Inject(method = "canBeCollidedWith", at = @At("HEAD"), cancellable = true)
+    private void disableOnShips(CallbackInfoReturnable<Boolean> cir) {
+        if (VSGameUtilsKt.isBlockInShipyard(level(), position())) {
+            cir.setReturnValue(false);
+        }
+    }
+
+    // Dummy
+    public MixinChainCollisionEntity(EntityType<?> entityType, Level level) {
+        super(entityType, level);
+    }
+}

--- a/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/compat/connectiblechains/MixinChainable.java
+++ b/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/compat/connectiblechains/MixinChainable.java
@@ -1,9 +1,12 @@
 package org.valkyrienskies.mod.fabric.mixin.compat.connectiblechains;
 
 import com.github.legoatoom.connectiblechains.entity.Chainable;
+import com.github.legoatoom.connectiblechains.entity.Chainable.ChainData;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.decoration.HangingEntity;
 import org.joml.Vector3dc;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
-@Mixin(value = Chainable.class, remap = false)
+@Mixin(Chainable.class)
 public interface MixinChainable {
     // Chainable is an interface and tickChain accepts a generic. We are lucky it is only ever used once, for HangingEntity
     // so we can use it as a Local. Forge port handles this in a far less overengineered way.
@@ -24,5 +27,14 @@ public interface MixinChainable {
         } else {
             return original.call();
         }
+    }
+
+    @WrapWithCondition(
+        method = "attachChain(Lnet/minecraft/world/entity/decoration/HangingEntity;Lcom/github/legoatoom/connectiblechains/entity/Chainable$ChainData;Lnet/minecraft/world/entity/Entity;Z)V",
+        at = @At(value = "INVOKE", target = "Lcom/github/legoatoom/connectiblechains/entity/ChainCollisionEntity;createCollision(Lnet/minecraft/world/entity/Entity;Lcom/github/legoatoom/connectiblechains/entity/Chainable$ChainData;)V")
+    )
+    private static boolean skipCreatingCollision(Entity entity, ChainData chainData) {
+        // Created collision entities are created between two nodes of the chain. Not applicable between world and ship, or different ships.
+        return VSGameUtilsKt.getShipManaging(entity) == VSGameUtilsKt.getShipManaging(((Chainable)entity).getChainHolder(chainData));
     }
 }

--- a/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/compat/connectiblechains/client/MixinChainKnotEntityRenderer.java
+++ b/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/compat/connectiblechains/client/MixinChainKnotEntityRenderer.java
@@ -50,7 +50,8 @@ public abstract class MixinChainKnotEntityRenderer {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/client/renderer/culling/Frustum;isVisible(Lnet/minecraft/world/phys/AABB;)Z"
-        )
+        ),
+        require = 0 // Present in older versions of the mod, seems to be removed in a bugfix update
     )
     private boolean adjustHolderAABB(Frustum frustum, AABB aabb, Operation<Boolean> original, @Local Entity chainHolder) {
         return frustum.isVisible(VSGameUtilsKt.transformRenderAABBToWorld(((ClientLevel) chainHolder.level()), chainHolder.position(), aabb));

--- a/fabric/src/main/resources/valkyrienskies-fabric.mixins.json
+++ b/fabric/src/main/resources/valkyrienskies-fabric.mixins.json
@@ -5,6 +5,7 @@
   "plugin": "org.valkyrienskies.mod.fabric.mixin.ValkyrienSkiesFabricMixinPlugin",
   "mixins": [
     "compat.connectiblechains.MixinChainable",
+    "compat.connectiblechains.MixinChainCollisionEntity",
     "compat.create.MixinBlockBreakingKineticTileEntity",
     "compat.create.MixinControlledContraptionEntity",
     "entity.MixinContainerEntity",
@@ -24,8 +25,8 @@
     "compat.create.client.MixinContraptionHandlerClient",
     "compat.create.client.MixinCullingBlockEntityIterator",
     "compat.create.client.MixinSuperGlueSelectionHandler",
-    "compat.sodium.MixinSodiumWorldRenderer",
     "compat.emf.MixinEMFAnimationEntityContext",
+    "compat.sodium.MixinSodiumWorldRenderer",
     "feature.duplicate_keybindings.KeyMappingAccessor",
     "feature.duplicate_keybindings.MixinKeyMapping"
   ],

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/connectiblechains/MixinChainCollisionEntity.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/connectiblechains/MixinChainCollisionEntity.java
@@ -1,0 +1,28 @@
+package org.valkyrienskies.mod.forge.mixin.compat.connectiblechains;
+
+import com.lilypuree.connectiblechains.entity.ChainCollisionEntity;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Mixin(ChainCollisionEntity.class)
+public abstract class MixinChainCollisionEntity extends Entity {
+
+    // This mixin will not be necessary in the case collisions become stable.
+    @Inject(method = "canBeCollidedWith", at = @At("HEAD"), cancellable = true)
+    private void disableOnShips(CallbackInfoReturnable<Boolean> cir) {
+        if (VSGameUtilsKt.isBlockInShipyard(level(), position())) {
+            cir.setReturnValue(false);
+        }
+    }
+
+    // Dummy
+    public MixinChainCollisionEntity(EntityType<?> entityType, Level level) {
+        super(entityType, level);
+    }
+}

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/connectiblechains/MixinChainLink.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/connectiblechains/MixinChainLink.java
@@ -1,0 +1,37 @@
+package org.valkyrienskies.mod.forge.mixin.compat.connectiblechains;
+
+import com.lilypuree.connectiblechains.chain.ChainLink;
+import com.lilypuree.connectiblechains.entity.ChainKnotEntity;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Mixin(value = ChainLink.class, remap = false)
+public abstract class MixinChainLink {
+    @Final
+    @Shadow
+    public ChainKnotEntity primary;
+    @Final
+    @Shadow
+    public Entity secondary;
+
+    @Inject(method = "createCollision", at = @At("HEAD"), cancellable = true)
+    private void skipCreatingCollision(CallbackInfo ci) {
+        if (VSGameUtilsKt.getShipManaging(primary) != VSGameUtilsKt.getShipManaging(secondary)) ci.cancel();
+    }
+
+    @WrapOperation(method = "destroy", at = @At(value = "INVOKE", target = "Lcom/lilypuree/connectiblechains/util/Helper;middleOf(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;"))
+    private Vec3 middleOfWorldPositions(Vec3 a, Vec3 b, Operation<Vec3> original, @Local Level level) {
+        return original.call(VSGameUtilsKt.toWorldCoordinates(level, a), VSGameUtilsKt.toWorldCoordinates(level, b));
+    }
+}

--- a/forge/src/main/resources/valkyrienskies-forge.mixins.json
+++ b/forge/src/main/resources/valkyrienskies-forge.mixins.json
@@ -4,7 +4,9 @@
   "compatibilityLevel": "JAVA_17",
   "plugin": "org.valkyrienskies.mod.forge.mixin.ValkyrienForgeMixinConfigPlugin",
   "mixins": [
+    "compat.connectiblechains.MixinChainCollisionEntity",
     "compat.connectiblechains.MixinChainKnotEntity",
+    "compat.connectiblechains.MixinChainLink",
     "compat.create.MixinBlockBreakingKineticTileEntity",
     "compat.create.MixinControlledContraptionEntity",
     "compat.create.client.MixinBlockEntityRenderHelper66",
@@ -34,11 +36,11 @@
     "compat.connectiblechains.client.MixinChainKnotEntityRenderer",
     "compat.create.client.MixinChainConveyorBlockEntity",
     "compat.create.client.MixinContraptionHandlerClient",
+    "compat.emf.MixinEMFAnimationEntityContext",
     "compat.oc2r.MixinComputerRenderer",
     "compat.oc2r.MixinMonitorRenderer",
     "compat.oc2r.MixinProjectorDepthRenderer",
-    "compat.sodium.MixinSodiumWorldRenderer",
-    "compat.emf.MixinEMFAnimationEntityContext"
+    "compat.sodium.MixinSodiumWorldRenderer"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
1) Chain collision entities are now shipyarded
2) Actual collision is disabled if they are on a ship. This is because collisions with shipyard entities are quite janky and can result in your camera getting stuck. The entities are still used, as attacking them with shears is the intended way to break the chain.
3) Intership connections do not attempt to create these entities (not sure they ever actually created them, but both versions of the mod attempted to do so).
4) On Forge, chain items now drop when an intership chain is broken as they get far from each other.
5) Fixed not working on Fabric with newest version on the mod, apparently the shouldRender override was outright removed while this PR was stuck.