### PR TITLE
Fix players still falling through Valkyrien Skies ships when teleporting to them if the ship is loaded for the first time this session.

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinPlayer.java
@@ -22,7 +22,7 @@ import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck;
 public abstract class MixinPlayer extends LivingEntity implements PlayerKnownShipsDuck {
 
     @Unique
-    private final LongSet vs_knownShips = new LongOpenHashSet();
+    private LongSet vs_knownShips = new LongOpenHashSet();
 
     protected MixinPlayer(EntityType<? extends LivingEntity> entityType,
         Level level) {
@@ -31,7 +31,9 @@ public abstract class MixinPlayer extends LivingEntity implements PlayerKnownShi
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void populateLoadedShips(Level level, BlockPos blockPos, float f, GameProfile gameProfile, CallbackInfo ci) {
-        VSGameUtilsKt.getShipObjectWorld(level).getLoadedShips().forEach(ship -> vs_knownShips.add(ship.getId()));
+        if (level.isClientSide()) { // Serverside we repopulate it from the previous ServerPlayer in ServerPlayer::restoreFrom.
+            VSGameUtilsKt.getShipObjectWorld(level).getLoadedShips().forEach(ship -> vs_knownShips.add(ship.getId()));
+        }
     }
 
     @Override
@@ -55,5 +57,15 @@ public abstract class MixinPlayer extends LivingEntity implements PlayerKnownShi
     @Override
     public boolean vs_isKnownShip(long shipId) {
         return vs_knownShips.contains(shipId);
+    }
+
+    @Override
+    public LongSet vs_getKnownShips() {
+        return vs_knownShips;
+    }
+
+    @Override
+    public void vs_setKnownShips(LongSet ships) {
+        this.vs_knownShips = ships;
     }
 }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinPlayer.java
@@ -1,13 +1,19 @@
 package org.valkyrienskies.mod.mixin.feature.spawn_player_on_ship;
 
+import com.mojang.authlib.GameProfile;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.ValkyrienSkiesMod;
 import org.valkyrienskies.mod.common.networking.PacketChangeKnownShips;
 import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck;
@@ -21,6 +27,11 @@ public abstract class MixinPlayer extends LivingEntity implements PlayerKnownShi
     protected MixinPlayer(EntityType<? extends LivingEntity> entityType,
         Level level) {
         super(entityType, level);
+    }
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void populateLoadedShips(Level level, BlockPos blockPos, float f, GameProfile gameProfile, CallbackInfo ci) {
+        VSGameUtilsKt.getShipObjectWorld(level).getLoadedShips().forEach(ship -> vs_knownShips.add(ship.getId()));
     }
 
     @Override

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinPlayer.java
@@ -31,7 +31,7 @@ public abstract class MixinPlayer extends LivingEntity implements PlayerKnownShi
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void populateLoadedShips(Level level, BlockPos blockPos, float f, GameProfile gameProfile, CallbackInfo ci) {
-        if (level.isClientSide()) { // Serverside we repopulate it from the previous ServerPlayer in ServerPlayer::restoreFrom.
+        if (level != null && level.isClientSide()) { // Serverside we repopulate it from the previous ServerPlayer in ServerPlayer::restoreFrom.
             VSGameUtilsKt.getShipObjectWorld(level).getLoadedShips().forEach(ship -> vs_knownShips.add(ship.getId()));
         }
     }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinServerPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinServerPlayer.java
@@ -1,0 +1,18 @@
+package org.valkyrienskies.mod.mixin.feature.spawn_player_on_ship;
+
+import net.minecraft.server.level.ServerPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck;
+
+@Mixin(ServerPlayer.class)
+public class MixinServerPlayer {
+
+    @Inject(method = "restoreFrom", at = @At("RETURN"))
+    private void copyFrom(ServerPlayer serverPlayer, boolean bl, CallbackInfo ci) {
+        ((PlayerKnownShipsDuck) this).vs_setKnownShips(((PlayerKnownShipsDuck) serverPlayer).vs_getKnownShips());
+    }
+
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixinducks/feature/tickets/PlayerKnownShipsDuck.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixinducks/feature/tickets/PlayerKnownShipsDuck.java
@@ -1,10 +1,16 @@
 package org.valkyrienskies.mod.mixinducks.feature.tickets;
 
+import it.unimi.dsi.fastutil.longs.LongSet;
+
 public interface PlayerKnownShipsDuck {
 
     void vs_addKnownShip(long shipId);
 
     void vs_removeKnownShip(long shipId);
+
+    LongSet vs_getKnownShips();
+
+    void vs_setKnownShips(LongSet ships);
 
     boolean vs_isKnownShip(long shipId);
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityShipCollisionUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityShipCollisionUtils.kt
@@ -1,6 +1,7 @@
 package org.valkyrienskies.mod.common.util
 
 import net.minecraft.client.multiplayer.ClientLevel
+import net.minecraft.core.SectionPos
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.util.Mth
 import net.minecraft.world.entity.Entity
@@ -11,20 +12,47 @@ import net.minecraft.world.phys.Vec3
 import net.minecraft.world.phys.shapes.VoxelShape
 import org.joml.primitives.AABBd
 import org.joml.primitives.AABBdc
+import org.joml.primitives.AABBi
 import org.valkyrienskies.core.api.ships.Ship
 import org.valkyrienskies.core.internal.collision.VsiConvexPolygonc
 import org.valkyrienskies.core.util.extend
+import org.valkyrienskies.core.util.toAABBd
+import org.valkyrienskies.mod.common.allShips
 import org.valkyrienskies.mod.common.dimensionId
 import org.valkyrienskies.mod.common.getLoadedShipManagingPos
-import org.valkyrienskies.mod.common.getShipsIntersecting
 import org.valkyrienskies.mod.common.shipObjectWorld
 import org.valkyrienskies.mod.common.vsCore
 import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck
 import org.valkyrienskies.mod.util.BugFixUtil
+import java.util.stream.Stream
 
 object EntityShipCollisionUtils {
 
     private val collider = vsCore.entityPolygonCollider
+
+    private fun getShipyardChunkAABBAround(ship: Ship): AABBi {
+        val box = AABBi()
+        // Since we don't know how big the ship is vertically we'll just have to trust the shipAABB and add some margin of error.
+        val minY = (ship.shipAABB?.minY() ?: Mth.floor(ship.transform.position.y())) - 16
+        val maxY = (ship.shipAABB?.maxY() ?: Mth.ceil(ship.transform.position.y())) + 16
+        ship.activeChunksSet.forEach { x, z ->
+            val minX = SectionPos.sectionToBlockCoord(x)
+            val minZ = SectionPos.sectionToBlockCoord(z)
+            val maxX = SectionPos.sectionToBlockCoord(x, 15)
+            val maxZ = SectionPos.sectionToBlockCoord(z, 15)
+            box.union(minX, minY, minZ).union(maxX, maxY, maxZ)
+        }
+        return box
+    }
+
+    private fun getAllShipsIntersectingEvenIfNotYetFullyLoaded(level: Level, aabb: AABBd): Stream<Ship> {
+        // shipAABB and worldAABB are sometimes too small when ship was just loaded for the first time.
+        // To circumvent this, we use activeChunksSet to find a rougher bounding box which should always contain the entire ship.
+        return level.allShips.stream().filter { ship ->
+            ship.chunkClaimDimension == level.dimensionId &&
+            getShipyardChunkAABBAround(ship).toAABBd(AABBd()).transform(ship.shipToWorld).intersectsAABB(aabb)
+        }
+    }
 
     @JvmStatic
     fun isCollidingWithUnloadedShips(entity: Entity): Boolean {
@@ -36,10 +64,10 @@ object EntityShipCollisionUtils {
             }
 
             val aabb = entity.boundingBox.toJOML()
-            return level.getShipsIntersecting(aabb)
-                .all { ship ->
+            return getAllShipsIntersectingEvenIfNotYetFullyLoaded(level, aabb)
+                .allMatch { ship ->
                     if (entity is PlayerKnownShipsDuck && !entity.vs_isKnownShip(ship.id)) {
-                        return true
+                        return@allMatch false
                     }
                     val aabbInShip = AABBd(aabb).transform(ship.worldToShip)
                     areAllChunksLoaded(ship, aabbInShip, level)

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -82,6 +82,7 @@
     "feature.shipyard_leashing.MixinPathfinderMob",
     "feature.spawn_player_on_ship.MixinPlayer",
     "feature.spawn_player_on_ship.MixinServerGamePacketListenerImpl",
+    "feature.spawn_player_on_ship.MixinServerPlayer",
     "feature.structure_template.PaletteInvoker",
     "feature.structure_template.StructureTemplateMixin",
     "feature.submarines.MixinWaterFluid",


### PR DESCRIPTION
# ⚒️ Pull Request Offering

> _We shall not introduce more regressions  \
> Lest we face eternal digressions_

---
## 🧾 What This PR Does
This is a follow-up to #1566 to catch an edge case I missed the first time around.
Basically, players would still fall through ships when they were loaded for the first time since loading the world sometimes because apparently the shipAABB would not contain the entire ship immediately.

To solve this, I use the activeChunkSet to create a separate bounding box only used during the unloaded ship check. Unfortunately I can't think of a good way to detect the vertical height so the shipAABB is still used for that, I just add 16 blocks up and 16 blocks down as a precaution. This should also make sure things work properly when the player is on top of the ship rather than inside it.

Also now closes #1654


## 🔍 How This Was Tested
- [ ] GameTest framework  
- [x] Singleplayer / Server  
- [ ] Logs looked sane  
- [x] The vibes felt right *(sometimes you really do just have to vibe it)*


## ⚠️ Breaking Changes
- [ ] Yes (describe)  
- [x] No  (are you *really* sure?)

As this only uses a slightly larger bounding box for ships when checking if they are unloaded it should be fairly painless.

---

## 🧪 GameTest Oath
- [ ] Please include at least one `@GameTest`  
or  
- [x] PR does not require a `@GameTest`   
  - [ ] True if this change is only a data/config/docs/logs change  
  - [x] Also True *if* you can make a good case on why you shouldn't have to add one

Part of me wants to add a game test to make sure this bug never comes back, but I don't really know where I should put it.

> PRs without a new GameTest **will not be merged**  (If they are determined to be required) \
> _unless explicitly exempted by a maintainer._

---

## 🗝️ Additional Notes
One thing about this is that now it's basically iterating through all ships and creating a new bounding box for each one in the same dimension as the player whenever the player moves. I'm just unsure how to fix this in a better way without modifying vs-core.

---

## 🜏 Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- No worlds shall be harmed in the making or merging of this PR 💀
