### PR TITLE
Disable client connectivity by default

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -69,7 +69,7 @@ object VSGameConfig {
             @ConfigEntry(
                 description = "Enable client connectivity; increases client load, but allows for client-sided sealed space visuals, like occluding water in a submarine."
             )
-            var enableClientConnectivity = true
+            var enableClientConnectivity = false
         }
 
         @ConfigEntry(

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,7 +49,7 @@ ephemera_version=d4xVSBKN
 # https://modrinth.com/mod/moonlight/versions
 moonlight_version = 1.20-2.16.22-fabric
 
-vs_core_version=1.1.0+f6a942e0e1
+vs_core_version=1.1.0+4477bcca69
 # Ideally we'd determine these automatically from vs_core. Add them manually for now
 krunch_version=1.0.0+ef745c293f
 krunch_api_version=1.0.0+ddc24f2f18


### PR DESCRIPTION
Goes along with https://github.com/ValkyrienSkies/vs-core/pull/98

It's unfortunate this will kill air pockets for the time being, but conn is just too laggy (because of bugs) to justify it being on by default 😔

Hopefully the Valkyrien Air stuff better air pockets can be finished for a (soonish) future release.