### PR TITLE
Update forge and CC deps

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -34,7 +34,7 @@
   "breaks": {
     "sodium": "<0.5.8",
     "create": "<6.0.7",
-    "computercraft": "<1.115.0"
+    "computercraft": "<1.115.1"
   },
   "custom": {
     "lithium:options": {

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -16,7 +16,7 @@ logoFile = "icon.png"
 [[dependencies.valkyrienskies]]
 modId = "forge"
 mandatory = true
-versionRange = "[40.2.4,)"
+versionRange = "[47.2.0,),[47.1.21,47.1.47]"
 ordering = "NONE"
 side = "BOTH"
 
@@ -37,7 +37,7 @@ side = "BOTH"
 [[dependencies.valkyrienskies]]
 modId = "computercraft"
 mandatory = false
-versionRange = "[1.115.0,)"
+versionRange = "[1.115.1,)"
 ordering = "NONE"
 side = "BOTH"
 


### PR DESCRIPTION
## What this PR does:
- [ ] Bug fix 
- [ ] Feature
- [x] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**

_this PR also bumps our CC dep from 1.115.0 to 1.115.1 because 1.115.1 is what works on create 6, but mainly the PR does the following:_

This changes our forge dependency range to `[47.2.0,),[47.1.21,47.1.47]`. This very specific version range means that if people try to install neoforge, which will be version `47.1.106`, it will give them this error:

<img width="846" height="475" alt="image" src="https://github.com/user-attachments/assets/a6f9f4f3-fe4b-4851-89c7-65a54240412b" />

Now, while technically they can go and install neoforge between `47.1.21` and `47.1.47` (and experience a crash), I have made sure that the option of `47.2` is presented to them _first_. This means that the `47.2` option is:
1. The first option they see
2. The simplest looking option they see (the other option is a scary long version range)
3. Only doable on **normal forge**, aka you cannot install Neoforge 47.2

My hope with this is that users will:
- Install neoforge (47.1.106)
- See the error
- See 47.2
- Go looking for 47.2
- Find its only available on normal forge
- Install normal forge

Without sacrificing compatibilty with any versions of forge (aka I could've just done a hard `47.2+` dep, but then we would lose our compat with forge `47.1.21+`)

---

## Modloaders this PR affects:
- [x] Forge
- [ ] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [x] Out of dev singleplayer
- [ ] GameTest framework


## Additional Notes

For some strange reason, if the user installs forge 47.1.19, the game will crash from a mixin despite the version range not being met. However, it does still log 
```
[21:05:41] [main/ERROR] [ne.mi.fm.lo.ModSorter/LOADING]: Missing or unsupported mandatory dependencies:
	Mod ID: 'forge', Requested by: 'valkyrienskies', Expected range: '[47.2.0,),[47.1.21,47.1.47]', Actual version: '47.1.19'
```
Which can hopefully be spotted in their debugging of the crash.

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
