### PR TITLE
Particles that collide with blocks now consider ships

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/particle_collision/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/particle_collision/MixinEntity.java
@@ -1,0 +1,37 @@
+package org.valkyrienskies.mod.mixin.feature.particle_collision;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.valkyrienskies.mod.common.util.EntityShipCollisionUtils;
+
+@Mixin(Entity.class)
+public class MixinEntity {
+
+    /**
+     * Route particle-style collision checks (entity == null) through VS ship collision first.
+     * This keeps behavior centralized at the vanilla collision primitive used by physics particles.
+     */
+    @ModifyVariable(
+        method = "collideBoundingBox(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/AABB;Lnet/minecraft/world/level/Level;Ljava/util/List;)Lnet/minecraft/world/phys/Vec3;",
+        at = @At("HEAD"),
+        argsOnly = true,
+        index = 1
+    )
+    private static Vec3 includeShipsForParticleCollision(
+        final Vec3 movement,
+        @Local(argsOnly = true) final Entity entity,
+        @Local(argsOnly = true) final AABB entityBoundingBox,
+        @Local(argsOnly = true) final Level level
+    ) {
+        if (entity != null || !level.isClientSide) {
+            return movement;
+        }
+        return EntityShipCollisionUtils.INSTANCE.adjustEntityMovementForShipCollisions(null, movement, entityBoundingBox, level);
+    }
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityShipCollisionUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityShipCollisionUtils.kt
@@ -27,6 +27,7 @@ import org.valkyrienskies.mod.util.BugFixUtil
 import java.util.stream.Stream
 
 object EntityShipCollisionUtils {
+    private const val PARTICLE_COLLISION_BOX_EXPANSION = 0.00390625 //1.0 / 256.0
 
     private val collider = vsCore.entityPolygonCollider
 
@@ -123,8 +124,14 @@ object EntityShipCollisionUtils {
             return movement
         }
 
+        val collisionBoundingBox = if (entity == null) {
+            entityBoundingBox.inflate(PARTICLE_COLLISION_BOX_EXPANSION)
+        } else {
+            entityBoundingBox
+        }
+
         val (newMovement, shipCollidingWith) = collider.adjustEntityMovementForPolygonCollisions(
-            movement.toJOML(), entityBoundingBox.toJOML(), stepHeight, collidingShipPolygons
+            movement.toJOML(), collisionBoundingBox.toJOML(), stepHeight, collidingShipPolygons
         )
         if (entity != null) {
             val standingOnShip = entity.level().getLoadedShipManagingPos(entity.onPos)

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -252,6 +252,7 @@
     "feature.block_tint.MixinClientLevel",
     "feature.commands.ClientSuggestionProviderAccessor",
     "feature.entity_movement_packets.MixinLocalPlayer",
+    "feature.particle_collision.MixinEntity",
     "feature.fix_render_chunk_sorting.MixinRenderChunk",
     "feature.fluid_camera_fix.MixinCamera",
     "feature.hit_outline.MixinLevelRenderer",


### PR DESCRIPTION
## What this PR does:
- [X] Bug fix 
- [X] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**
Redirects particle usage of `Entity.collideBoundingBox` so that particles that should collide with blocks properly collide with ships.

https://github.com/user-attachments/assets/3490dcc3-3f13-4de8-8682-4175b399c1f3

---

## Modloaders this PR affects:
- [X] Forge
- [X] Fabric

## Where this PR was tested:
- [X] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [X] No

---

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
