### PR TITLE
Source fluid blocks treated as full blocks

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
@@ -321,7 +321,12 @@ object MassDatapackResolver : BlockStateInfoProvider {
         fun getFluidState(fluidState: FluidState, blockStateInfo: VSBlockStateInfo?, isLiquid: Boolean = false): LiquidState {
             val cached = fluidStateToBlockTypeMap[fluidState]
             if (cached != null) return cached
-            val maxY = ((fluidState.ownHeight * 16.0).roundToInt() - 1).coerceIn(0, 15)
+            // Treat source fluids as full blocks in VS physics registration.
+            val maxY = if (fluidState.isSource) {
+                15
+            } else {
+                ((fluidState.ownHeight * 16.0).roundToInt() - 1).coerceIn(0, 15)
+            }
             val fluidBox = AABBi(0, 0, 0, 15, maxY, 15)
             return if (fluidState.type in liquidMaterialToDensityMap) {
                 val (density, dragCoefficient) = liquidMaterialToDensityMap[fluidState.type]!!


### PR DESCRIPTION
## What this PR does:
- [X] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**
Source fluid blocks are set to full height blocks when being passed to physics.

---

## Modloaders this PR affects:
- [X] Forge
- [X] Fabric

## Where this PR was tested:
- [X] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [X] No

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
