### PR TITLE
Fix CBC autocannons

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -82,9 +82,9 @@ dependencies {
     modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:imm_ptl_core:${immptl_version}")
     modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:q_misc_util:${immptl_version}")
     modCompileOnly("com.github.iPortalTeam.ImmersivePortalsMod:build:${immptl_version}")
-    modCompileOnly("com.rbasamoyai:createbigcannons:${createbigcannons_version}+mc.${minecraft_version}-fabric") { transitive = false }
-    modCompileOnly("com.rbasamoyai:createbigcannons:${createbigcannons_version}+mc.${minecraft_version}-forge") { transitive = false }
-    modCompileOnly("com.rbasamoyai:ritchiesprojectilelib:2.1.0+mc.${minecraft_version}-forge")
+    modCompileOnly("com.rbasamoyai:createbigcannons:${createbigcannons_version}+mc.${minecraft_version}-fabric${createbigcannons_build}") { transitive = false }
+    modCompileOnly("com.rbasamoyai:createbigcannons:${createbigcannons_version}+mc.${minecraft_version}-forge${createbigcannons_build}") { transitive = false }
+    modCompileOnly("com.rbasamoyai:ritchiesprojectilelib:${rpl_version}+mc.${minecraft_version}-forge")
 }
 
 architectury {

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_movement_packets/MixinLocalPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_movement_packets/MixinLocalPlayer.java
@@ -79,6 +79,8 @@ public abstract class MixinLocalPlayer extends Entity implements IEntityDragging
         if (arg instanceof ServerboundMoveVehiclePacket vehiclePacket && getRootVehicle() instanceof IEntityDraggingInformationProvider dragProvider) {
             if (dragProvider.getDraggingInformation().isEntityBeingDraggedByAShip()) {
                 if (dragProvider.getDraggingInformation().getLastShipStoodOn() != null) {
+                    if (!dragProvider.vs$shouldDrag()) return;
+
                     ClientShip ship = VSGameUtilsKt.getShipObjectWorld(Minecraft.getInstance().level).getAllShips().getById(
                         dragProvider.getDraggingInformation().getLastShipStoodOn());
                     if (ship != null) {

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/GameToPhysicsAdapter.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/GameToPhysicsAdapter.kt
@@ -318,5 +318,45 @@ class GameToPhysicsAdapter {
         disablePairs.add(shipA to shipB)
     }
 
+    /**
+     * Gets all of the ships connected to [start] with joints.
+     *
+     * Note: This function is mildly expensive. Try to avoid using it too often,
+     * perhaps cache the return value for a few ticks.
+     *
+     * @param start the "root" [ShipId] to start from
+     * @return A list of all connected ships (as [ShipId]s)
+     */
+    fun getAllConnectedShips(start: ShipId): List<ShipId> {
+        val visited = mutableSetOf<ShipId>()
+        val queue = ArrayDeque<ShipId>()
+
+        queue.add(start)
+        visited.add(start)
+
+        while (queue.isNotEmpty()) {
+            val currentShip = queue.removeFirst()
+
+            val jointIds = getJointsFromShip(currentShip) ?: continue
+
+            for (jointId in jointIds) {
+                val joint = getJointById(jointId) ?: continue
+
+                // Get the other ship attached to the joint
+                val otherShip = when (currentShip) {
+                    joint.shipId0 -> joint.shipId1
+                    joint.shipId1 -> joint.shipId0
+                    else -> null
+                }
+
+                if (otherShip != null && visited.add(otherShip)) {
+                    queue.add(otherShip)
+                }
+            }
+        }
+
+        return visited.toList()
+    }
+
     private data class ForceAtPos(val force: Vector3dc, val pos: Vector3dc?)
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -80,6 +80,11 @@ dependencies {
     // Twilight Forest
     modImplementation("teamtwilight:twilightforest:${twilightforest_version}:universal")
 
+    // CBC
+    //modRuntimeOnly("com.rbasamoyai:createbigcannons:${createbigcannons_version}+mc.${minecraft_version}-forge-build.250") { transitive = false }
+    //modRuntimeOnly("com.rbasamoyai:ritchiesprojectilelib:${rpl_version}+mc.${minecraft_version}-forge")
+
+
     // Create compat
     modImplementation("com.simibubi.create:create-${minecraft_version}:${create_version}:slim") { transitive = false }
     modImplementation("net.createmod.ponder:Ponder-Forge-${minecraft_version}:${ponder_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,13 @@ cc_tweaked_version = 1.115.1
 create_fabric_version=6.0.7.0+build.1728-mc1.20.1
 
 # https://modrinth.com/mod/create-big-cannons/versions
-createbigcannons_version= 5.9.1
+createbigcannons_version= 5.11.0-dev
+# Only used for in-dev versions, otherwise leave blank
+createbigcannons_build=-build.250
+rpl_version=2.1.1
+
+
+
 create_utilities_version=0.2.1+1.20.1
 energy_version=2.3.0
 


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [x] Compat with another mod

**Explain what this PR is doing:**

Fix CBC autocannons disappearing on the player riding them on a VS ship

---

## Modloaders this PR affects:
- [x] Forge
- [ ] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Additional Notes

2 hours of debugging for a one line fix... fml.

This bug was 100% a VS skill issue, but was only present with CBC because CBC autocannons are the only shipyard entity that uses a controlling player.

Normal Create contraptions are shipyard entities, but don't use controlling players
Minecarts are shipyard entities, but don't use controlling players
Horses and boats and stuff use controlling players, but aren't shipyard entities.

Only the CBC autocannon meets both these conditions.

As for why this didn't happen before? no clue, the git history is clobbered. It broke on the great 2.4-ening somewhere.

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
