### PR TITLE
1.20.1/new airpockets -> Simultaneous flooding for multiple air pockets

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -104,6 +104,10 @@ loom {
     accessWidenerPath = file("src/main/resources/valkyrienskies-common.accesswidener")
 }
 
+test {
+    useJUnitPlatform()
+}
+
 jar {
     // Exclude dummy Optifine classes
     exclude "net/optifine/**"

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/air_pockets/ShipWaterPocketFloodOrdering.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/air_pockets/ShipWaterPocketFloodOrdering.kt
@@ -1,0 +1,46 @@
+package org.valkyrienskies.mod.common.air_pockets
+
+import it.unimi.dsi.fastutil.ints.IntArrayList
+
+internal data class PendingFloodComponentOrder(
+    val orderedIndices: IntArrayList,
+    val fairnessWeight: Int,
+)
+
+internal fun mergeOrderedFloodComponentAdds(components: List<PendingFloodComponentOrder>): IntArrayList {
+    var totalSize = 0
+    for (component in components) {
+        totalSize += component.orderedIndices.size
+    }
+
+    val merged = IntArrayList(totalSize)
+    if (components.isEmpty()) return merged
+
+    val cursors = IntArray(components.size)
+
+    // Give every pending component an immediate slot so disconnected pockets start flooding together.
+    for (i in components.indices) {
+        val ordered = components[i].orderedIndices
+        if (ordered.isEmpty) continue
+        merged.add(ordered.getInt(0))
+        cursors[i] = 1
+    }
+
+    var progressed = true
+    while (progressed) {
+        progressed = false
+        for (i in components.indices) {
+            val ordered = components[i].orderedIndices
+            val cycleBudget = components[i].fairnessWeight.coerceAtLeast(1)
+            var emitted = 0
+            while (emitted < cycleBudget && cursors[i] < ordered.size) {
+                merged.add(ordered.getInt(cursors[i]))
+                cursors[i]++
+                emitted++
+                progressed = true
+            }
+        }
+    }
+
+    return merged
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/air_pockets/ShipWaterPocketManager.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/air_pockets/ShipWaterPocketManager.kt
@@ -4918,7 +4918,7 @@ object ShipWaterPocketManager {
         val newPlanes = Int2DoubleOpenHashMap()
         val toAddAll = BitSet(volume)
         val toRemoveAll = BitSet(volume)
-        val orderedAddsAll = IntArrayList()
+        val orderedAddComponents = mutableListOf<PendingFloodComponentOrder>()
         var virtualFrontsRemaining = MAX_VIRTUAL_INGRESS_FRONTS
 
         if (!targetWetInterior.isEmpty) {
@@ -5230,11 +5230,12 @@ object ShipWaterPocketManager {
                     val anchorZ = anchorT / sizeY
 
                     val emitted = BitSet(volume)
+                    val orderedAddsForComponent = IntArrayList(candidateCount)
                     fun emitIfPending(idx: Int) {
                         if (idx < 0 || idx >= volume) return
                         if (emitted.get(idx) || !toAddAll.get(idx)) return
                         emitted.set(idx)
-                        orderedAddsAll.add(idx)
+                        orderedAddsForComponent.add(idx)
                     }
 
                     if (seedMissing) {
@@ -5577,6 +5578,15 @@ object ShipWaterPocketManager {
                     for (i in 0 until candidateCount) {
                         emitted.clear(candidateIdxs[i])
                     }
+
+                    if (!orderedAddsForComponent.isEmpty) {
+                        orderedAddComponents.add(
+                            PendingFloodComponentOrder(
+                                orderedIndices = orderedAddsForComponent,
+                                fairnessWeight = frontCount.coerceAtLeast(1),
+                            ),
+                        )
+                    }
                 }
 
                 var start = missing.nextSetBit(0)
@@ -5604,6 +5614,7 @@ object ShipWaterPocketManager {
         state.floodPlaneByComponent = newPlanes
         state.activeFloodIngressPoints = (MAX_VIRTUAL_INGRESS_FRONTS - virtualFrontsRemaining).coerceAtLeast(1)
 
+        val orderedAddsAll = mergeOrderedFloodComponentAdds(orderedAddComponents)
         enqueueFloodWriteDiffs(state, toAddAll, toRemoveAll, orderedAddsAll)
         state.persistDirty = true
     }

--- a/common/src/test/kotlin/org/valkyrienskies/mod/feature/ship_water_pockets/ShipWaterPocketFloodOrderingTest.kt
+++ b/common/src/test/kotlin/org/valkyrienskies/mod/feature/ship_water_pockets/ShipWaterPocketFloodOrderingTest.kt
@@ -1,0 +1,55 @@
+package org.valkyrienskies.mod.feature.ship_water_pockets
+
+import it.unimi.dsi.fastutil.ints.IntArrayList
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.valkyrienskies.mod.common.air_pockets.PendingFloodComponentOrder
+import org.valkyrienskies.mod.common.air_pockets.mergeOrderedFloodComponentAdds
+
+class ShipWaterPocketFloodOrderingTest {
+
+    @Test
+    fun mergeOrderedFloodComponentAddsInterleavesEqualWeightStarts() {
+        val merged = mergeOrderedFloodComponentAdds(
+            listOf(
+                component(1, 1, 2, 3),
+                component(1, 10, 11, 12),
+            ),
+        )
+
+        assertEquals(listOf(1, 10, 2, 11, 3, 12), asList(merged))
+    }
+
+    @Test
+    fun mergeOrderedFloodComponentAddsKeepsSmallerComponentActiveDuringWeightedCycles() {
+        val merged = mergeOrderedFloodComponentAdds(
+            listOf(
+                component(3, 1, 2, 3, 4, 5),
+                component(1, 10, 11, 12),
+            ),
+        )
+
+        assertEquals(listOf(1, 10, 2, 3, 4, 11, 5, 12), asList(merged))
+    }
+
+    @Test
+    fun mergeOrderedFloodComponentAddsPreservesSingleComponentOrder() {
+        val merged = mergeOrderedFloodComponentAdds(
+            listOf(component(4, 7, 4, 9, 12)),
+        )
+
+        assertEquals(listOf(7, 4, 9, 12), asList(merged))
+    }
+
+    private fun component(weight: Int, vararg ordered: Int): PendingFloodComponentOrder {
+        val indices = IntArrayList(ordered.size)
+        for (idx in ordered) {
+            indices.add(idx)
+        }
+        return PendingFloodComponentOrder(indices, weight)
+    }
+
+    private fun asList(indices: IntArrayList): List<Int> {
+        return (0 until indices.size).map { indices.getInt(it) }
+    }
+}

--- a/common/src/test/kotlin/org/valkyrienskies/valkyrienair/feature/ship_water_pockets/ShipWaterPocketAsyncRuntimeTest.kt
+++ b/common/src/test/kotlin/org/valkyrienskies/valkyrienair/feature/ship_water_pockets/ShipWaterPocketAsyncRuntimeTest.kt
@@ -10,9 +10,9 @@ import kotlin.jvm.functions.Function0
 
 class ShipWaterPocketAsyncRuntimeTest {
     private val runtimeClass =
-        Class.forName("org.valkyrienskies.valkyrienair.feature.ship_water_pockets.ShipPocketAsyncRuntime")
+        Class.forName("org.valkyrienskies.mod.common.air_pockets.ShipPocketAsyncRuntime")
     private val subsystemClass =
-        Class.forName("org.valkyrienskies.valkyrienair.feature.ship_water_pockets.ShipPocketAsyncSubsystem")
+        Class.forName("org.valkyrienskies.mod.common.air_pockets.ShipPocketAsyncSubsystem")
     private val trySubmitMethod =
         runtimeClass.getMethod("trySubmit", subsystemClass, Function0::class.java)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,9 +55,9 @@ ephemera_version=d4xVSBKN
 # https://modrinth.com/mod/moonlight/versions
 moonlight_version = 1.20-2.16.22-fabric
 
-vs_core_version=1.1.0+1d4a7373e9
+vs_core_version=1.1.0+4e60b17cd2
 # Ideally we'd determine these automatically from vs_core. Add them manually for now
-krunch_version=1.0.0+ecca9e2967
+krunch_version=1.0.0+b15534abbd
 krunch_api_version=1.0.0+7d7acb73b2
 # Prevent kotlin from autoincluding stdlib as a dependency, which breaks
 # gradle's composite builds (includeBuild) for some reason. We'll add it manually

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,9 +55,9 @@ ephemera_version=d4xVSBKN
 # https://modrinth.com/mod/moonlight/versions
 moonlight_version = 1.20-2.16.22-fabric
 
-vs_core_version=1.1.0+4e60b17cd2
+vs_core_version=1.1.0+9ce43ae27c
 # Ideally we'd determine these automatically from vs_core. Add them manually for now
-krunch_version=1.0.0+b15534abbd
+krunch_version=1.0.0+f3f71b0a2e
 krunch_api_version=1.0.0+7d7acb73b2
 # Prevent kotlin from autoincluding stdlib as a dependency, which breaks
 # gradle's composite builds (includeBuild) for some reason. We'll add it manually


### PR DESCRIPTION
## What this PR does:
- [X] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**
This PR fixes a bug that caused sequential flooding instead of simultaneous flooding when a ship had multiple air pockets.

---

## Modloaders this PR affects:
- [X] Forge
- [X] Fabric

## Where this PR was tested:
- [ ] In-dev singleplayer
- [ ] In-dev dedicated server
- [X] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [X] No

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
