### PR TITLE
Fix Y velocity accumulation during horizontal collision + NaN in backOff()

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
@@ -25,7 +25,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.util.EntityDraggingInformation;
@@ -113,28 +113,23 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
     }
 
     /**
-     * This mixin replaces the following code in Entity.move().
-     *
-     * <p>if (movement.x != vec3d.x) { this.setVelocity(0.0D, vec3d2.y, vec3d2.z); } </p>
-     *
-     * <p>if (movement.z != vec3d.z) { this.setVelocity(vec3d2.x, vec3d2.y, 0.0D); } </p>
-     *
-     * <p>This code makes accurate collision with non axis-aligned surfaces impossible, so this mixin replaces it. </p>
+     * Replaces vanilla's axis-zeroing collision response with projection-based velocity removal,
+     * enabling accurate collision with non-axis-aligned ship surfaces.
      */
-    @Inject(method = "move", at = @At(
+    @WrapOperation(method = "move", at = @At(
         value = "INVOKE",
-        target = "Lnet/minecraft/world/entity/Entity;setDeltaMovement(DDD)V"),
-        locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true
-    )
-    private void redirectSetVelocity(final MoverType moverType, final Vec3 movement, final CallbackInfo callbackInfo,
-        final Vec3 movementAdjustedForCollisions) {
+        target = "Lnet/minecraft/world/entity/Entity;setDeltaMovement(DDD)V"))
+    private void redirectSetVelocity(final Entity instance, final double x, final double y, final double z,
+        final Operation<Void> original,
+        @Local(argsOnly = true) final Vec3 movement,
+        @Local(ordinal = 1) final Vec3 movementAdjustedForCollisions) {
 
         // Compute the collision response horizontal
         final Vector3dc collisionResponseHorizontal =
             new Vector3d(movementAdjustedForCollisions.x - movement.x, 0.0,
                 movementAdjustedForCollisions.z - movement.z);
 
-        // Remove the component of [movementAdjustedForCollisions] that is parallel to [collisionResponseHorizontal]
+        // Remove the component of velocity that is parallel to the collision normal
         if (collisionResponseHorizontal.lengthSquared() > 1e-6) {
             final Vec3 deltaMovement = getDeltaMovement();
 
@@ -151,10 +146,6 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
                     - collisionResponseHorizontalNormal.z() * parallelHorizontalVelocityComponent
             );
         }
-        // The rest of the move function (including tryCheckInsideBlocks) is skipped, so calling it here
-        tryCheckInsideBlocks();
-        // Cancel the original invocation of Entity.setVelocity(DDD)V to remove vanilla behavior
-        callbackInfo.cancel();
     }
 
     // endregion
@@ -294,9 +285,6 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
 
     @Shadow
     public abstract void setDeltaMovement(double x, double y, double z);
-
-    @Shadow
-    protected abstract void tryCheckInsideBlocks();
 
     @Shadow
     protected abstract Vec3 collide(Vec3 vec3d);

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityDragger.kt
@@ -311,6 +311,9 @@ object EntityDragger {
             }
         }
 
+        if (d == 0.0 && e == 0.0 && f == 0.0) {
+            return Vec3(0.0, vec3.y, 0.0)
+        }
         val motionLength = sqrt(d * d + e * e + f * f)
         return ship.shipToWorld.transformDirection(Vector3d(d, e, f)).normalize().mul(motionLength).toMinecraft()
     }


### PR DESCRIPTION
Resubmission of #1712 with an additional fix for the NaN bug that caused the revert (`7d4abed4`).

**Fix 1: Y velocity accumulation (from #1712)**

`redirectSetVelocity` in MixinEntity used `@Inject + cancel` to replace vanilla's axis-zeroing with projection-based velocity removal. `cancel()` aborted the rest of `Entity.move()` after the `setDeltaMovement(DDD)V` call, skipping `block.updateEntityAfterFallOn` (which resets Y velocity on ground contact), `walkDist` accumulation, `tryCheckInsideBlocks`, and other post-collision behavior. Without `updateEntityAfterFallOn`, Y velocity accumulated from gravity every tick while grounded. On beds, this converted into upward launches via `BedBlock.bounceUp`.

The fix replaces `@Inject + cancel` with `@WrapOperation`, wrapping only the `setDeltaMovement(DDD)V` call and letting the rest of `Entity.move()` run. Full details in #1712.

**Fix 2: NaN from zero-vector normalize in backOff()**

`EntityDragger.backOff()` transforms player movement into ship space and uses while loops to reduce the components (`d`, `e`, `f`) until `isValidWalkablePosition` returns true for each direction. When no valid position exists in any direction (typically at a ship corner while sneaking), all three reach 0.0. `Vector3d(0, 0, 0).normalize()` returns `(NaN, NaN, NaN)`, which propagates through `Entity.move()` and permanently corrupts `walkDist`, freezing view bobbing for the rest of the session.

This was masked by the old `@Inject + cancel` because `cancel()` aborted `Entity.move()` before reaching `walkDist` accumulation (bytecode offsets 515 vs 660 in `Entity.move`). Fix 1's `@WrapOperation` lets the full method run, exposing the NaN.

The fix adds a zero-vector guard after the while loops: if `d == 0.0 && e == 0.0 && f == 0.0`, return `Vec3(0.0, vec3.y, 0.0)` instead of calling `normalize()`. This preserves the gravity component while preventing the NaN.

**Known limitations of backOff()**

`backOff()` is still fundamentally flawed. The NaN guard is a symptom fix for the specific issue reported (frozen view bobbing). Known remaining issues:
- Players can't crouch to their hitbox edge on ships like vanilla allows
- Sneaking while falling onto a rotated ship shifts the player sideways
- Several architectural deviations from vanilla's `maybeBackOffFromEdge`: single-point raycasts instead of bounding box collision checks, reduces all 3 axes (d/e/f) instead of just horizontal (d/f), coordinate space mixing in the `level.clip` raycast

Tested on Fabric 1.20.1 in singleplayer. View bobbing freeze no longer occurs.

Fixes #1681