### PR TITLE
Fix bluemap compat

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/ValkyrienCommonMixinConfigPlugin.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/ValkyrienCommonMixinConfigPlugin.java
@@ -102,6 +102,12 @@ public class ValkyrienCommonMixinConfigPlugin implements IMixinConfigPlugin {
             return LoadedMods.getFlywheel() == FlywheelVersion.V06;
         }
 
+        if (mixinClassName.contains("org.valkyrienskies.mod.mixin.mod_compat.bluemap")) {
+            // Our mixins will crash if bluemap version is NONE or 5.12(+)
+            // We can't support bluemap 5.12(+) because it needs JVM 21, so that's for an addon to do.
+            return LoadedMods.getBluemap().matches("^5\\.3(-.*)?$");
+        }
+
         if (mixinClassName.contains("org.valkyrienskies.mod.mixin.mod_compat.common_create.client.trackOutlines")) {
             //interactive has its own track outline stuff so disable fixed version of VS2's track outline stuff
             if (classExists("org.valkyrienskies.create_interactive.mixin.client.MixinTrackBlockOutline")) {

--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/LoadedMods.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/LoadedMods.kt
@@ -35,6 +35,16 @@ object LoadedMods {
         }
     }
 
+    @JvmStatic
+    val bluemap: String by lazy {
+        try {
+            val claz = Class.forName("de.bluecolored.bluemap.core.BlueMap")
+            claz.getField("VERSION").get(null) as String
+        } catch (e: ClassNotFoundException) {
+            "NONE"
+        }
+    }
+
     class CompatInfo(private val className: String) : ReadOnlyProperty<Any?, Boolean> {
         private var isLoaded: Boolean? = null
 
@@ -54,6 +64,12 @@ object LoadedMods {
     enum class FlywheelVersion {
         V1,
         V06,
+        NONE
+    }
+
+    enum class BluemapVersion {
+        V53,
+        V512,
         NONE
     }
 }


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [x] Compat with another mod

**Explain what this PR is doing:**
This PR makes it so our Bluemap compat mixins will not load if Bluemap is detected to be 5.12+. We support bluemap 5.3, but bluemap 5.12 needs JVM 21 (even on 1.20.1), so we can't support it. My intention with using a mixin config instead of a hard dependency version range is to allow a third-party addon to re-implement the VS+bluemap compat on JVM 21.

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [x] In-dev dedicated server
- [x] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [x] No

---


## Additional Notes
I might make the bluemap x VS addon for bluemap 5.12, if I get round to it. It looks like mostly using their api will be better than trying to fix our mixins, as bluemap has changed quite significantly.

I don't know why circle ci is failing, I didn't change the gradle yet its failing to find `cpw.mods:modlauncher:10.0.+` for some reason.

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds