### PR TITLE
Fix compat with real camera

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntityRenderDispatcher.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinEntityRenderDispatcher.java
@@ -37,12 +37,16 @@ public class MixinEntityRenderDispatcher {
     @Inject(method = "distanceToSqr(Lnet/minecraft/world/entity/Entity;)D", at = @At("HEAD"), cancellable = true)
     private void preDistanceToSqr(final Entity entity, final CallbackInfoReturnable<Double> cir) {
         final Vec3 pos = entity.position();
+        // entity seems to be null sometimes when the "real camera" mod is used
+        if (entity == null) return;
         cir.setReturnValue(VSGameUtilsKt.squaredDistanceToInclShips(entity, pos.x, pos.y, pos.z));
     }
 
     @Inject(method = "distanceToSqr(DDD)D", at = @At("HEAD"), cancellable = true)
     private void preDistanceToSqr(final double x, final double y, final double z,
         final CallbackInfoReturnable<Double> cir) {
+        // entity seems to be null sometimes when the "real camera" mod is used
+        if (camera.getEntity() == null) return;
         cir.setReturnValue(VSGameUtilsKt.squaredDistanceToInclShips(camera.getEntity(), x, y, z));
     }
 


### PR DESCRIPTION
## What this PR does:
- [ ] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [x] Compat with another mod

**Explain what this PR is doing:**

Makes the game not crash on rendering an entity with https://www.curseforge.com/minecraft/mc-mods/real-camera installed.

No idea what real camera is doing, but I just added two null checks to our entity rendering mixins and it seems to be fixed.

More info https://discord.com/channels/244934352092397568/1473159289253269564/1473478775718023322

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
