### PR TITLE
Remove "Collision box is too big" log

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/get_entities/MixinLevel.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/get_entities/MixinLevel.java
@@ -56,9 +56,9 @@ public class MixinLevel {
         final Predicate<? super T> predicate, final CallbackInfoReturnable<List<T>> cir) {
 
         if (BugFixUtil.INSTANCE.isCollisionBoxTooBig(area)) {
-            LIMITER.maybeRun(() ->
+            /*LIMITER.maybeRun(() ->
                 LOGGER.error(new Exception(
-                    "Collision box is too big! " + area + " returning empty list! this might break things")));
+                    "Collision box is too big! " + area + " returning empty list! this might break things")));*/
             cir.setReturnValue(Collections.emptyList());
             cir.cancel();
         }
@@ -73,9 +73,9 @@ public class MixinLevel {
         final Predicate<? super Entity> predicate, final CallbackInfoReturnable<List<Entity>> cir) {
 
         if (BugFixUtil.INSTANCE.isCollisionBoxTooBig(area)) {
-            LIMITER.maybeRun(() ->
+            /*LIMITER.maybeRun(() ->
                 LOGGER.error(new Exception(
-                    "Collision box is too big! " + area + " returning empty list! this might break things")));
+                    "Collision box is too big! " + area + " returning empty list! this might break things")));*/
             cir.setReturnValue(Collections.emptyList());
             cir.cancel();
         }


### PR DESCRIPTION
## What this PR does:
idk what category this is ngl

**Explain what this PR is doing:**

Removes the "Collision box is too big! Returning empty list, this may break things" log. This log triggers way too much with some other mods installed, and causes people to think there is an issue when in reality there isn't. It has never been helpful in debugging an issue anyway

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
