### PR TITLE
Blocks respect obstructions

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/block_placement/MixinBlockItem.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/block_placement/MixinBlockItem.java
@@ -70,7 +70,9 @@ public abstract class MixinBlockItem {
         if (!result) {
             return false;
         }
-        if (!VSGameConfig.COMMON.BLOCK_PLACEMENT.getEnableExtendedObstructionChecks()) {
+        final boolean checkBlockObstructions = VSGameConfig.COMMON.BLOCK_PLACEMENT.getEnableBlockObstructionChecks();
+        final boolean checkEntityObstructions = VSGameConfig.COMMON.BLOCK_PLACEMENT.getEnableEntityObstructionChecks();
+        if (!checkBlockObstructions && !checkEntityObstructions) {
             return true;
         }
 
@@ -87,17 +89,17 @@ public abstract class MixinBlockItem {
         final Ship ship = VSGameUtilsKt.getShipManagingPos(level, blockPos);
         if (ship != null) {
             final Matrix4dc shipToWorld = ship.getShipToWorld();
-            if (vs_hasObstructionWithWorldBlocks(level, placementBoxes, shipToWorld)) {
+            if (checkBlockObstructions && vs_hasObstructionWithWorldBlocks(level, placementBoxes, shipToWorld)) {
                 return false;
             }
-            if (vs_hasObstructionWithEntities(level, placementBoxes, shipToWorld)) {
+            if (checkEntityObstructions && vs_hasObstructionWithEntities(level, placementBoxes, shipToWorld)) {
                 return false;
             }
             return true;
         }
 
         final AABBd worldBounds = VectorConversionsMCKt.toJOML(voxelShape.bounds().move(blockPos));
-        if (vs_hasWorldPlacementObstructionWithShips(level, placementBoxes, worldBounds)) {
+        if (checkBlockObstructions && vs_hasWorldPlacementObstructionWithShips(level, placementBoxes, worldBounds)) {
             return false;
         }
 

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/block_placement/MixinBlockItem.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/block_placement/MixinBlockItem.java
@@ -2,13 +2,17 @@ package org.valkyrienskies.mod.mixin.feature.block_placement;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import com.llamalad7.mixinextras.sugar.Local;
+import java.util.ArrayList;
+import java.util.List;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.entity.player.Player;
+import net.minecraft.core.BlockPos.MutableBlockPos;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.joml.Intersectiond;
@@ -21,10 +25,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.PlayerUtil;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.config.VSGameConfig;
 import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 
 @Mixin(BlockItem.class)
 public abstract class MixinBlockItem {
+    @Unique
+    private static final double VS_OBSTRUCTION_SHRINK = 1.0E-3;
 
     @WrapOperation(
         at = @At(
@@ -55,30 +62,165 @@ public abstract class MixinBlockItem {
             target = "Lnet/minecraft/world/level/Level;isUnobstructed(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/phys/shapes/CollisionContext;)Z"
         )
     )
-    private boolean checkObstructionByPlayer(
+    private boolean checkObstructions(
         final Level level, final BlockState blockState, final BlockPos blockPos, final CollisionContext ctx,
-        Operation<Boolean> original, @Local(argsOnly = true) BlockPlaceContext blockPlaceContext
+        Operation<Boolean> original
     ) {
         boolean result = original.call(level, blockState, blockPos, ctx);
-        if (result) {
-            Ship ship = VSGameUtilsKt.getShipManagingPos(level, blockPos);
-            if (ship != null) {
-                VoxelShape voxelShape = blockState.getCollisionShape(level, blockPos, ctx);
-                Player player = blockPlaceContext.getPlayer();
+        if (!result) {
+            return false;
+        }
+        if (!VSGameConfig.COMMON.BLOCK_PLACEMENT.getEnableExtendedObstructionChecks()) {
+            return true;
+        }
 
-                if (player != null
-                    && !player.isRemoved()
-                    && player.blocksBuilding
-                    && !voxelShape.isEmpty()
-                    && vs_testObAab(
-                        VectorConversionsMCKt.toJOML(voxelShape.bounds().move(blockPos)),
-                        ship.getShipToWorld(),
-                        VectorConversionsMCKt.toJOML(player.getBoundingBox().deflate(0.1))
-                    )
-                ) return false;
+        final VoxelShape voxelShape = blockState.getCollisionShape(level, blockPos, ctx);
+        if (voxelShape.isEmpty()) {
+            return true;
+        }
+
+        final List<AABBd> placementBoxes = vs_getCollisionBoxes(voxelShape, blockPos);
+        if (placementBoxes.isEmpty()) {
+            return true;
+        }
+
+        final Ship ship = VSGameUtilsKt.getShipManagingPos(level, blockPos);
+        if (ship != null) {
+            final Matrix4dc shipToWorld = ship.getShipToWorld();
+            if (vs_hasObstructionWithWorldBlocks(level, placementBoxes, shipToWorld)) {
+                return false;
+            }
+            if (vs_hasObstructionWithEntities(level, placementBoxes, shipToWorld)) {
+                return false;
+            }
+            return true;
+        }
+
+        final AABBd worldBounds = VectorConversionsMCKt.toJOML(voxelShape.bounds().move(blockPos));
+        if (vs_hasWorldPlacementObstructionWithShips(level, placementBoxes, worldBounds)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Unique
+    private static boolean vs_hasObstructionWithWorldBlocks(
+        final Level level, final List<AABBd> placementBoxes, final Matrix4dc shipToWorld
+    ) {
+        for (final AABBd placementBox : placementBoxes) {
+            if (vs_hasObstructionWithNonReplaceableBlocks(level, placementBox, shipToWorld)) {
+                return true;
             }
         }
-        return result;
+        return false;
+    }
+
+    @Unique
+    private static boolean vs_hasObstructionWithEntities(
+        final Level level, final List<AABBd> placementBoxes, final Matrix4dc shipToWorld
+    ) {
+        final AABBd worldBounds = placementBoxes.get(0).transform(shipToWorld, new AABBd());
+        for (int i = 1; i < placementBoxes.size(); i++) {
+            worldBounds.union(placementBoxes.get(i).transform(shipToWorld, new AABBd()));
+        }
+
+        for (final Entity entity : level.getEntities((Entity) null, VectorConversionsMCKt.toMinecraft(worldBounds))) {
+            if (entity.isRemoved() || !entity.blocksBuilding) {
+                continue;
+            }
+            final AABBd entityAABB = VectorConversionsMCKt.toJOML(entity.getBoundingBox().deflate(1.0E-7));
+            for (final AABBd placementBox : placementBoxes) {
+                if (vs_testObAab(placementBox, shipToWorld, entityAABB)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Unique
+    private static boolean vs_hasWorldPlacementObstructionWithShips(
+        final Level level, final List<AABBd> placementBoxes, final AABBd worldBounds
+    ) {
+        for (final Ship ship : VSGameUtilsKt.getShipsIntersecting(level, worldBounds)) {
+            final Matrix4dc worldToShip = ship.getWorldToShip();
+            for (final AABBd placementBox : placementBoxes) {
+                if (vs_hasObstructionWithNonReplaceableBlocks(level, placementBox, worldToShip)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Unique
+    private static boolean vs_hasObstructionWithNonReplaceableBlocks(
+        final Level level, final AABBd placementBox, final Matrix4dc placementToBlockSpace
+    ) {
+        final AABBd shrunkenPlacementBox = vs_deflateAabb(placementBox, VS_OBSTRUCTION_SHRINK);
+        if (shrunkenPlacementBox == null) {
+            return false;
+        }
+        final AABBd placementInBlockSpaceBounds = shrunkenPlacementBox.transform(placementToBlockSpace, new AABBd());
+        final int minX = Mth.floor(placementInBlockSpaceBounds.minX());
+        final int minY = Mth.floor(placementInBlockSpaceBounds.minY());
+        final int minZ = Mth.floor(placementInBlockSpaceBounds.minZ());
+        final int maxX = Mth.floor(placementInBlockSpaceBounds.maxX());
+        final int maxY = Mth.floor(placementInBlockSpaceBounds.maxY());
+        final int maxZ = Mth.floor(placementInBlockSpaceBounds.maxZ());
+
+        final MutableBlockPos mutablePos = new MutableBlockPos();
+        for (int x = minX; x <= maxX; x++) {
+            for (int y = minY; y <= maxY; y++) {
+                for (int z = minZ; z <= maxZ; z++) {
+                    mutablePos.set(x, y, z);
+                    final BlockState blockState = level.getBlockState(mutablePos);
+                    if (blockState.canBeReplaced()) {
+                        continue;
+                    }
+
+                    final VoxelShape blockShape = blockState.getCollisionShape(level, mutablePos);
+                    if (blockShape.isEmpty()) {
+                        continue;
+                    }
+
+                    for (final AABB blockBox : blockShape.toAabbs()) {
+                        final AABBd blockBoxInBlockSpace =
+                            VectorConversionsMCKt.toJOML(blockBox.move(mutablePos.getX(), mutablePos.getY(), mutablePos.getZ()));
+                        if (vs_testObAab(shrunkenPlacementBox, placementToBlockSpace, blockBoxInBlockSpace)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    @Unique
+    private static AABBd vs_deflateAabb(final AABBd source, final double amount) {
+        final double minX = source.minX() + amount;
+        final double minY = source.minY() + amount;
+        final double minZ = source.minZ() + amount;
+        final double maxX = source.maxX() - amount;
+        final double maxY = source.maxY() - amount;
+        final double maxZ = source.maxZ() - amount;
+
+        if (minX >= maxX || minY >= maxY || minZ >= maxZ) {
+            return null;
+        }
+
+        return new AABBd(minX, minY, minZ, maxX, maxY, maxZ);
+    }
+
+    @Unique
+    private static List<AABBd> vs_getCollisionBoxes(final VoxelShape voxelShape, final BlockPos blockPos) {
+        final List<AABBd> boxes = new ArrayList<>();
+        for (final AABB box : voxelShape.toAabbs()) {
+            boxes.add(VectorConversionsMCKt.toJOML(box.move(blockPos)));
+        }
+        return boxes;
     }
 
     @Unique

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/block_placement/MixinBlockItem.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/block_placement/MixinBlockItem.java
@@ -111,7 +111,7 @@ public abstract class MixinBlockItem {
         final Level level, final List<AABBd> placementBoxes, final Matrix4dc shipToWorld
     ) {
         for (final AABBd placementBox : placementBoxes) {
-            if (vs_hasObstructionWithNonReplaceableBlocks(level, placementBox, shipToWorld)) {
+            if (vs_hasObstructionWithBlockCollisionShapes(level, placementBox, shipToWorld)) {
                 return true;
             }
         }
@@ -148,7 +148,7 @@ public abstract class MixinBlockItem {
         for (final Ship ship : VSGameUtilsKt.getShipsIntersecting(level, worldBounds)) {
             final Matrix4dc worldToShip = ship.getWorldToShip();
             for (final AABBd placementBox : placementBoxes) {
-                if (vs_hasObstructionWithNonReplaceableBlocks(level, placementBox, worldToShip)) {
+                if (vs_hasObstructionWithBlockCollisionShapes(level, placementBox, worldToShip)) {
                     return true;
                 }
             }
@@ -157,7 +157,7 @@ public abstract class MixinBlockItem {
     }
 
     @Unique
-    private static boolean vs_hasObstructionWithNonReplaceableBlocks(
+    private static boolean vs_hasObstructionWithBlockCollisionShapes(
         final Level level, final AABBd placementBox, final Matrix4dc placementToBlockSpace
     ) {
         final AABBd shrunkenPlacementBox = vs_deflateAabb(placementBox, VS_OBSTRUCTION_SHRINK);
@@ -178,10 +178,6 @@ public abstract class MixinBlockItem {
                 for (int z = minZ; z <= maxZ; z++) {
                     mutablePos.set(x, y, z);
                     final BlockState blockState = level.getBlockState(mutablePos);
-                    if (blockState.canBeReplaced()) {
-                        continue;
-                    }
-
                     final VoxelShape blockShape = blockState.getCollisionShape(level, mutablePos);
                     if (blockShape.isEmpty()) {
                         continue;

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -336,10 +336,16 @@ object VSGameConfig {
 
         class BlockPlacement {
             @ConfigEntry(
-                description = "If true, VS2 block placement additionally checks ship/world/entity obstructions " +
-                    "so placement is denied when those collision shapes intersect."
+                description = "If true, VS2 block placement additionally checks block obstructions across ship/world " +
+                    "spaces so placement is denied when collision shapes intersect."
             )
-            var enableExtendedObstructionChecks = true
+            var enableBlockObstructionChecks = false
+
+            @ConfigEntry(
+                description = "If true, VS2 block placement additionally checks entity obstructions " +
+                    "during cross-space placement so placement is denied when collision shapes intersect."
+            )
+            var enableEntityObstructionChecks = true
         }
 
         class Advanced { // Debug configs that may be either side

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -327,8 +327,20 @@ object VSGameConfig {
     class Common {
 
         @JvmField
+        @ConfigCategory(title = "Block Placement")
+        val BLOCK_PLACEMENT = BlockPlacement()
+
+        @JvmField
         @ConfigCategory(title = "Advanced")
         val ADVANCED = Advanced()
+
+        class BlockPlacement {
+            @ConfigEntry(
+                description = "If true, VS2 block placement additionally checks ship/world/entity obstructions " +
+                    "so placement is denied when those collision shapes intersect."
+            )
+            var enableExtendedObstructionChecks = true
+        }
 
         class Advanced { // Debug configs that may be either side
             @ConfigEntry(


### PR DESCRIPTION
## What this PR does:
- [ ] Bug fix 
- [X] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**
When attempting to place blocks on ships, world blocks and entities obstruct them
When attempting to place blocks in the world, ship blocks obstruct them
Configuration for both entity and block obstructions. Block obstructions currently default to `false` because people use that functionality for cheap ways to push ships.

---

## Modloaders this PR affects:
- [X] Forge
- [X] Fabric

## Where this PR was tested:
- [X] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [X] No

---


## Additional Notes
Obstruction check bounds are slightly deflated to compensate for imprecision when a ship is laying on the ground.

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
