### PR TITLE
Fix: Y velocity accumulates during horizontal collision

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
@@ -25,7 +25,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.util.EntityDraggingInformation;
@@ -113,28 +113,23 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
     }
 
     /**
-     * This mixin replaces the following code in Entity.move().
-     *
-     * <p>if (movement.x != vec3d.x) { this.setVelocity(0.0D, vec3d2.y, vec3d2.z); } </p>
-     *
-     * <p>if (movement.z != vec3d.z) { this.setVelocity(vec3d2.x, vec3d2.y, 0.0D); } </p>
-     *
-     * <p>This code makes accurate collision with non axis-aligned surfaces impossible, so this mixin replaces it. </p>
+     * Replaces vanilla's axis-zeroing collision response with projection-based velocity removal,
+     * enabling accurate collision with non-axis-aligned ship surfaces.
      */
-    @Inject(method = "move", at = @At(
+    @WrapOperation(method = "move", at = @At(
         value = "INVOKE",
-        target = "Lnet/minecraft/world/entity/Entity;setDeltaMovement(DDD)V"),
-        locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true
-    )
-    private void redirectSetVelocity(final MoverType moverType, final Vec3 movement, final CallbackInfo callbackInfo,
-        final Vec3 movementAdjustedForCollisions) {
+        target = "Lnet/minecraft/world/entity/Entity;setDeltaMovement(DDD)V"))
+    private void redirectSetVelocity(final Entity instance, final double x, final double y, final double z,
+        final Operation<Void> original,
+        @Local(argsOnly = true) final Vec3 movement,
+        @Local(ordinal = 1) final Vec3 movementAdjustedForCollisions) {
 
         // Compute the collision response horizontal
         final Vector3dc collisionResponseHorizontal =
             new Vector3d(movementAdjustedForCollisions.x - movement.x, 0.0,
                 movementAdjustedForCollisions.z - movement.z);
 
-        // Remove the component of [movementAdjustedForCollisions] that is parallel to [collisionResponseHorizontal]
+        // Remove the component of velocity that is parallel to the collision normal
         if (collisionResponseHorizontal.lengthSquared() > 1e-6) {
             final Vec3 deltaMovement = getDeltaMovement();
 
@@ -151,10 +146,6 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
                     - collisionResponseHorizontalNormal.z() * parallelHorizontalVelocityComponent
             );
         }
-        // The rest of the move function (including tryCheckInsideBlocks) is skipped, so calling it here
-        tryCheckInsideBlocks();
-        // Cancel the original invocation of Entity.setVelocity(DDD)V to remove vanilla behavior
-        callbackInfo.cancel();
     }
 
     // endregion
@@ -294,9 +285,6 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
 
     @Shadow
     public abstract void setDeltaMovement(double x, double y, double z);
-
-    @Shadow
-    protected abstract void tryCheckInsideBlocks();
 
     @Shadow
     protected abstract Vec3 collide(Vec3 vec3d);


### PR DESCRIPTION
`redirectSetVelocity` in MixinEntity uses `@Inject + callbackInfo.cancel()` to replace vanilla's axis-zeroing with projection-based velocity removal. But `cancel()` on an `@Inject` at an INVOKE target cancels the *entire remaining method*, not just the targeted call. This skips everything after `setDeltaMovement(DDD)V` in `Entity.move()`, including `block.onEntityLand()` which resets Y velocity on ground contact.

Without `onEntityLand`, Y velocity accumulates from gravity every tick while grounded (~-0.08/tick). After 100 ticks against a wall: vel.y ≈ -3.4. On a bed, `BedBlock.onEntityLand` bounces the player (`vel.y = -vel.y * 0.66`), converting this into a ~20 block upward launch. No sneaking required - just walking into a wall while standing on a bed is enough.

Found via https://www.reddit.com/r/feedthebeast/comments/1rlk2dm/weird_launch_bug_that_only_happens_in_my_fabric/

This affects any entity with horizontal collision (wall contact), not just beds - beds just make it visible because of the bounce. On regular blocks the accumulated velocity is silently zeroed when horizontal collision stops. Other skipped behavior includes `block.onSteppedOn()`, the velocity multiplier (soul sand/honey), and fire checks.

The bug was technically introduced in [541f58d5](https://github.com/ValkyrienSkies/Valkyrien-Skies-2/commit/541f58d5925a5a520a9d1d879265e9cf3d48eae6) (2021-03-23) when the mixin changed from `@Redirect` to `@Inject + cancel`, but was masked because the Y velocity was set from `movementAdjustedForCollisions.y` (which is 0 during ground collision). It became visible after [fdb33aa0](https://github.com/ValkyrienSkies/Valkyrien-Skies-2/commit/fdb33aa0a31f1c9692465efaf834b2a700b62279) ("THE GREAT UNFUCKENING PART 1", 2025-06-22) which correctly changed to using `getDeltaMovement().y` for the projection - but this meant the accumulated Y velocity was no longer being overwritten.

The fix replaces `@Inject + cancel` with `@WrapOperation`, which wraps only the `setDeltaMovement(DDD)V` call and lets all subsequent vanilla code run normally. The projection math is unchanged. The mixin is in `common/` so this affects both Fabric and Forge.

This was partially caught before in #955 where @MoePus noticed `tryCheckInsideBlocks` was being skipped. @ewoudje commented:

> Yep nice catch, Im kinda worried if we the mixin also skips other things such as checking for fire, or popping the profiler.

This turned out to be right - `onEntityLand` and several other calls were also missing.

Tested in-dev singleplayer on both Fabric 1.20.1 and Forge 1.20.1. Positive testing confirms the issue is fixed on both loaders. Negative testing (checking for regressions) was limited to basic gameplay - more thorough testing of player collision scenarios would be appreciated.

Related commits:
- [b1aec085](https://github.com/ValkyrienSkies/Valkyrien-Skies-2/commit/b1aec085f04e981be74d61cdd86c8fe48445907d) (2021-03-21) - replaced `@Overwrite` of `move()` with `@Redirect` (which correctly preserved `onEntityLand`)
- [541f58d5](https://github.com/ValkyrienSkies/Valkyrien-Skies-2/commit/541f58d5925a5a520a9d1d879265e9cf3d48eae6) (2021-03-23) - changed to `@Inject + cancel`, accidentally skipping `onEntityLand`
- [fdb33aa0](https://github.com/ValkyrienSkies/Valkyrien-Skies-2/commit/fdb33aa0a31f1c9692465efaf834b2a700b62279) (2025-06-22) - changed Y velocity source from `movementAdjustedForCollisions` to `getDeltaMovement()`, unmasking the bug
- [be136874](https://github.com/ValkyrienSkies/Valkyrien-Skies-2/commit/be13687497e80201fb1d4c13198a3f005eddb3ee) / #955 (2024-09-23) - restored `tryCheckInsideBlocks` but not `onEntityLand`

### Test demo

Before fix (velocity accumulates, bed bounce launches player ~20 blocks):

https://cb.2d.rocks/files/github-assets/vs-fix-bed-launch-unfixed.mp4

After fix (velocity stays stable, player stays on bed):

https://cb.2d.rocks/files/github-assets/vs-fix-bed-launch-fixed.mp4

Fixes #1681