### PR TITLE
Rename loggers

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/assembly/ShipAssembler.kt
@@ -47,7 +47,7 @@ import org.valkyrienskies.mod.util.logger
 
 object ShipAssembler {
 
-    val ASSEMBLY_LOGGER = logger("Sandwich Factory").logger
+    val ASSEMBLY_LOGGER = logger("(Valkyrien Skies) Sandwich Factory").logger
 
     class SingleItemMap<K, V>(val mkey: K, val mvalue: V, val default: V, val defaultFn: ((K) -> V)? = null): Map<K, V> {
         override val size: Int = 1

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/DimensionParametersResolver.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/DimensionParametersResolver.kt
@@ -14,7 +14,7 @@ import org.valkyrienskies.mod.util.logger
 
 object DimensionParametersResolver: SimpleJsonResourceReloadListener(Gson(), "vs_dimension_parameters") {
 
-    val logger = logger("Bloon Factory").logger
+    val logger = logger("(Valkyrien Skies) Bloon Factory").logger
     var dimensionMap: Map<String, Parameters> = hashMapOf()
 
     override fun apply(

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/SplitHandler.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/SplitHandler.kt
@@ -161,7 +161,7 @@ class SplitHandler(private val doEdges: Boolean, private val doCorners: Boolean)
 
     companion object {
 
-        val SPLITLOGGER = logger("kitkat factory")
+        val SPLITLOGGER = logger("(Valkyrien Skies) kitkat factory")
 
         val offsetsToCheck: ArrayList<Vec3i> = arrayListOf(
             Vec3i(1, 0, 0),

--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/flywheel/ShipEffect.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/flywheel/ShipEffect.kt
@@ -62,7 +62,7 @@ class ShipEffect(val ship: ClientShip, val level: ClientLevel) : Effect {
 
     companion object {
         private val map = WeakHashMap<ClientShip, ShipEffect>()
-        private val logger by logger("ShipEffect-Flywheel")
+        private val logger by logger("(Valkyrien Skies) ShipEffect-Flywheel")
 
         fun getShipEffect(ship: ClientShip): ShipEffect = map.getOrPut(ship) {
             ShipEffect(ship, Minecraft.getInstance().level!!).apply {


### PR DESCRIPTION
## What this PR does:
- [ ] Bug fix 
- [ ] Feature
- [x] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**

Related to https://github.com/ValkyrienSkies/Kelvin/issues/11

Renames all our unique loggers to have (Valkyrien Skies) as a prefix, so they can be identified by normal players in logs easier.

Related PRs:
- https://github.com/ValkyrienSkies/Kelvin/pull/12
- https://github.com/ValkyrienSkies/vs-core/pull/102

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds