### PR TITLE
[1.20.1] Hexal's Wisp Compatibility

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/README.md
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/README.md
@@ -5,7 +5,7 @@
 
 ## ShipAmbit.kt
 - Handles both permissions checks and ambit checks based on Ship context (both of the Ship the caster may be on and the Ship the target position may be on).
-- This is meant to be extended by `FabricShipAmbit` and `ForgeShipAmbit` to handle modloader-specific Hexcasting addon compatibilities such as HexTweaks' custom `ComputerCastEnv`.
+- This is meant to be extended by `FabricShipAmbit` and `ForgeShipAmbit` to handle modloader-specific Hexcasting addon compatibilities such as HexTweaks' `ComputerCastEnv` or Hexal's `WispCastEnv`.
 
 ## HexTweaksCompat.kt
 - A shared class used to get a caster position from `CompterCastEnv`.

--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/hexal/HexalCompat.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/hexal/HexalCompat.kt
@@ -1,0 +1,14 @@
+package org.valkyrienskies.mod.compat.hexcasting.hexal
+
+import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
+import net.minecraft.world.phys.Vec3
+import net.walksanator.hextweaks.casting.environment.ComputerCastingEnv
+import ram.talia.hexal.api.casting.eval.env.WispCastEnv
+
+object HexalCompat {
+    fun getWispPosition(env: CastingEnvironment): Vec3? {
+        if (env is WispCastEnv)
+            return env.wisp.position()
+        return null
+    }
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/hexal/HexalCompat.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/hexcasting/hexal/HexalCompat.kt
@@ -1,6 +1,7 @@
 package org.valkyrienskies.mod.compat.hexcasting.hexal
 
 import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
+import net.minecraft.world.entity.Entity
 import net.minecraft.world.phys.Vec3
 import net.walksanator.hextweaks.casting.environment.ComputerCastingEnv
 import ram.talia.hexal.api.casting.eval.env.WispCastEnv
@@ -8,7 +9,7 @@ import ram.talia.hexal.api.casting.eval.env.WispCastEnv
 object HexalCompat {
     fun getWispPosition(env: CastingEnvironment): Vec3? {
         if (env is WispCastEnv)
-            return env.wisp.position()
+            return (env.wisp as Entity).position()
         return null
     }
 }

--- a/common/src/main/resources/data/hexal/vs_entities/wisp/projectile.json
+++ b/common/src/main/resources/data/hexal/vs_entities/wisp/projectile.json
@@ -1,0 +1,3 @@
+{
+  "handler": "valkyrienskies:shipyard"
+}

--- a/common/src/main/resources/data/hexal/vs_entities/wisp/ticking.json
+++ b/common/src/main/resources/data/hexal/vs_entities/wisp/ticking.json
@@ -1,0 +1,3 @@
+{
+  "handler": "valkyrienskies:shipyard"
+}

--- a/common/src/main/resources/data/hexal/vs_entities/wisp/wandering.json
+++ b/common/src/main/resources/data/hexal/vs_entities/wisp/wandering.json
@@ -1,0 +1,3 @@
+{
+  "handler": "valkyrienskies:shipyard"
+}

--- a/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/compat/hexcasting/FabricShipAmbit.kt
+++ b/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/compat/hexcasting/FabricShipAmbit.kt
@@ -4,12 +4,15 @@ import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 import net.fabricmc.loader.api.FabricLoader
 import net.minecraft.world.phys.Vec3
 import org.valkyrienskies.mod.compat.hexcasting.ShipAmbit
+import org.valkyrienskies.mod.compat.hexcasting.hexal.HexalCompat
 import org.valkyrienskies.mod.compat.hexcasting.hextweaks.HexTweaksCompat
 
 class FabricShipAmbit(env: CastingEnvironment) : ShipAmbit(env) {
     override fun getCasterPosition(): Vec3? {
         if (FabricLoader.getInstance().isModLoaded("hextweaks"))
             HexTweaksCompat.getComputerPosition(env)?.let { return it }
+        if (FabricLoader.getInstance().isModLoaded("hexal"))
+            HexalCompat.getWispPosition(env)?.let { return it }
 
         return super.getCasterPosition()
     }

--- a/forge/src/main/kotlin/org/valkyrienskies/mod/forge/compat/hexcasting/ForgeShipAmbit.kt
+++ b/forge/src/main/kotlin/org/valkyrienskies/mod/forge/compat/hexcasting/ForgeShipAmbit.kt
@@ -4,12 +4,15 @@ import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
 import net.minecraft.world.phys.Vec3
 import net.minecraftforge.fml.ModList
 import org.valkyrienskies.mod.compat.hexcasting.ShipAmbit
+import org.valkyrienskies.mod.compat.hexcasting.hexal.HexalCompat
 import org.valkyrienskies.mod.compat.hexcasting.hextweaks.HexTweaksCompat
 
 class ForgeShipAmbit(env: CastingEnvironment) : ShipAmbit(env) {
     override fun getCasterPosition(): Vec3? {
         if (ModList.get().isLoaded("hextweaks"))
             HexTweaksCompat.getComputerPosition(env)?.let { return it }
+        if (ModList.get().isLoaded("hexal"))
+            HexalCompat.getWispPosition(env)?.let { return it }
 
         return super.getCasterPosition()
     }


### PR DESCRIPTION
## What this PR does:
This PR adds extra Hexcasting compatibility explicitly for the Hexal addon. This addon adds Wisps which are entities that can do magic separate from the player. Due to how exactly their casting environment is made, the did not receive the current Ambit extension VS provides via `ShipAmbit` (and `FabricShipAmbit`/`ForgeShipAmbit`). This PR rectifies that by adding a similar check to how HexTweaks' compat works with `ComputerCastEnv` where it provides the Wisp's position for proper handling.

I also made the three Wisp entities into Shipyard entities so they can properly exist in the Shipyard.

The documentation is also updated a little more.

---

## Modloaders this PR affects:
- [X] Forge
- [X] Fabric

## Where this PR was tested:
- [X] In-dev singleplayer
- [X] In-dev dedicated server
- [X] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [X] No

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
