### PR TITLE
[1.20.1] Hexcasting Hotfix

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/HexcastingCompat.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/HexcastingCompat.kt
@@ -3,9 +3,9 @@ package org.valkyrienskies.mod.compat.hexcasting
 import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 
 object HexcastingCompat {
-    fun register(clazz: Class<out AmbitRemapping>) {
+    fun register(clazz: Class<out ShipAmbit>) {
         CastingEnvironment.addCreateEventListener { env, _ ->
-            env.addExtension(clazz.getConstructor(CastingEnvironment::class.java).newInstance(env) as AmbitRemapping)
+            env.addExtension(clazz.getConstructor(CastingEnvironment::class.java).newInstance(env) as ShipAmbit)
         }
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/README.md
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/README.md
@@ -1,0 +1,12 @@
+# Hexcasting Compatibility
+
+## HexcastingCompat.kt
+- Handles registering all `ShipAmbit` instances using `register` due to how hexcasting handles such things.
+
+## ShipAmbit.kt
+- Handles both permissions checks and ambit checks based on Ship context (both of the Ship the caster may be on and the Ship the target position may be on).
+- This is meant to be extended by `FabricShipAmbit` and `ForgeShipAmbit` to handle modloader-specific Hexcasting addon compatibilities such as HexTweaks' custom `ComputerCastEnv`.
+
+## HexTweaksCompat.kt
+- A shared class used to get a caster position from `CompterCastEnv`.
+- Should only be referred to in `FabricShipAmbit` and `ForgeShipAmbit` after checking if HexTweaks is loaded.

--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/ShipAmbit.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/ShipAmbit.kt
@@ -15,7 +15,7 @@ import org.valkyrienskies.mod.common.util.toJOML
 import org.valkyrienskies.mod.compat.hexcasting.hextweaks.HexTweaksCompat
 import java.util.UUID
 
-open class AmbitRemapping(val env: CastingEnvironment) : IsVecInRange, HasEditPermissionsAt {
+open class ShipAmbit(val env: CastingEnvironment) : IsVecInRange, HasEditPermissionsAt {
     private val id = UUID.randomUUID()
     private val key = Key(id)
 
@@ -51,10 +51,6 @@ open class AmbitRemapping(val env: CastingEnvironment) : IsVecInRange, HasEditPe
     }
 
     open fun getCasterPosition(): Vec3? {
-        try { // Since there is no X-Plat way to test if a mod is loaded
-            return HexTweaksCompat.getComputerPosition(env)
-        } catch (_: ClassNotFoundException) {}
-
         return when (env) {
             is CircleCastEnv -> {
                 env.impetus?.blockPos?.center
@@ -66,4 +62,4 @@ open class AmbitRemapping(val env: CastingEnvironment) : IsVecInRange, HasEditPe
     }
 }
 
-class Key(val id: UUID) : Key<AmbitRemapping> {}
+class Key(val id: UUID) : Key<ShipAmbit> {}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/ShipAmbit.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/ShipAmbit.kt
@@ -12,7 +12,6 @@ import org.valkyrienskies.mod.api.positionToShip
 import org.valkyrienskies.mod.api.positionToWorld
 import org.valkyrienskies.mod.common.getLoadedShipManagingPos
 import org.valkyrienskies.mod.common.util.toJOML
-import org.valkyrienskies.mod.compat.hexcasting.hextweaks.HexTweaksCompat
 import java.util.UUID
 
 open class ShipAmbit(val env: CastingEnvironment) : IsVecInRange, HasEditPermissionsAt {
@@ -47,7 +46,7 @@ open class ShipAmbit(val env: CastingEnvironment) : IsVecInRange, HasEditPermiss
 
         // Is Caster in the Shipyard?
         // Transform Other Position to Caster's Shipyard
-        casterShip?.let { casterShip -> return env.isVecInRange(casterShip.positionToShip(otherPos)) } ?: return env.isVecInRange(otherPos)
+        return env.isVecInRange(casterShip?.positionToShip(otherPos))
     }
 
     open fun getCasterPosition(): Vec3? {

--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/ShipAmbit.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/ShipAmbit.kt
@@ -12,7 +12,6 @@ import org.valkyrienskies.mod.api.positionToShip
 import org.valkyrienskies.mod.api.positionToWorld
 import org.valkyrienskies.mod.common.getLoadedShipManagingPos
 import org.valkyrienskies.mod.common.util.toJOML
-import org.valkyrienskies.mod.compat.hexcasting.hextweaks.HexTweaksCompat
 import java.util.UUID
 
 open class ShipAmbit(val env: CastingEnvironment) : IsVecInRange, HasEditPermissionsAt {
@@ -25,10 +24,8 @@ open class ShipAmbit(val env: CastingEnvironment) : IsVecInRange, HasEditPermiss
     override fun onHasEditPermissionsAt(pos: BlockPos, current: Boolean): Boolean {
         if (current) return true
         // Always use Worldspace for permissions
-        env.world.getLoadedShipManagingPos(pos)?.let { ship ->
-            return env.hasEditPermissionsAt(BlockPos.containing(ship.positionToWorld(pos.center)))
-        }
-        return current
+        val ship = env.world.getLoadedShipManagingPos(pos)
+        return env.hasEditPermissionsAt(BlockPos.containing(ship.positionToWorld(pos.center)))
     }
 
     @OptIn(GameTickOnly::class)
@@ -47,7 +44,7 @@ open class ShipAmbit(val env: CastingEnvironment) : IsVecInRange, HasEditPermiss
 
         // Is Caster in the Shipyard?
         // Transform Other Position to Caster's Shipyard
-        casterShip?.let { casterShip -> return env.isVecInRange(casterShip.positionToShip(otherPos)) } ?: return env.isVecInRange(otherPos)
+        return env.isVecInRange(casterShip?.positionToShip(otherPos))
     }
 
     open fun getCasterPosition(): Vec3? {

--- a/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/compat/hexcasting/FabricShipAmbit.kt
+++ b/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/compat/hexcasting/FabricShipAmbit.kt
@@ -3,16 +3,14 @@ package org.valkyrienskies.mod.fabric.compat.hexcasting
 import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 import net.fabricmc.loader.api.FabricLoader
 import net.minecraft.world.phys.Vec3
-import org.valkyrienskies.mod.compat.hexcasting.AmbitRemapping
+import org.valkyrienskies.mod.compat.hexcasting.ShipAmbit
 import org.valkyrienskies.mod.compat.hexcasting.hextweaks.HexTweaksCompat
 
-class FabricShipAmbit(env: CastingEnvironment) : AmbitRemapping(env) {
+class FabricShipAmbit(env: CastingEnvironment) : ShipAmbit(env) {
     override fun getCasterPosition(): Vec3? {
-        super.getCasterPosition()?.let { return it }
-
         if (FabricLoader.getInstance().isModLoaded("hextweaks"))
             HexTweaksCompat.getComputerPosition(env)?.let { return it }
 
-        return null
+        return super.getCasterPosition()
     }
 }

--- a/forge/src/main/kotlin/org/valkyrienskies/mod/forge/compat/hexcasting/ForgeShipAmbit.kt
+++ b/forge/src/main/kotlin/org/valkyrienskies/mod/forge/compat/hexcasting/ForgeShipAmbit.kt
@@ -3,16 +3,14 @@ package org.valkyrienskies.mod.forge.compat.hexcasting
 import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 import net.minecraft.world.phys.Vec3
 import net.minecraftforge.fml.ModList
-import org.valkyrienskies.mod.compat.hexcasting.AmbitRemapping
+import org.valkyrienskies.mod.compat.hexcasting.ShipAmbit
 import org.valkyrienskies.mod.compat.hexcasting.hextweaks.HexTweaksCompat
 
-class ForgeShipAmbit(env: CastingEnvironment) : AmbitRemapping(env) {
+class ForgeShipAmbit(env: CastingEnvironment) : ShipAmbit(env) {
     override fun getCasterPosition(): Vec3? {
-        super.getCasterPosition()?.let { return it }
-
         if (ModList.get().isLoaded("hextweaks"))
             HexTweaksCompat.getComputerPosition(env)?.let { return it }
 
-        return null
+        return super.getCasterPosition()
     }
 }


### PR DESCRIPTION
# ⚒️ Pull Request Offering

> _We shall not introduce more regressions  \
> Lest we face eternal digressions_

---
## 🧾 What This PR Does
This PR fixes a mistake I made in my last PR regarding HexTweaks due to forgetting how I made the compatibility originally and forgetting how I did it and incidentally redoing it worse.

I also simplified a few lines as I didnt realize `Ship#positionInWorld` and `Ship#positionInShip` already handled nullable Ships.


## 🔍 How This Was Tested
- [ ] GameTest framework  
- [X] Singleplayer / Server  
- [X] Logs looked sane  
- [X] The vibes felt right *(sometimes you really do just have to vibe it)*


## ⚠️ Breaking Changes
- [ ] Yes (describe)  
- [X] No  (are you *really* sure?)

---

## 🧪 GameTest Oath
- [ ] Please include at least one `@GameTest`  
or  
- [X] PR does not require a `@GameTest`   
  - [ ] True if this change is only a data/config/docs/logs change  
  - [ ] Also True *if* you can make a good case on why you shouldn't have to add one
Literally on idea how I'd gametest this. It needs a Hexcaster to use it.

---

## 🗝️ Additional Notes
I reverted to how HexTweaks was previously handled and cleaned up some lines.

---

## 🜏 Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- No worlds shall be harmed in the making or merging of this PR 💀
