### PR TITLE
Add `getAllConnectedShips` to `GameToPhysicsAdapter`

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/GameToPhysicsAdapter.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/GameToPhysicsAdapter.kt
@@ -318,5 +318,45 @@ class GameToPhysicsAdapter {
         disablePairs.add(shipA to shipB)
     }
 
+    /**
+     * Gets all of the ships connected to [start] with joints.
+     *
+     * Note: This function is mildly expensive. Try to avoid using it too often,
+     * perhaps cache the return value for a few ticks.
+     *
+     * @param start the "root" [ShipId] to start from
+     * @return A list of all connected ships (as [ShipId]s)
+     */
+    fun getAllConnectedShips(start: ShipId): List<ShipId> {
+        val visited = mutableSetOf<ShipId>()
+        val queue = ArrayDeque<ShipId>()
+
+        queue.add(start)
+        visited.add(start)
+
+        while (queue.isNotEmpty()) {
+            val currentShip = queue.removeFirst()
+
+            val jointIds = getJointsFromShip(currentShip) ?: continue
+
+            for (jointId in jointIds) {
+                val joint = getJointById(jointId) ?: continue
+
+                // Get the other ship attached to the joint
+                val otherShip = when (currentShip) {
+                    joint.shipId0 -> joint.shipId1
+                    joint.shipId1 -> joint.shipId0
+                    else -> null
+                }
+
+                if (otherShip != null && visited.add(otherShip)) {
+                    queue.add(otherShip)
+                }
+            }
+        }
+
+        return visited.toList()
+    }
+
     private data class ForceAtPos(val force: Vector3dc, val pos: Vector3dc?)
 }


### PR DESCRIPTION
## What this PR does:
- [ ] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [x] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**

Adds a new method `getAllConnectedShips(start: ShipId): List<ShipId>` to `GameToPhysicsAdapter`

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework

## Additional Notes

I only did light testing of this function as it was kinda tricky to make some sort of debug item around.

The function might be a bit laggy if many ships and joints are present in the world, but I added a notice to the KDoc that states that, so hopefully addons can avoid spamming it out.

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
