### PR TITLE
Update changelog and change version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
-## VS 2.5.0.0
+## VS 2.5.0
 
-Proper air pockets! As well as a new version scheme, and many small fixes.
+Proper air pockets! As well as a many small fixes.
+
+**Note: PhysX is still not the default. We have just chosen to use 2.5 for the air pocket release instead.**
 
 #### Changes:
 - Old (buggy) air pocket system has been entirely replaced by an incredibly impressive system.
@@ -16,6 +18,8 @@ Proper air pockets! As well as a new version scheme, and many small fixes.
 - Added liquid overlap to GTPA
 - Moved command related classes (aka `ShipArgument` and others). 
   **Breaking change**, but only imports will need changing
+- The second version digit (2.**5**.0) is going to be bumped a bit more 
+  frequently for medium-sized updates. You may want to anticipate this in your version ranges.
 
 #### Bugfixes:
 - Fixed buoyancy on large ships not being quite right

--- a/changelog.md
+++ b/changelog.md
@@ -2,20 +2,6 @@
 
 Proper air pockets! As well as a new version scheme, and many small fixes.
 
-**Physx is still not the default, we chose to use 2.5 to mark the occasion of air pockets instead**
-
----
-
-The new version scheme is:
-
-`a.b.c.d`
-
-Which will allow us to better separate minor changes
-(`c`) from just bug fixes (`d`), instead of before where we had 
-`a.b.cd` where `cd` could mean anything from a medium update to a small bugfix.
-
----
-
 #### Changes:
 - Old (buggy) air pocket system has been entirely replaced by an incredibly impressive system.
   We owe a huge thanks to GigaBrawler for making this new system, with additional thanks to 

--- a/changelog.md
+++ b/changelog.md
@@ -1,18 +1,42 @@
-## VS 2.4.10
-Critical fixes, Jolt, Command Feedback, and Hexcasting Compat
+## VS 2.5.0.0
+
+Proper air pockets! As well as a new version scheme, and many small fixes.
+
+**Physx is still not the default, we chose to use 2.5 to mark the occasion of air pockets instead**
+
+---
+
+The new version scheme is:
+
+`a.b.c.d`
+
+Which will allow us to better separate minor changes
+(`c`) from just bug fixes (`d`), instead of before where we had 
+`a.b.cd` where `cd` could mean anything from a medium update to a small bugfix.
+
+---
 
 #### Changes:
-- Jolt physics now available as an engine option
-- Proper VS Command feedback
-- Connectivity, client and server, is disabled by default in config while it's being fixed- you'll want to update your configs and disable buoyancy. We're working on a much better flooding system, so stay tuned...
-- Removed Herobrine
+- Old (buggy) air pocket system has been entirely replaced by an incredibly impressive system.
+  We owe a huge thanks to GigaBrawler for making this new system, with additional thanks to 
+  Copper, Brickyboy, and Zyxkad for helping.
+- Atmospheric max has been changed from 1000 to 2000. This should make propeller planes 
+  much more controllable at altitudes above the clouds, where before they would stall pretty suddenly.
+- Added `/vs dry` command to help dry your flooded ships
+
+#### API changes:
+- Fixed `transformFromWorldToNearbyShipsAndWorld` util function
+- Added `getAllConnectedShips` to GTPA
+- Added liquid overlap to GTPA
+- Moved command related classes (aka `ShipArgument` and others). 
+  **Breaking change**, but only imports will need changing
 
 #### Bugfixes:
-- Respawn breaking all ships (hopefully)
-- Some minor connectivity improvements (but its still off by default now)
-- Engine adjustments
-- Weather/snow on ships
-- Bluemap crash fix on newer versions
-- Hexcasting null crash
-- Cannon recoil direction with CBC compat fixed
-- Additional miscellaneous fixes
+- Fixed buoyancy on large ships not being quite right
+- Fixed an issue where Connectivity would still cause lag even if disabled
+- Fixed a crash with Real Camera
+- Fixed hexcasting and hexal compat issues
+- Fixed copycats duping on assembly
+- Fixed CBC autocannons breaking on VS ships
+- Fixed a crash with Create: Hypertubes (sorry it took so long Rok!)
+- Fixed visual artifacts with the ship AABB when at large coordinates

--- a/common/src/main/resources/data/valkyrienskies/vs_dimension_parameters/overworld.json
+++ b/common/src/main/resources/data/valkyrienskies/vs_dimension_parameters/overworld.json
@@ -1,6 +1,6 @@
 {
   "dimensionId": "minecraft:dimension:minecraft:overworld",
-  "maxYPos": 1000,
+  "maxYPos": 2000,
   "seaLevel": 62,
   "gravity": [0.0, -10.0, 0.0],
   "priority": -1

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,8 @@ org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=1G
 minecraft_version=1.20.1
 enabled_platforms=quilt,fabric,forge
 archives_base_name=valkyrienskies-120
-# a.b.c.d
-# a: if this changes, the entire mod is new somehow
-# b: if this changes, lots of stuff overhauled (like 2.5 type changes)
-# c: if this changes, some stuff overhauled (minor api changes)
-# d: if this changes, its just bug fixes
-mod_version=2.5.0.0
+
+mod_version=2.4.11
 maven_group=org.valkyrienskies.mod
 
 # https://www.curseforge.com/minecraft/mc-mods/architectury-api/files/

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,12 @@ org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=1G
 minecraft_version=1.20.1
 enabled_platforms=quilt,fabric,forge
 archives_base_name=valkyrienskies-120
-mod_version=2.4.10
+# a.b.c.d
+# a: if this changes, the entire mod is new somehow
+# b: if this changes, lots of stuff overhauled (like 2.5 type changes)
+# c: if this changes, some stuff overhauled (minor api changes)
+# d: if this changes, its just bug fixes
+mod_version=2.5.0.0
 maven_group=org.valkyrienskies.mod
 
 # https://www.curseforge.com/minecraft/mc-mods/architectury-api/files/

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ minecraft_version=1.20.1
 enabled_platforms=quilt,fabric,forge
 archives_base_name=valkyrienskies-120
 
-mod_version=2.4.11
+mod_version=2.5.0
 maven_group=org.valkyrienskies.mod
 
 # https://www.curseforge.com/minecraft/mc-mods/architectury-api/files/


### PR DESCRIPTION
**Explain what this PR is doing:**

Bumps the version to 2.4.11 and adds a changelog.

After an hour long argument in VS creators, I'm defeated. I want a new version scheme `a.b.c.d` so we can use `c` for medium updates and `d` for bug fixes, but everyone else despises having an actually useful semver so whatever. The useless `2.4.11` it is.