### PR TITLE
Update MixinLevelRendererVanilla.java

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/vanilla_renderer/MixinLevelRendererVanilla.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/vanilla_renderer/MixinLevelRendererVanilla.java
@@ -231,14 +231,14 @@ public abstract class MixinLevelRendererVanilla implements LevelRendererDuck, Le
         }
     }
 
-    // If ships stop rendering try uncommenting this line.
-//    @WrapOperation(
-//        method = "*",
-//        at = @At(value = "INVOKE", target = "Lnet/minecraft/core/BlockPos;distSqr(Lnet/minecraft/core/Vec3i;)D")
-//    )
-//    private double distToShips(BlockPos from, Vec3i to, Operation<Double> distSqr){
-//        return VSGameUtilsKt.squaredDistanceBetweenInclShips(level, from.getCenter(), Vec3.atCenterOf(to), distSqr);
-//    }
+    @WrapOperation(
+        method = "*",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/core/BlockPos;distSqr(Lnet/minecraft/core/Vec3i;)D"),
+        require = 0
+    )
+    private double distToShips(BlockPos from, Vec3i to, Operation<Double> distSqr){
+        return VSGameUtilsKt.squaredDistanceBetweenInclShips(level, from.getCenter(), Vec3.atCenterOf(to), distSqr);
+    }
 
     @Inject(
         method = "*",

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/vanilla_renderer/MixinLevelRendererVanilla.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/vanilla_renderer/MixinLevelRendererVanilla.java
@@ -231,13 +231,14 @@ public abstract class MixinLevelRendererVanilla implements LevelRendererDuck, Le
         }
     }
 
-    @WrapOperation(
-        method = "*",
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/core/BlockPos;distSqr(Lnet/minecraft/core/Vec3i;)D")
-    )
-    private double distToShips(BlockPos from, Vec3i to, Operation<Double> distSqr){
-        return VSGameUtilsKt.squaredDistanceBetweenInclShips(level, from.getCenter(), Vec3.atCenterOf(to), distSqr);
-    }
+    // If ships stop rendering try uncommenting this line.
+//    @WrapOperation(
+//        method = "*",
+//        at = @At(value = "INVOKE", target = "Lnet/minecraft/core/BlockPos;distSqr(Lnet/minecraft/core/Vec3i;)D")
+//    )
+//    private double distToShips(BlockPos from, Vec3i to, Operation<Double> distSqr){
+//        return VSGameUtilsKt.squaredDistanceBetweenInclShips(level, from.getCenter(), Vec3.atCenterOf(to), distSqr);
+//    }
 
     @Inject(
         method = "*",

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/vanilla_renderer/MixinLevelRendererVanilla.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/vanilla_renderer/MixinLevelRendererVanilla.java
@@ -231,15 +231,6 @@ public abstract class MixinLevelRendererVanilla implements LevelRendererDuck, Le
         }
     }
 
-    @WrapOperation(
-        method = "*",
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/core/BlockPos;distSqr(Lnet/minecraft/core/Vec3i;)D"),
-        require = 0
-    )
-    private double distToShips(BlockPos from, Vec3i to, Operation<Double> distSqr){
-        return VSGameUtilsKt.squaredDistanceBetweenInclShips(level, from.getCenter(), Vec3.atCenterOf(to), distSqr);
-    }
-
     @Inject(
         method = "*",
         at = @At(


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**
This PR comments out a line which caused the issues described in #1763. The line had the error 'Cannot resolve any target instructions in target class'.

Vanilla code
```
if (this.minecraft.options.prioritizeChunkUpdates().get() == PrioritizeChunkUpdates.NEARBY) { //type 2
    BlockPos blockPos2 = renderChunk.getOrigin().offset(8, 8, 8);
    bl = blockPos2.distSqr(blockPos) < (double)768.0F || renderChunk.isDirtyFromPlayer(); //this call caused the crash
} else if (this.minecraft.options.prioritizeChunkUpdates().get() == PrioritizeChunkUpdates.PLAYER_AFFECTED) {
    bl = renderChunk.isDirtyFromPlayer();
}
```
---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework (I tested this and it failed, however my change doesn't affect it!)


## Breaking Changes
- [ ] Yes (describe)
- [x] No

---


## Additional Notes
Anything else reviewers might need to know:
The line didn't appear to affect ship rendering, but if a proper VS dev could verify this it would be appreciated.
---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
