### PR TITLE
Fix copycats duping items on assembly

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembler.kt
@@ -10,6 +10,7 @@ import net.minecraft.world.level.LevelReader
 import net.minecraft.world.level.ServerLevelAccessor
 import net.minecraft.world.level.block.Blocks
 import net.minecraft.world.level.block.Block
+import net.minecraft.world.level.block.entity.BlockEntity
 import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor
@@ -226,8 +227,16 @@ object ShipAssembler {
         if (removeOriginal) {
             for (pos in blocks) {
                 level.getBlockEntity(pos)?.let {
-                    Clearable.tryClear(it)
+                    if (it is Clearable) {
+                        Clearable.tryClear(it)
+                    } else {
+                        // Clear all NBT if it doesn't implement IClearable
+                        it.load(CompoundTag())
+                    }
+                    // Without this, copycats still drop their items
+                    level.removeBlockEntity(pos)
                 }
+
                 level.setBlock(pos, Blocks.BARRIER.defaultBlockState(), Block.UPDATE_CLIENTS)
             }
             for (pos in blocks) {


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [x] Compat with another mod

**Explain what this PR is doing:**

Fixes copycats dropping a copy of their item on assembly. This was originally fixed by https://github.com/ValkyrienSkies/Valkyrien-Skies-2/commit/a7a742fa627f3eb13771f2c9a55c19692ad50542 but broke with the new assembly https://github.com/ValkyrienSkies/Valkyrien-Skies-2/pull/1598

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [x] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [x] No

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
