### PR TITLE
[1.20.1] Fixed Hexal Wisp Crash

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/hexcasting/hexal/MixinRenderHelper.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/hexcasting/hexal/MixinRenderHelper.java
@@ -8,7 +8,6 @@ import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.valkyrienskies.core.api.ships.ClientShip;
 import org.valkyrienskies.mod.api.ValkyrienSkies;
 import ram.talia.hexal.api.linkable.ILinkable.IRenderCentre;
@@ -18,19 +17,11 @@ import ram.talia.hexal.client.RenderHelperKt;
 @Mixin(RenderHelperKt.class)
 public class MixinRenderHelper {
     @WrapOperation(method = "playLinkParticles", at = @At(value = "INVOKE",
-        target = "Lram/talia/hexal/api/linkable/ILinkable$IRenderCentre$DefaultImpls;renderCentre$default(Lram/talia/hexal/api/linkable/ILinkable$IRenderCentre;Lram/talia/hexal/api/linkable/ILinkable$IRenderCentre;ZILjava/lang/Object;)Lnet/minecraft/world/phys/Vec3;", ordinal = 0))
+        target = "Lram/talia/hexal/api/linkable/ILinkable$IRenderCentre$DefaultImpls;renderCentre$default(Lram/talia/hexal/api/linkable/ILinkable$IRenderCentre;Lram/talia/hexal/api/linkable/ILinkable$IRenderCentre;ZILjava/lang/Object;)Lnet/minecraft/world/phys/Vec3;"))
     private static Vec3 valkyrienskies$transformSource(IRenderCentre source, IRenderCentre sink, boolean b, int i, Object o, Operation<Vec3> original, @Local(argsOnly = true) Level level) {
         Vec3 sourceCenter = original.call(source, sink, b, i, o);
         if (ValkyrienSkies.getShipManagingBlock(level, sourceCenter) instanceof ClientShip ship)
             sourceCenter = ValkyrienSkies.positionToWorld(ship, sourceCenter);
         return sourceCenter;
-    }
-
-    @ModifyVariable(method = "playLinkParticles", at = @At("STORE"), name = "delta")
-    private static Vec3 valkyrienskies$swapDelta(Vec3 value, @Local(name = "sourceCentre") Vec3 sourceCenter, @Local(name = "source") IRenderCentre source, @Local(name = "sink") IRenderCentre sink, @Local(argsOnly = true) Level level) {
-        Vec3 sinkCenter = sink.renderCentre(source, true);
-        if (ValkyrienSkies.getShipManagingBlock(level, sinkCenter) instanceof ClientShip ship)
-            sinkCenter = ValkyrienSkies.positionToWorld(ship, sinkCenter);
-        return sinkCenter.subtract(sourceCenter);
     }
 }


### PR DESCRIPTION
## What this PR does:
- [X] Bug fix 
- [ ] Feature
- [X] Code refactor / improvement
- [ ] API addition / improvement
- [X] Compat with another mod

**Explain what this PR is doing:**
This PR fixes a crash with Hexal's Wisps when Linked caused by my previous `MixinRenderHelper` implementation

---

## Modloaders this PR affects:
- [X] Forge
- [X] Fabric

## Where this PR was tested:
- [X] In-dev singleplayer
- [X] In-dev dedicated server
- [X] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [X] No

---


## Additional Notes
This fix was tested by another member of the Hexcasting community

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
