### PR TITLE
Fix recoil direction

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create_big_cannons/MixinCannonContraption.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create_big_cannons/MixinCannonContraption.java
@@ -41,7 +41,8 @@ public class MixinCannonContraption {
         if (VSGameConfig.SERVER.getCbc().getShellRecoil()) {
             GameToPhysicsAdapter applier = ValkyrienSkiesMod.getOrCreateGTPA(VSGameUtilsKt.getDimensionId(cannon.level()));
             if (applier != null) {
-                double recoilForce = magnitude * VSGameConfig.SERVER.getCbc().getShellRecoilMult();
+                // Invert (by mult by -1) because magnitude is in direction the cannon shot, not the direction recoil is
+                double recoilForce = magnitude * VSGameConfig.SERVER.getCbc().getShellRecoilMult() * -1;
                 applier.applyInvariantForceToPos(
                     ship.getId(),
                     ship.getTransform().getShipToWorldRotation().transform(VectorConversionsMCKt.toJOML(vector).negate().normalize()).mul(recoilForce),


### PR DESCRIPTION
Fixes cannon recoil direction (when enabled in config) being reversed, causing this goofiness:

https://github.com/user-attachments/assets/eec91b19-70e3-4f3d-87db-37a5532feb57

just multiplied magnitude by -1