### PR TITLE
Add /vs dry command

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
@@ -25,6 +25,7 @@ import org.joml.Vector3dc
 import org.joml.Vector3ic
 import org.joml.primitives.AABBd
 import org.joml.primitives.AABBdc
+import org.joml.primitives.AABBic
 import org.valkyrienskies.core.api.ships.ClientShip
 import org.valkyrienskies.core.api.ships.LoadedServerShip
 import org.valkyrienskies.core.api.ships.LoadedShip
@@ -570,4 +571,19 @@ fun Entity?.applyShipVelocity(ship: Ship?) {
 @Suppress("unused")
 fun BlockState?.inAssemblyBlacklist(): Boolean {
     return this?.`is`(ASSEMBLE_BLACKLIST) ?: false
+}
+
+/**
+ * Calls the consumer [f] for every (integer) position in the AABBic.
+ *
+ * This function is expensive, don't call it too often.
+ */
+fun AABBic.forEach(f: (Int, Int, Int) -> Unit) {
+    for (x in this.minX()..this.maxX()) {
+        for (y in this.minY()..this.maxY()) {
+            for (z in this.minZ()..this.maxZ()) {
+                f.invoke(x, y, z)
+            }
+        }
+    }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembler.kt
@@ -27,6 +27,7 @@ import org.valkyrienskies.core.api.util.GameTickOnly
 import org.valkyrienskies.core.internal.ships.VsiServerShip
 import org.valkyrienskies.mod.common.dimensionId
 import org.valkyrienskies.mod.common.executeIf
+import org.valkyrienskies.mod.common.forEach
 import org.valkyrienskies.mod.common.getLoadedShipManagingPos
 import org.valkyrienskies.mod.common.getShipManagingPos
 import org.valkyrienskies.mod.common.inAssemblyBlacklist
@@ -346,6 +347,7 @@ object ShipAssembler {
         return assembleToShip(level as ServerLevel, blocks.toSet(), scale)
     }
 
+    @Suppress("unused")
     fun isValidShipBlock(state: BlockState?) : Boolean {
         if (state == null) return false
         if (state.isAir) return false
@@ -361,17 +363,12 @@ object ShipAssembler {
         }
         if (deleteBlocks) {
             val aabb = ship.shipAABB ?: return 0
-            // There has to be a better way to do this...
-            for (x in aabb.minX()..aabb.maxX()) {
-                for (y in aabb.minY()..aabb.maxY()) {
-                    for (z in aabb.minZ()..aabb.maxZ()) {
-                        // Not sure if 2 is what we want, but its what /fill uses
-                        if (dropBlocks)
-                            level.destroyBlock(BlockPos(x, y, z), true)
-                        else
-                            level.setBlock(BlockPos(x, y, z), Blocks.AIR.defaultBlockState(), 2)
-                    }
-                }
+            aabb.forEach { x, y, z ->
+                if (dropBlocks)
+                    level.destroyBlock(BlockPos(x, y, z), true)
+                else
+                    // Not sure if 2 is what we want, but it's what /fill uses
+                    level.setBlock(BlockPos(x, y, z), Blocks.AIR.defaultBlockState(), 2)
             }
         }
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
@@ -6,15 +6,19 @@ import com.mojang.brigadier.arguments.DoubleArgumentType
 import com.mojang.brigadier.arguments.IntegerArgumentType
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.context.CommandContext
+import com.sun.org.apache.xpath.internal.operations.Bool
 import net.minecraft.commands.CommandRuntimeException
 import net.minecraft.commands.CommandSourceStack
 import net.minecraft.commands.Commands.argument
 import net.minecraft.commands.Commands.literal
 import net.minecraft.commands.SharedSuggestionProvider
 import net.minecraft.commands.arguments.coordinates.Vec3Argument
+import net.minecraft.core.BlockPos
 import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.Component.translatable
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.level.block.Blocks
+import net.minecraft.world.level.material.Fluids
 import net.minecraft.world.phys.BlockHitResult
 import net.minecraftforge.common.ForgeConfigSpec
 import org.joml.Quaterniond
@@ -23,6 +27,7 @@ import org.joml.Vector3d
 import org.joml.Vector3dc
 import org.valkyrienskies.core.api.ships.LoadedServerShip
 import org.valkyrienskies.core.api.ships.ServerShip
+import org.valkyrienskies.core.api.ships.Ship
 import org.valkyrienskies.core.api.world.ServerShipWorld
 import org.valkyrienskies.core.api.world.ShipWorld
 import org.valkyrienskies.core.api.world.properties.DimensionId
@@ -31,9 +36,11 @@ import org.valkyrienskies.core.impl.config.VSCoreConfig
 import org.valkyrienskies.core.internal.ShipTeleportData
 import org.valkyrienskies.mod.common.BlockStateInfo
 import org.valkyrienskies.mod.common.assembly.ShipAssembler
+import org.valkyrienskies.mod.common.command.ShipArgument
 import org.valkyrienskies.mod.common.config.VSConfigUpdater
 import org.valkyrienskies.mod.common.config.VSGameConfig
 import org.valkyrienskies.mod.common.dimensionId
+import org.valkyrienskies.mod.common.forEach
 import org.valkyrienskies.mod.common.getShipManagingPos
 import org.valkyrienskies.mod.common.shipObjectWorld
 import org.valkyrienskies.mod.common.util.SplittingDisablerAttachment
@@ -67,6 +74,8 @@ object VSCommands {
     private const val AIR_VALUES_PRESSURE_MESSAGE = "command.valkyrienskies.air_values.pressure"
     private const val GET_GRAVITY_MESSAGE = "command.valkyrienskies.get_gravity"
     private const val SET_SPLITTING_MESSAGE = "command.valkyrienskies.set_splitting"
+    private const val DRY_SHIP_NO_BLOCKS_MESSAGE = "command.valkyrienskies.dry.no_blocks"
+    private const val DRY_SHIP_SUCCESS_MESSAGE = "command.valkyrienskies.dry.success"
 
     private const val GET_SHIP_SUCCESS_MESSAGE = "command.valkyrienskies.get_ship.success"
     private const val GET_SHIP_FAIL_MESSAGE = "command.valkyrienskies.get_ship.fail"
@@ -119,10 +128,21 @@ object VSCommands {
                 .requires{ it.hasPermission(VSGameConfig.SERVER.Commands.deleteShipCommandPerms)}
                     .then(argument("ships", ShipArgument.ships())
                         .executes {
-                            deleteShip(it)
+                            deleteShip(it, ShipArgument.getShips(it, "ships").toList() as List<ServerShip>)
                         }.then(argument("deleteBlocks", BoolArgumentType.bool())
                             .executes {
-                                deleteShip(it, BoolArgumentType.getBool(it, "deleteBlocks"))
+                                deleteShip(it, ShipArgument.getShips(it, "ships").toList() as List<ServerShip>, BoolArgumentType.getBool(it, "deleteBlocks"))
+                            }
+                        )
+                    )
+                ).then(literal("dry")
+                    .requires{ it.hasPermission(VSGameConfig.SERVER.Commands.dryShipCommandPerms)}
+                    .then(argument("ship", ShipArgument.ships())
+                        .executes {
+                            dryShip(it, ShipArgument.getShip(it, "ship"))
+                        }.then(argument("allfluids", BoolArgumentType.bool())
+                            .executes {
+                                dryShip(it, ShipArgument.getShip(it, "ship"), BoolArgumentType.getBool(it, "allfluids"))
                             }
                         )
                     )
@@ -656,9 +676,36 @@ object VSCommands {
         }*/
     }
 
-    fun deleteShip(context: CommandContext<CommandSourceStack>, deleteBlocks: Boolean = false): Int {
-        val r = ShipArgument.getShips(context, "ships").toList() as List<ServerShip>
+    fun dryShip(context: CommandContext<CommandSourceStack>, ship: Ship, allFluids: Boolean = false): Int {
+        val level = context.source.level
 
+        // Shouldn't ever happen, but just in case
+        if (ship.shipAABB == null) {
+            context.source.sendFailure(Component.translatable(DRY_SHIP_NO_BLOCKS_MESSAGE))
+            return 0
+        }
+
+        var dryCount = 0
+
+        ship.shipAABB!!.forEach { x, y, z ->
+            var pos = BlockPos(x, y, z)
+            val state = level.getFluidState(pos)
+            // (isWater or isFlowingWater) or (allFluids and isFluid)
+            if ((state.`is`(Fluids.WATER) || state.`is`(Fluids.FLOWING_WATER)) ||(allFluids && !state.`is`(Fluids.EMPTY))) {
+                level.setBlock(pos, Blocks.AIR.defaultBlockState(), 2)
+                dryCount += 1
+            }
+        }
+
+        context.source.sendSuccess({
+                Component.translatable(DRY_SHIP_SUCCESS_MESSAGE, dryCount)
+            }, true
+        )
+
+        return 1
+    }
+
+    fun deleteShip(context: CommandContext<CommandSourceStack>, r: List<ServerShip>, deleteBlocks: Boolean = false): Int {
         val deletedShips = r.map {
             ship -> ShipAssembler.deleteShip(context.source.level, ship, deleteBlocks, dropBlocks = false)
         }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
@@ -18,6 +18,9 @@ import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.Component.translatable
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.level.block.Blocks
+import net.minecraft.world.level.block.LiquidBlockContainer
+import net.minecraft.world.level.block.SimpleWaterloggedBlock
+import net.minecraft.world.level.block.state.properties.BlockStateProperties
 import net.minecraft.world.level.material.Fluids
 import net.minecraft.world.phys.BlockHitResult
 import net.minecraftforge.common.ForgeConfigSpec
@@ -140,11 +143,7 @@ object VSCommands {
                     .then(argument("ship", ShipArgument.ships())
                         .executes {
                             dryShip(it, ShipArgument.getShip(it, "ship"))
-                        }.then(argument("allfluids", BoolArgumentType.bool())
-                            .executes {
-                                dryShip(it, ShipArgument.getShip(it, "ship"), BoolArgumentType.getBool(it, "allfluids"))
-                            }
-                        )
+                        }
                     )
                 ).then(literal("set-splitting")
                     .requires{ it.hasPermission(VSGameConfig.SERVER.Commands.deleteShipCommandPerms)}
@@ -676,7 +675,7 @@ object VSCommands {
         }*/
     }
 
-    fun dryShip(context: CommandContext<CommandSourceStack>, ship: Ship, allFluids: Boolean = false): Int {
+    fun dryShip(context: CommandContext<CommandSourceStack>, ship: Ship): Int {
         val level = context.source.level
 
         // Shouldn't ever happen, but just in case
@@ -688,12 +687,24 @@ object VSCommands {
         var dryCount = 0
 
         ship.shipAABB!!.forEach { x, y, z ->
-            var pos = BlockPos(x, y, z)
-            val state = level.getFluidState(pos)
-            // (isWater or isFlowingWater) or (allFluids and isFluid)
-            if ((state.`is`(Fluids.WATER) || state.`is`(Fluids.FLOWING_WATER)) ||(allFluids && !state.`is`(Fluids.EMPTY))) {
-                level.setBlock(pos, Blocks.AIR.defaultBlockState(), 2)
+            val pos = BlockPos(x, y, z)
+            val state = level.getBlockState(pos)
+
+            if (state.liquid()) {
+                level.setBlock(pos, Blocks.AIR.defaultBlockState(), 2);
                 dryCount += 1
+            } else {
+                if (state.block is LiquidBlockContainer && state.block !is SimpleWaterloggedBlock) {
+                    // Hack specifically for seagrass and nothing else
+                    level.destroyBlock(pos, true);
+                    level.setBlock(pos, Blocks.AIR.defaultBlockState(), 2);
+                    dryCount += 1
+                } else {
+                    if (state.hasProperty(BlockStateProperties.WATERLOGGED)) {
+                        level.setBlock(pos, state.setValue(BlockStateProperties.WATERLOGGED, false), 2);
+                        dryCount += 1
+                    }
+                }
             }
         }
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
@@ -6,7 +6,6 @@ import com.mojang.brigadier.arguments.DoubleArgumentType
 import com.mojang.brigadier.arguments.IntegerArgumentType
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.context.CommandContext
-import com.sun.org.apache.xpath.internal.operations.Bool
 import net.minecraft.commands.CommandRuntimeException
 import net.minecraft.commands.CommandSourceStack
 import net.minecraft.commands.Commands.argument
@@ -21,7 +20,6 @@ import net.minecraft.world.level.block.Blocks
 import net.minecraft.world.level.block.LiquidBlockContainer
 import net.minecraft.world.level.block.SimpleWaterloggedBlock
 import net.minecraft.world.level.block.state.properties.BlockStateProperties
-import net.minecraft.world.level.material.Fluids
 import net.minecraft.world.phys.BlockHitResult
 import net.minecraftforge.common.ForgeConfigSpec
 import org.joml.Quaterniond
@@ -39,7 +37,8 @@ import org.valkyrienskies.core.impl.config.VSCoreConfig
 import org.valkyrienskies.core.internal.ShipTeleportData
 import org.valkyrienskies.mod.common.BlockStateInfo
 import org.valkyrienskies.mod.common.assembly.ShipAssembler
-import org.valkyrienskies.mod.common.command.ShipArgument
+import org.valkyrienskies.mod.common.command.arguments.RelativeVector3Argument
+import org.valkyrienskies.mod.common.command.arguments.ShipArgument
 import org.valkyrienskies.mod.common.config.VSConfigUpdater
 import org.valkyrienskies.mod.common.config.VSGameConfig
 import org.valkyrienskies.mod.common.dimensionId
@@ -145,7 +144,7 @@ object VSCommands {
                             dryShip(it, ShipArgument.getShip(it, "ship"))
                         }
                     )
-                ).then(literal("set-splitting")
+                ).then(literal("splitting")
                     .requires{ it.hasPermission(VSGameConfig.SERVER.Commands.deleteShipCommandPerms)}
                     .then(argument("ships", ShipArgument.ships())
                         .then(argument("enable", BoolArgumentType.bool())

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -316,6 +316,11 @@ object VSGameConfig {
                 description = "The permission level required to use the /vs backend command. Must be 0 <= x <= 4"
             )
             var changeBackendCommandPerms = 4
+
+            @ConfigEntry(
+                description = "The permission level required to use the /vs dry command. Must be 0 <= x <= 4"
+            )
+            var dryShipCommandPerms = 2
         }
     }
 

--- a/common/src/main/resources/assets/valkyrienskies/lang/en_us.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/en_us.json
@@ -54,6 +54,8 @@
   "command.valkyrienskies.air_values.pressure": "At y: %s, pressure is %s",
   "command.valkyrienskies.get_gravity": "The gravity in %s is %s",
   "command.valkyrienskies.set_splitting": "Set splitting to %s on %s ships",
+  "command.valkyrienskies.dry.no_blocks": "Ship has no blocks!",
+  "command.valkyrienskies.dry.success": "Successfully dried %s blocks",
 
   "misc.valkyrienskies.create.deployer_working_mode": "Ship Behaviour",
   "misc.valkyrienskies.create.deployer_working_mode.original": "Place on current ship",


### PR DESCRIPTION
## What this PR does:
- [ ] Bug fix 
- [x] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**

This PR adds a new command, `/vs dry <ship>`. This command clears all fluid out of the ships AABB (replacing with air), as well as un-waterlogging any waterlogged blocks.

This will be useful once valkyrien air is finished for admins to un-flood their ships quickly.

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Additional Notes

I added a new util function to `VSGameUtilsKt`, which iterates over an `AABBic`. Up until now, we only ever iterated over an `AABBic` in one place (ship assembly), but now that we need it in a second place (for this command) I thought I should make it a util function.

I also refactored the `/vs delete` command slightly to not have the ship argument calculated in the function, this just makes the code a bit clearer and less prone to breaking if someone changes the argument id.

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
