### PR TITLE
prevent log spam that happens when player paused the game before the first tick

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinServerGamePacketListenerImpl.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinServerGamePacketListenerImpl.java
@@ -3,7 +3,6 @@ package org.valkyrienskies.mod.mixin.feature.spawn_player_on_ship;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
-import net.minecraft.client.Minecraft;
 import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -12,6 +11,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.valkyrienskies.mod.common.util.EntityShipCollisionUtils;
+import org.valkyrienskies.mod.util.MinecraftClientHelper;
 
 @Mixin(ServerGamePacketListenerImpl.class)
 public abstract class MixinServerGamePacketListenerImpl {
@@ -37,7 +37,7 @@ public abstract class MixinServerGamePacketListenerImpl {
     private void injectHandleMovePlayer(final ServerboundMovePlayerPacket packet, final CallbackInfo ci) {
         if (EntityShipCollisionUtils.isCollidingWithUnloadedShips(this.player)) {
             ci.cancel();
-            if (this.player.getServer().isSingleplayer() && Minecraft.getInstance().isPaused()) {
+            if (this.player.getServer().isSingleplayer() && MinecraftClientHelper.isSinglePlayerPaused()) {
                 // Prevent log spam when player paused the world while ship loading
                 // (e.g. player is on a ship when they loading a world, and they unfocused the game that the world will be paused from the first tick)
                 return;

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinServerGamePacketListenerImpl.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/spawn_player_on_ship/MixinServerGamePacketListenerImpl.java
@@ -3,6 +3,7 @@ package org.valkyrienskies.mod.mixin.feature.spawn_player_on_ship;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.client.Minecraft;
 import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -36,6 +37,11 @@ public abstract class MixinServerGamePacketListenerImpl {
     private void injectHandleMovePlayer(final ServerboundMovePlayerPacket packet, final CallbackInfo ci) {
         if (EntityShipCollisionUtils.isCollidingWithUnloadedShips(this.player)) {
             ci.cancel();
+            if (this.player.getServer().isSingleplayer() && Minecraft.getInstance().isPaused()) {
+                // Prevent log spam when player paused the world while ship loading
+                // (e.g. player is on a ship when they loading a world, and they unfocused the game that the world will be paused from the first tick)
+                return;
+            }
             LOGGER.warn("{} moved while colliding with unloaded ships!", this.player.getName().getString());
             this.teleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(),
                 this.player.getXRot());

--- a/common/src/main/java/org/valkyrienskies/mod/util/MinecraftClientHelper.java
+++ b/common/src/main/java/org/valkyrienskies/mod/util/MinecraftClientHelper.java
@@ -1,0 +1,14 @@
+package org.valkyrienskies.mod.util;
+
+import net.minecraft.client.Minecraft;
+
+/**
+ * A helper class to prevent minecraft client only classes be loaded in common mixin
+ */
+public final class MinecraftClientHelper {
+    private MinecraftClientHelper() {}
+
+    public static boolean isSinglePlayerPaused() {
+        return Minecraft.getInstance().isPaused();
+    }
+}


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**
Prevent a log spam tha happens when player is on a ship when they loading a world, and they unfocused the game that the world will be paused from the first tick

```
<player name> moved while colliding with unloaded ships!
```

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [ ] In-dev singleplayer
- [ ] In-dev dedicated server
- [x] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [x] No

---


## Additional Notes
Anything else reviewers might need to know:
Performance concerns, edge cases, etc

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
