### PR TITLE
Add liquid overlap to GTPA

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/GameToPhysicsAdapter.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/GameToPhysicsAdapter.kt
@@ -37,6 +37,7 @@ class GameToPhysicsAdapter {
     private val enablePairs = ConcurrentLinkedQueue<Pair<ShipId, ShipId>>()
     private val disablePairs = ConcurrentLinkedQueue<Pair<ShipId, ShipId>>()
 
+    private val shipToLiquidOverlap = ConcurrentHashMap<Long, Double>()
 
     fun physTick(physLevel: PhysLevel, delta: Double) {
 
@@ -142,6 +143,10 @@ class GameToPhysicsAdapter {
         enablePairs.pollUntilEmpty { pair -> physLevel.enableCollisionBetween(pair.first, pair.second) }
         disablePairs.pollUntilEmpty { pair -> physLevel.disableCollisionBetween(pair.first, pair.second) }
 
+        shipToLiquidOverlap.clear()
+        physLevel.getAllPhysShips().forEach { ship ->
+            shipToLiquidOverlap[ship.id] = ship.liquidOverlap
+        }
     }
 
     /**
@@ -356,6 +361,14 @@ class GameToPhysicsAdapter {
         }
 
         return visited.toList()
+    }
+
+    /**
+     * Gets the percent of the ship that is overlapping a fluid, from 0 to 1.
+     * Should not be null unless the `id` is not a valid ship
+     */
+    fun getLiquidOverlap(id: Long): Double? {
+        return shipToLiquidOverlap[id]
     }
 
     private data class ForceAtPos(val force: Vector3dc, val pos: Vector3dc?)


### PR DESCRIPTION
## What this PR does:
- [x] API addition / improvement

**Explain what this PR is doing:**

Adds a `shipToLiquidOverlap: ConcurrentHashMap<Long, Double>` to the `GameToPhysicsAdapter`. This allows developers to access the phys ship only value `liquidOverlap` from the game tick

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
