### PR TITLE
Fix (probably) players getting stuck in ships after respawning

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinPlayer.java
@@ -1,13 +1,19 @@
 package org.valkyrienskies.mod.mixin.feature.spawn_player_on_ship;
 
+import com.mojang.authlib.GameProfile;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.ValkyrienSkiesMod;
 import org.valkyrienskies.mod.common.networking.PacketChangeKnownShips;
 import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck;
@@ -21,6 +27,11 @@ public abstract class MixinPlayer extends LivingEntity implements PlayerKnownShi
     protected MixinPlayer(EntityType<? extends LivingEntity> entityType,
         Level level) {
         super(entityType, level);
+    }
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void populateLoadedShips(Level level, BlockPos blockPos, float f, GameProfile gameProfile, CallbackInfo ci) {
+        VSGameUtilsKt.getShipObjectWorld(level).getLoadedShips().forEach(ship -> vs_knownShips.add(ship.getId()));
     }
 
     @Override


### PR DESCRIPTION
After a Player entity is reinstantiated, its collisions with ships are broken until the player relogs. I tracked this down to this recent change:
<img width="1108" height="504" alt="image" src="https://github.com/user-attachments/assets/d0911961-cc58-4357-a0cf-a59c606356f1" />
For collision purposes, a ship that is not in `vs_knownShips` of spawn_player_on_ship/MixinPlayer is now considered unloaded.

The `vs_knownShips` set is only populated from VSGamePackets and SeamlessChunksManager, first for server side and second for client side.
<img width="1164" height="240" alt="image" src="https://github.com/user-attachments/assets/8242b6af-7261-42f1-b9f0-c1f04887b4e9" />

This creates a problem with player entities recreated without a fresh login, as player's `vs_knownShips` set is empty but the client does not receive ship load packets for the ships the player entity is supposed to be aware of (because the ships are already loaded). For now my fix is to repopulate the set from the list of loaded ships when the player entity is created. @Acuadragon100 is that an acceptable fix to your code or does it interfere with your logic?

Safety moments:
1) Level should not be null, earlier in Player/Entity constructor Level is used so if we got to TAIL of Player ctor we have a valid level.
2) Players might exist in some weird Levels that do not have a corresponding vscore ship world, in that case getShipObjectWorld gives us a dummy world. VSCore code examination (undocumented btw!) reveals `getLoadedShips` does not throw an exception returning an empty iterable instead.