### PR TITLE
deltaMovement Y velocity buildup patch

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
@@ -174,7 +174,7 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
             target = "Lnet/minecraft/world/entity/Entity;setDeltaMovement(DDD)V"
         )
     )
-    private void CancelsetDeltaMovement(Entity instance, double d, double e, double f) {}
+    private void cancelSetDeltaMovement(Entity instance, double d, double e, double f) {}
 
 
     // region Block standing on friction and sprinting particles mixins

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
@@ -4,6 +4,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityDimensions;
@@ -23,6 +24,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
@@ -36,6 +38,18 @@ import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider;
 public abstract class MixinEntity implements IEntityDraggingInformationProvider {
 
     // region collision
+
+    @Shadow
+    protected abstract BlockPos getBlockPosBelowThatAffectsMyMovement();
+
+    @Shadow
+    public abstract BlockPos blockPosition();
+
+    @Shadow
+    public abstract void setDeltaMovement(Vec3 vec3);
+
+    @Shadow
+    public abstract void sendSystemMessage(Component component);
 
     @Shadow
     public boolean hasImpulse;
@@ -136,7 +150,7 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
 
         // Remove the component of [movementAdjustedForCollisions] that is parallel to [collisionResponseHorizontal]
         if (collisionResponseHorizontal.lengthSquared() > 1e-6) {
-            final Vec3 deltaMovement = getDeltaMovement();
+            final Vec3 deltaMovement = this.getDeltaMovement();
 
             final Vector3dc collisionResponseHorizontalNormal = collisionResponseHorizontal.normalize(new Vector3d());
             final double parallelHorizontalVelocityComponent =
@@ -144,20 +158,24 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
                     .dot(deltaMovement.x, 0.0, deltaMovement.z);
 
             setDeltaMovement(
-                deltaMovement.x
-                    - collisionResponseHorizontalNormal.x() * parallelHorizontalVelocityComponent,
+                deltaMovement.x - collisionResponseHorizontalNormal.x() * parallelHorizontalVelocityComponent,
                 deltaMovement.y,
-                deltaMovement.z
-                    - collisionResponseHorizontalNormal.z() * parallelHorizontalVelocityComponent
+                deltaMovement.z - collisionResponseHorizontalNormal.z() * parallelHorizontalVelocityComponent
             );
         }
-        // The rest of the move function (including tryCheckInsideBlocks) is skipped, so calling it here
-        tryCheckInsideBlocks();
-        // Cancel the original invocation of Entity.setVelocity(DDD)V to remove vanilla behavior
-        callbackInfo.cancel();
     }
-
     // endregion
+
+    @Redirect(
+        method = "move",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/entity/Entity;setDeltaMovement(DDD)V",
+            ordinal = 0
+        )
+    )
+    private void fish(Entity instance, double d, double e, double f) {} //cancel the target without cancelling the move method
+
 
     // region Block standing on friction and sprinting particles mixins
     @Unique

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
@@ -166,7 +166,7 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
     }
     // endregion
 
-    // this cancels the actual setDeltaMovement. We can't cancel it in the @Inject, that cancels the entire move function
+    // This cancels the actual setDeltaMovement. We can't cancel it in the @Inject, that cancels the entire move function. Somehow this doesn't interfere with the @Inject, crazy.
     @Redirect(
         method = "move",
         at = @At(

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/entity_collision/MixinEntity.java
@@ -166,15 +166,15 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
     }
     // endregion
 
+    // this cancels the actual setDeltaMovement. We can't cancel it in the @Inject, that cancels the entire move function
     @Redirect(
         method = "move",
         at = @At(
             value = "INVOKE",
-            target = "Lnet/minecraft/world/entity/Entity;setDeltaMovement(DDD)V",
-            ordinal = 0
+            target = "Lnet/minecraft/world/entity/Entity;setDeltaMovement(DDD)V"
         )
     )
-    private void fish(Entity instance, double d, double e, double f) {} //cancel the target without cancelling the move method
+    private void CancelsetDeltaMovement(Entity instance, double d, double e, double f) {}
 
 
     // region Block standing on friction and sprinting particles mixins


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix 

**Explain what this PR is doing:**
Prevents deltaMovement Y axis buildup when moving into a solid object.

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer


## Breaking Changes
- [x] No

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
