### PR TITLE
Fix util function

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
@@ -205,6 +205,20 @@ private fun getShipObjectManagingPosImpl(world: Level?, chunkX: Int, chunkZ: Int
  */
 fun Level.transformFromWorldToNearbyShipsAndWorld(aabb: AABB, cb: Consumer<AABB>) {
     val tmpAABB = AABBd()
+    cb.accept(aabb)
+    getShipsIntersecting(aabb).forEach { ship ->
+        cb.accept(tmpAABB.set(aabb).transform(ship.worldToShip).toMinecraft())
+    }
+}
+
+/**
+ * Same as [transformFromWorldToNearbyShipsAndWorld] but does not call [cb] with the original [aabb].
+ *
+ * Not sure if this is actually useful, but our MixinEntity for water-flowing on ships seems to need it.
+ */
+fun Level.transformFromWorldToNearbyShips(aabb: AABB, cb: Consumer<AABB>) {
+    val tmpAABB = AABBd()
+    //cb.accept(aabb)
     getShipsIntersecting(aabb).forEach { ship ->
         cb.accept(tmpAABB.set(aabb).transform(ship.worldToShip).toMinecraft())
     }

--- a/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/feature/water_in_ships_entity/MixinEntity.java
+++ b/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/feature/water_in_ships_entity/MixinEntity.java
@@ -146,7 +146,7 @@ public abstract class MixinEntity {
         valkyrienskies$fluidPushVec = instance;
         IEntityDraggingInformationProvider provider = (IEntityDraggingInformationProvider) (Object) this;
         boolean sealed = provider.vs$isInSealedArea();
-        VSGameUtilsKt.transformFromWorldToNearbyShipsAndWorld(level, aabb, (shipAabb) -> {
+        VSGameUtilsKt.transformFromWorldToNearbyShips(level, aabb, (shipAabb) -> {
             valkyrienskies$fluidPushAABB = shipAabb; // enable ship context
             valkyrienskies$fluidPushRet = valkyrienskies$fluidPushRet || (this.updateFluidHeightAndDoFluidPushing(tagKey, d) && !sealed);
             //recall in the ship context

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/feature/water_in_ships_entity/MixinEntity.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/feature/water_in_ships_entity/MixinEntity.java
@@ -154,7 +154,7 @@ public abstract class MixinEntity {
     )
     private void collectShipFluidPush(@Coerce Object2ObjectMap instance, BiConsumer consumer, Operation<Void> original,
         @Local(ordinal = 0, argsOnly = true) Predicate<FluidState> shouldUpdate, @Local AABB aabb) {
-        VSGameUtilsKt.transformFromWorldToNearbyShipsAndWorld(level, aabb, (shipAabb) -> {
+        VSGameUtilsKt.transformFromWorldToNearbyShips(level, aabb, (shipAabb) -> {
             valkyrienskies$fluidPushAABB = shipAabb; // enable ship context
             this.updateFluidHeightAndDoFluidPushing(shouldUpdate); //recall in the ship context
         });


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [x] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**
This PR fixes a bug introduced in https://github.com/ValkyrienSkies/Valkyrien-Skies-2/pull/1368 which made the VSGameUtils function `transformFromWorldToNearbyShipsAndWorld` not behave as it's KDoc suggested. 

While the KDoc said that it "calls the [cb] with the AABB itself", the water PR removed this functionality. I don't know why the water mixin needed it to not call with the original AABB, but I don't want to go down that rabbit hole. So instead, I added a new util function `transformFromWorldToNearbyShips`, which does not call the `cb` with the original aabb. This new function is used in the MixinEntities, and the old function repaired to its stated functionality.

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [x] Yes (describe)
- [ ] No

Technically they could be breaking changes if addons relied on this function _not_ calling the cb... but since it was a bug not intended functionality (as made clear by the KDoc), that's for the addons to figure out (if any).

---


## Additional Notes
Anything else reviewers might need to know:

Not sure flowing water on ships is still working 100%, even before this PR. It's all a little sus tbh. But a full rewrite is for... later.

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
