### PR TITLE
cancel directional lighting on ships embeddium

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     }
 
     //modCompileOnly("curse.maven:rubidium-574856:4024781")
-    modCompileOnly("maven.modrinth:embeddium:${embeddium_version}")
+    modImplementation("maven.modrinth:embeddium:${embeddium_version}")
 
     modRuntimeOnly("maven.modrinth:forge-config-screens:v8.0.2-1.20.1-Forge")
 

--- a/forge/gradle.properties
+++ b/forge/gradle.properties
@@ -22,7 +22,7 @@ oc2r_version = 2.1.3
 # https://modrinth.com/mod/tis3d/version/MC1.19.2-forge-1.7.4
 tis3d_version = MC1.20.1-forge-1.7.5
 # https://modrinth.com/mod/embeddium/versions
-embeddium_version = 0.2.9+mc1.20.1
+embeddium_version = 0.3.31+mc1.20.1
 # https://modrinth.com/plugin/dynmap/versions
 dynmap_version=RtI5TFAi
 # https://modrinth.com/mod/hextweaks/versions

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/sodium/MixinSmoothLightPipeline.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/sodium/MixinSmoothLightPipeline.java
@@ -1,0 +1,39 @@
+package org.valkyrienskies.mod.forge.mixin.compat.sodium;
+
+import me.jellysquid.mods.sodium.client.model.light.data.QuadLightData;
+import me.jellysquid.mods.sodium.client.model.light.smooth.SmoothLightPipeline;
+import me.jellysquid.mods.sodium.client.model.quad.ModelQuadView;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+@Mixin(value = SmoothLightPipeline.class, remap = false)
+public class MixinSmoothLightPipeline {
+
+    @Inject(method = "calculate", at = @At(value = "INVOKE",
+        target = "Lme/jellysquid/mods/sodium/client/model/light/smooth/SmoothLightPipeline;applySidedBrightness(Lme/jellysquid/mods/sodium/client/model/light/data/QuadLightData;Lnet/minecraft/core/Direction;Z)V"), cancellable = true)
+    private void calculateInject(ModelQuadView quad, BlockPos pos, QuadLightData out, Direction cullFace,
+        Direction lightFace, boolean shade, CallbackInfo ci) {
+
+        Level level = Minecraft.getInstance().level;
+        if (level != null && VSGameUtilsKt.isBlockInShipyard(level, pos)) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "calculate", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/model/light/smooth/SmoothLightPipeline;applySidedBrightnessFromNormals(Lme/jellysquid/mods/sodium/client/model/light/data/QuadLightData;Lme/jellysquid/mods/sodium/client/model/quad/ModelQuadView;Z)V"), cancellable = true)
+    private void calculateInject2(ModelQuadView quad, BlockPos pos, QuadLightData out, Direction cullFace,
+        Direction lightFace, boolean shade, CallbackInfo ci) {
+
+        Level level = Minecraft.getInstance().level;
+        if (level != null && VSGameUtilsKt.isBlockInShipyard(level, pos)) {
+            ci.cancel();
+        }
+    }
+}

--- a/forge/src/main/resources/valkyrienskies-forge.mixins.json
+++ b/forge/src/main/resources/valkyrienskies-forge.mixins.json
@@ -21,6 +21,7 @@
     "compat.mffs.MixinClientPacketHandler",
     "compat.mffs.MixinFrequencyGrid",
     "compat.modular_routers.MixinRouterMenu",
+    "compat.sodium.MixinSmoothLightPipeline",
     "compat.thermalexpansion.MixinTileCoFH",
     "compat.twilightforest.ChunkGeneratorTwilightMixin",
     "entity.MixinContainerEntity",


### PR DESCRIPTION
# ⚒️ Pull Request Offering

> _We shall not introduce more regressions  \
> Lest we face eternal digressions_

---
## 🧾 What This PR Does
Feature: Blocks on ships will no longer render with directional tint when using Embeddium


## 🔍 How This Was Tested
Singleplayer


## ⚠️ Breaking Changes
No

---

## 🧪 GameTest Oath
Gametest not applicable, since this is a change to rendering

---

## 🗝️ Additional Notes
Anything else reviewers might need to know:
performance concerns, edge cases, forbidden knowledge, etc. 💀

Might not work with older versions of Embeddium due to added mixins to internals

---

## 🜏 Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- No worlds shall be harmed in the making or merging of this PR 💀
