### PR TITLE
Ship weather occlusion

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/world_weather/MixinLevelRenderer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/world_weather/MixinLevelRenderer.java
@@ -1,0 +1,118 @@
+package org.valkyrienskies.mod.mixin.feature.world_weather;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.Heightmap.Types;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.CompatUtil;
+
+@Mixin(LevelRenderer.class)
+public class MixinLevelRenderer {
+
+    @WrapOperation(
+        method = "tickRain(Lnet/minecraft/client/Camera;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/LevelReader;getHeightmapPos(Lnet/minecraft/world/level/levelgen/Heightmap$Types;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/BlockPos;"
+        )
+    )
+    private BlockPos includeShipsInWeatherTickOcclusion(
+        final LevelReader levelReader, final Types types, final BlockPos pos, final Operation<BlockPos> original,
+        @Share("weatherSurfaceLookupPos") final LocalRef<BlockPos> weatherSurfaceLookupPos
+    ) {
+        weatherSurfaceLookupPos.set(null);
+        if (levelReader instanceof Level level) {
+            final BlockPos vanillaHeight = original.call(levelReader, types, pos);
+            final BlockPos worldHeight = BlockPos.containing(
+                CompatUtil.INSTANCE.toSameSpaceAs(level, vanillaHeight.getCenter(), (Ship) null, null)
+            );
+            final BlockHitResult shipSurfaceHit =
+                CompatUtil.INSTANCE.getShipHeightmapHitAboveWorldHeight(level, types, worldHeight);
+            weatherSurfaceLookupPos.set(shipSurfaceHit == null ? null : shipSurfaceHit.getBlockPos().immutable());
+            return shipSurfaceHit == null
+                ? worldHeight
+                : new BlockPos(worldHeight.getX(), Mth.floor(Math.nextDown(shipSurfaceHit.getLocation().y)) + 1, worldHeight.getZ());
+        }
+        return original.call(levelReader, types, pos);
+    }
+
+    @WrapOperation(
+        method = "tickRain(Lnet/minecraft/client/Camera;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/LevelReader;getBlockState(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;"
+        )
+    )
+    private BlockState includeShipsInWeatherTickSurfaceState(
+        final LevelReader levelReader,
+        final BlockPos pos,
+        final Operation<BlockState> original,
+        @Share("weatherSurfaceLookupPos") final LocalRef<BlockPos> weatherSurfaceLookupPos
+    ) {
+        final BlockPos lookupPos = weatherSurfaceLookupPos.get();
+        return original.call(levelReader, lookupPos != null ? lookupPos : pos);
+    }
+
+    @WrapOperation(
+        method = "tickRain(Lnet/minecraft/client/Camera;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/LevelReader;getFluidState(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/material/FluidState;"
+        )
+    )
+    private FluidState includeShipsInWeatherTickSurfaceFluid(
+        final LevelReader levelReader,
+        final BlockPos pos,
+        final Operation<FluidState> original,
+        @Share("weatherSurfaceLookupPos") final LocalRef<BlockPos> weatherSurfaceLookupPos
+    ) {
+        final BlockPos lookupPos = weatherSurfaceLookupPos.get();
+        return original.call(levelReader, lookupPos != null ? lookupPos : pos);
+    }
+
+    @WrapOperation(
+        method = "tickRain(Lnet/minecraft/client/Camera;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/block/state/BlockState;getCollisionShape(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/phys/shapes/VoxelShape;"
+        )
+    )
+    private VoxelShape includeShipsInWeatherTickCollisionShape(
+        final BlockState state,
+        final BlockGetter levelReader,
+        final BlockPos pos,
+        final Operation<VoxelShape> original,
+        @Share("weatherSurfaceLookupPos") final LocalRef<BlockPos> weatherSurfaceLookupPos
+    ) {
+        final BlockPos lookupPos = weatherSurfaceLookupPos.get();
+        // This fixes ship surface lookup, but vanilla still interprets the returned shape in world-axis block space. Solutions welcome?
+        return original.call(state, levelReader, lookupPos != null ? lookupPos : pos);
+    }
+
+    @WrapOperation(
+        method = "renderSnowAndRain(Lnet/minecraft/client/renderer/LightTexture;FDDD)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/Level;getHeight(Lnet/minecraft/world/level/levelgen/Heightmap$Types;II)I"
+        )
+    )
+    private int includeShipsInWeatherRenderOcclusion(
+        final Level level, final Types types, final int x, final int z, final Operation<Integer> original
+    ) {
+        return CompatUtil.INSTANCE.getWorldHeightIncludingShips(level, types, x, z);
+    }
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/CompatUtil.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/CompatUtil.kt
@@ -1,12 +1,19 @@
 package org.valkyrienskies.mod.common
 
 import net.minecraft.core.BlockPos
+import net.minecraft.tags.BlockTags
+import net.minecraft.util.Mth
+import net.minecraft.world.level.ClipContext
 import net.minecraft.world.level.Level
 import net.minecraft.world.level.LightLayer
+import net.minecraft.world.level.levelgen.Heightmap.Types
+import net.minecraft.world.phys.BlockHitResult
+import net.minecraft.world.phys.HitResult
 import net.minecraft.world.phys.Vec3
 import org.joml.Vector3d
 import org.joml.Vector3dc
 import org.valkyrienskies.core.api.ships.Ship
+import org.valkyrienskies.mod.common.world.clipIncludeShips
 import org.valkyrienskies.mod.common.util.toJOML
 import org.valkyrienskies.mod.common.util.toMinecraft
 import org.valkyrienskies.mod.common.util.transformPosition
@@ -93,6 +100,81 @@ object CompatUtil {
     fun toSameSpaceAs(level: Level?, px: Double, py: Double, pz: Double, target: BlockPos): Vec3 {
         return toSameSpaceAs(level, Vector3d(px, py, pz), level.getShipManagingPos(target))
             .toMinecraft()
+    }
+
+    /**
+     * Get the vanilla heightmap position in world space, then raycast only the space above it for ships.
+     */
+    fun getWorldHeightmapPosIncludingShips(level: Level, types: Types, pos: BlockPos): BlockPos {
+        val worldHeight = BlockPos.containing(toSameSpaceAs(level, level.getHeightmapPos(types, pos).center, targetShip = null))
+        val shipSurfaceHit = getShipHeightmapHitAboveWorldHeight(level, types, worldHeight) ?: return worldHeight
+        val shipHeightY = Mth.floor(Math.nextDown(shipSurfaceHit.location.y)) + 1
+        return BlockPos(worldHeight.x, shipHeightY, worldHeight.z)
+    }
+
+    fun getWorldHeightIncludingShips(level: Level, types: Types, x: Int, z: Int): Int =
+        getWorldHeightmapPosIncludingShips(level, types, BlockPos(x, level.minBuildHeight, z)).y
+
+    fun getShipHeightmapPosAboveWorldHeight(level: Level, types: Types, worldHeight: BlockPos): BlockPos? {
+        return getShipHeightmapHitAboveWorldHeight(level, types, worldHeight)?.blockPos?.immutable()
+    }
+
+    fun getShipHeightmapHitAboveWorldHeight(level: Level, types: Types, worldHeight: BlockPos): BlockHitResult? {
+        if (worldHeight.y >= level.maxBuildHeight) {
+            return null
+        }
+
+        val start = Vec3(worldHeight.x + 0.5, level.maxBuildHeight.toDouble(), worldHeight.z + 0.5)
+        val end = worldHeight.center
+        if (types == Types.MOTION_BLOCKING_NO_LEAVES) {
+            return clipAboveWorldHeightIgnoringLeafHits(level, start, end)
+        }
+
+        val blockClip = when (types) {
+            Types.WORLD_SURFACE, Types.WORLD_SURFACE_WG -> ClipContext.Block.OUTLINE
+            else -> ClipContext.Block.COLLIDER
+        }
+        val fluidClip = when (types) {
+            Types.MOTION_BLOCKING, Types.MOTION_BLOCKING_NO_LEAVES, Types.WORLD_SURFACE, Types.WORLD_SURFACE_WG ->
+                ClipContext.Fluid.ANY
+            else -> ClipContext.Fluid.NONE
+        }
+        val hit = level.clipIncludeShips(
+            ClipContext(start, end, blockClip, fluidClip, null),
+            skipWorld = true
+        )
+        return if (hit.type == HitResult.Type.MISS) null else hit
+    }
+
+    // ClipContext cannot express MOTION_BLOCKING_NO_LEAVES exactly, so this retries through leaf hits
+    private fun clipAboveWorldHeightIgnoringLeafHits(
+        level: Level,
+        start: Vec3,
+        end: Vec3
+    ): BlockHitResult? {
+        var currentStart = start
+
+        while (true) {
+            val hit = level.clipIncludeShips(
+                ClipContext(currentStart, end, ClipContext.Block.COLLIDER, ClipContext.Fluid.ANY, null),
+                skipWorld = true
+            )
+
+            if (hit.type == HitResult.Type.MISS) {
+                return null
+            }
+
+            val hitPos = hit.blockPos
+            if (!level.getBlockState(hitPos).`is`(BlockTags.LEAVES)) {
+                return hit
+            }
+
+            currentStart = hit.location.add(0.0, -0.25, 0.0)
+
+            if (currentStart.y <= end.y) {
+                return null
+            }
+        }
     }
 
     /**

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -260,6 +260,7 @@
     "feature.render_leashes.MixinMobRenderer",
     "feature.render_pathfinding.MixinDebugRenderer",
     "feature.render_ship_debug_bb.MixinDebugRenderer",
+    "feature.world_weather.MixinLevelRenderer",
     "feature.seamless_copy.MixinClientPacketListener",
     "feature.ship_debug_overlay.MixinDebugScreenOverlay",
     "feature.shipyard_entities.MixinClientLevel",


### PR DESCRIPTION
## What this PR does:
- [X] Bug fix 
- [X] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**
Adds a method in CompatUtils.kt to calculate heightmap at position inclusive with ships via adding a worldheight-down clip to existing heightmap.
Uses this method to mixin to rain and snow renderer and rain tick so that rain is occluded by VS ships.

---

## Modloaders this PR affects:
- [X] Forge
- [X] Fabric

## Where this PR was tested:
- [X] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [ ] No

---


## Additional Notes

Slight performance concerns when the CompatUtils method is searching for BLOCKING_NO_LEAVES, in order to maintain parity leaf blocks have to be manually skipped by looping consecutive clips

Returned voxelshapes aren't rotated correctly, any solution to this would be well out of scope of this feature

Rain splash particles, as any particle, does not collide with the ship so in the rain roofs can be a bit "leaky". Fix for this would be out of scope for this feature.

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
