### PR TITLE
Duct tape fix for carved pumpkins breaking assembly

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/fix_blockstate_null_checks/MixinCarvedPumpkinBlock.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/fix_blockstate_null_checks/MixinCarvedPumpkinBlock.java
@@ -1,0 +1,23 @@
+package org.valkyrienskies.mod.mixin.feature.fix_blockstate_null_checks;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.world.level.block.CarvedPumpkinBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+// Might become redundant if assembly is rewritten in some different way.
+@Mixin(CarvedPumpkinBlock.class)
+public class MixinCarvedPumpkinBlock {
+    // This mixin is not a thing of honor... no highly esteemed deed is commemorated here... nothing valued is here.
+    // As this block is relocated to a ship (assembly) it runs a check for spawning a golem.
+    // The check involves checking blockstates of neighboring blocks which might be null, leading to a NPE.
+    @WrapOperation(method = {
+        "method_51167", "method_51168"
+    }, at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/state/BlockState;isAir()Z"))
+    private static boolean nullCheck(BlockState instance, Operation<Boolean> original) {
+        if (instance == null) return false;
+        return original.call(instance);
+    }
+}

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -57,6 +57,7 @@
     "feature.entity_movement_packets.MixinServerEntity",
     "feature.explosions.MixinExplosion",
     "feature.fire_between_ship_and_world.LavaFluidMixin",
+    "feature.fix_blockstate_null_checks.MixinCarvedPumpkinBlock",
     "feature.fluid_escaping_ship_config.MixinFlowingFluid",
     "feature.fluid_escaping_ship_config.MixinVineBlock",
     "feature.get_entities.MixinLevel",


### PR DESCRIPTION
Total duct tape btw, the real reason is blockstates being null so if assy is somehow done differently next time this might be redundant

This would be necessary both for pumpkins and wither skulls but the real offender is blockState.isAir() check which is done later in process for wither spawning (and a wither skull would fail the block pattern test anyway) but right in the beginning of iron golem pattern