### PR TITLE
fix: Resolve ClassCastException (Vec3 to BlockPos) with vanilla rendering

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/vanilla_renderer/MixinLevelRendererVanilla.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/vanilla_renderer/MixinLevelRendererVanilla.java
@@ -87,22 +87,7 @@ public abstract class MixinLevelRendererVanilla implements LevelRendererDuck, Le
     @Unique
     private ShipTransform lastTransform = null;
 
-    /**
-     * Fix the distance to render chunks, so that MC doesn't think ship chunks are too far away
-     */
-    @Redirect(
-        method = "compileChunks",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/core/BlockPos;distSqr(Lnet/minecraft/core/Vec3i;)D"
-        ),
-        require = 0
-    )
-    private double includeShipChunksInNearChunks(final BlockPos b, final Vec3i v) {
-        return VSGameUtilsKt.squaredDistanceBetweenInclShips(
-            level, b.getX(), b.getY(), b.getZ(), v.getX(), v.getY(), v.getZ()
-        );
-    }
+
 
     /**
      * Force frustum update if the ship moves and the camera doesn't
@@ -209,7 +194,11 @@ public abstract class MixinLevelRendererVanilla implements LevelRendererDuck, Le
         at = @At(value = "INVOKE", target = "Lnet/minecraft/core/BlockPos;distSqr(Lnet/minecraft/core/Vec3i;)D")
     )
     private double distToShips(BlockPos from, Vec3i to, Operation<Double> distSqr){
-        return VSGameUtilsKt.squaredDistanceBetweenInclShips(level, from.getCenter(), Vec3.atCenterOf(to), distSqr);
+        Vec3 worldFrom = VSGameUtilsKt.toWorldCoordinates(level, from.getCenter());
+        Vec3 worldTo = VSGameUtilsKt.toWorldCoordinates(level, Vec3.atCenterOf(to));
+        BlockPos bpFrom = BlockPos.containing(worldFrom.x(), worldFrom.y(), worldFrom.z());
+        BlockPos bpTo = BlockPos.containing(worldTo.x(), worldTo.y(), worldTo.z());
+        return distSqr.call(bpFrom, bpTo);
     }
 
     @Inject(


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**
This PR fixes a crash that occurs when entering the game under specific conditions while using vanilla rendering. 

The game was throwing the following crash:
`java.lang.ClassCastException: class net.minecraft.world.phys.Vec3 cannot be cast to class net.minecraft.core.BlockPos`

I fixed this by converting the Vec3 world coordinates to BlockPos using BlockPos.containing() before calling the distSqr operation in the distToShips mixin.

---

## Modloaders this PR affects:
- [x] Forge
- [ ] Fabric

## Where this PR was tested:
- [ ] In-dev singleplayer
- [ ] In-dev dedicated server
- [x] Out of dev singleplayer
- [ ] GameTest framework

## Breaking Changes
- [ ] Yes (describe)
- [x] No

---

## Additional Notes
Anything else reviewers might need to know:
Hi! This is my first time contributing to this project. I found this ClassCastException bug and tried my best to fix it here. I'm not 100% sure if this is the most optimal approach for the mod's architecture, so please let me know if there's anything I should change or improve! 

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds