### PR TITLE
It was connectivity 2, electric boogaloo

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembler.kt
@@ -24,7 +24,9 @@ import org.valkyrienskies.core.api.ships.LoadedServerShip
 import org.valkyrienskies.core.api.ships.ServerShip
 import org.valkyrienskies.core.api.ships.properties.ShipId
 import org.valkyrienskies.core.api.util.GameTickOnly
+import org.valkyrienskies.core.impl.config.VSCoreConfig
 import org.valkyrienskies.core.internal.ships.VsiServerShip
+import org.valkyrienskies.mod.common.config.VSGameConfig
 import org.valkyrienskies.mod.common.dimensionId
 import org.valkyrienskies.mod.common.executeIf
 import org.valkyrienskies.mod.common.getLoadedShipManagingPos
@@ -307,23 +309,26 @@ object ShipAssembler {
             }
             VSAssemblyEvents.onPasteAfterBlocksAreLoaded.emit(VSAssemblyEvents.OnPasteAfterBlocksAreLoaded(level, fromShip, toShip, Pair(fromCenter, centerOfShip), eventData))
             //force update connectivity because this new assemblyslop doesn't update it :(
-            for (pos in chunkPoses) {
-                val worldChunk = level.getChunk(pos.x, pos.z) ?: continue
-                val chunkSections = worldChunk.sections ?: continue
-                for (sectionY in 0 until worldChunk.sectionsCount) {
-                    val sectionPos = Vector3i(pos.x, worldChunk.getSectionYFromSectionIndex(sectionY), pos.z)
-                    val section = chunkSections[sectionY] ?: continue
-                    if (section.hasOnlyAir()) continue
-                    val update = section.toDenseVoxelUpdate(sectionPos)
-                    level.shipObjectWorld.forceUpdateConnectivityChunk(
-                        level.dimensionId,
-                        sectionPos.x,
-                        sectionPos.y,
-                        sectionPos.z,
-                        update
-                    )
+            if (VSCoreConfig.SERVER.sp.enableConnectivity) {
+                for (pos in chunkPoses) {
+                    val worldChunk = level.getChunk(pos.x, pos.z) ?: continue
+                    val chunkSections = worldChunk.sections ?: continue
+                    for (sectionY in 0 until worldChunk.sectionsCount) {
+                        val sectionPos = Vector3i(pos.x, worldChunk.getSectionYFromSectionIndex(sectionY), pos.z)
+                        val section = chunkSections[sectionY] ?: continue
+                        if (section.hasOnlyAir()) continue
+                        val update = section.toDenseVoxelUpdate(sectionPos)
+                        level.shipObjectWorld.forceUpdateConnectivityChunk(
+                            level.dimensionId,
+                            sectionPos.x,
+                            sectionPos.y,
+                            sectionPos.z,
+                            update
+                        )
+                    }
                 }
             }
+
             if (fromShip is LoadedServerShip) {
                 val splittingDisabler = fromShip.getAttachment(SplittingDisablerAttachment::class.java)
                 if (wasSplittingEnabled) {


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**

Makes the ship assembler class not send a big ol laggy connectivity update if connectivity is disabled :facepalm: 

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Additional Notes

Someone got a watchdog crash from this... and its probably a big reason why ship assembly in 2.4 was still laggier than 2.3

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
