### PR TITLE
Reluctantly support Arclight/Ketting

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/fluid_escaping_ship_config/MixinVineBlock.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/fluid_escaping_ship_config/MixinVineBlock.java
@@ -16,7 +16,13 @@ import org.valkyrienskies.mod.common.config.VSGameConfig;
 
 @Mixin(VineBlock.class)
 public class MixinVineBlock {
-    @WrapOperation(method = "randomTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;I)Z"))
+    @WrapOperation(
+        method = "randomTick",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;I)Z"),
+        // Arclight and Ketting both use an @Overwrite on the entire VineBlock behaviour, leading to the @Inject failing.
+        // We make this mixin optional to reluctantly support the @Overwrite and prevent a hard crash.
+        require = 0
+    )
     boolean cancelSpread(ServerLevel level, BlockPos toPos, BlockState blockState, int i, Operation<Boolean> original) {
         if (VSGameConfig.SERVER.getPreventVinesEscapingShip() && level != null) {
             final Ship ship = VSGameUtilsKt.getShipManagingPos((Level) level, toPos);

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create_big_cannons/MixinCannonContraption.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/create_big_cannons/MixinCannonContraption.java
@@ -38,17 +38,18 @@ public class MixinCannonContraption {
     @Unique
     private void vs$handleRecoil(ControlPitchContraption instance, Vec3 vector, AbstractContraptionEntity cannon, float magnitude) {
         LoadedServerShip ship = (LoadedServerShip) VSGameUtilsKt.getLoadedShipManagingPos(cannon.level(), BlockPos.containing(cannon.getAnchorVec()));
-        if (VSGameConfig.SERVER.getCbc().getShellRecoil()) {
-            GameToPhysicsAdapter applier = ValkyrienSkiesMod.getOrCreateGTPA(VSGameUtilsKt.getDimensionId(cannon.level()));
-            if (applier != null) {
-                // Invert (by mult by -1) because magnitude is in direction the cannon shot, not the direction recoil is
-                double recoilForce = magnitude * VSGameConfig.SERVER.getCbc().getShellRecoilMult() * -1;
-                applier.applyInvariantForceToPos(
-                    ship.getId(),
-                    ship.getTransform().getShipToWorldRotation().transform(VectorConversionsMCKt.toJOML(vector).negate().normalize()).mul(recoilForce),
-                    VectorConversionsMCKt.toJOML(cannon.getAnchorVec().add(0.5, 0.5, 0.5)).sub(ship.getTransform().getPositionInShip())
-                );
-            }
-        }
+        // We aren't on a ship, nothing to apply recoil to
+        if (ship == null) return;
+        if (!VSGameConfig.SERVER.getCbc().getShellRecoil()) return;
+
+        GameToPhysicsAdapter applier = ValkyrienSkiesMod.getOrCreateGTPA(VSGameUtilsKt.getDimensionId(cannon.level()));
+        // Invert (by mult by -1) because magnitude is in direction the cannon shot, not the direction recoil is
+        double recoilForce = magnitude * VSGameConfig.SERVER.getCbc().getShellRecoilMult() * -1;
+        applier.applyWorldForceToBodyPos(
+            ship.getId(),
+            ship.getTransform().getShipToWorldRotation().transform(VectorConversionsMCKt.toJOML(vector).negate().normalize()).mul(recoilForce),
+            VectorConversionsMCKt.toJOML(cannon.getAnchorVec().add(0.5, 0.5, 0.5)).sub(ship.getTransform().getPositionInShip())
+        );
+
     }
 }


### PR DESCRIPTION
**Explain what this PR is doing:**

Reluctantly support Arclight/Ketting which use an `@Overwrite` mixin on the entire VineBlock behaviour, causing our `@Inject` to fail. This PR just makes our vine mixin `require=0`.

Fixes https://github.com/ValkyrienSkies/Valkyrien-Skies-2/issues/1684

---

## Modloaders this PR affects:
- Arclight
- Ketting
- Other plugin + mod hybrids?

## Where this PR was tested:
- [ ] In-dev singleplayer
- [ ] In-dev dedicated server
- [x] Out of dev server
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [x] No

---


## Additional Notes

I hate that these plugin loaders carelessly use an `@Overwrite` on so much logic like this, its really anti-compatible when it comes to modern mixin standars. I'm sure whatever they are doing (which looks to be emitting an event) could be done with an `@Inject` or other less-invasive mixin.

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds