### PR TITLE
Add theatrical compat

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/theatrical/MixinFixtureRenderer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/theatrical/MixinFixtureRenderer.java
@@ -2,27 +2,36 @@ package org.valkyrienskies.mod.mixin.mod_compat.theatrical;
 
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import dev.imabad.theatrical.blockentities.light.BaseLightBlockEntity;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.Vec3i;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
 @Mixin(targets = {"dev.imabad.theatrical.client.blockentities.FixtureRenderer$1"})
-public class MixinFixtureRenderer {
-    @WrapOperation(
-        method = "render",
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;atLowerCornerOf(Lnet/minecraft/core/Vec3i;)Lnet/minecraft/world/phys/Vec3;"),
-        remap = false
-    )
-    private static Vec3 wrapAtCornerOf(Vec3i vec3i, Operation<Vec3> original) {
-        Level level = Minecraft.getInstance().level;
-        if (level == null) return original.call(vec3i);
+public class MixinFixtureRenderer<T extends BaseLightBlockEntity> {
 
-        return VSGameUtilsKt.toWorldCoordinates(level, original.call(vec3i));
+    @Redirect(
+        method = "render",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/phys/Vec3;atLowerCornerOf(Lnet/minecraft/core/Vec3i;)Lnet/minecraft/world/phys/Vec3;"
+        )
+    )
+    private Vec3 redirectAtLowerCornerOf(Vec3i pos) {
+        Level level = Minecraft.getInstance().level;
+
+        Vec3 vanilla = Vec3.atLowerCornerOf(pos);
+
+        if (level == null) {
+            return vanilla;
+        }
+
+        return VSGameUtilsKt.toWorldCoordinates(level, vanilla);
     }
 
     @WrapMethod(

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/theatrical/MixinMovingLightRenderer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/theatrical/MixinMovingLightRenderer.java
@@ -2,27 +2,34 @@ package org.valkyrienskies.mod.mixin.mod_compat.theatrical;
 
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.Vec3i;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
 @Mixin(targets = {"dev.imabad.theatrical.client.blockentities.MovingLightRenderer$1"})
 public class MixinMovingLightRenderer {
-    @WrapOperation(
+    @Redirect(
         method = "render",
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;atLowerCornerOf(Lnet/minecraft/core/Vec3i;)Lnet/minecraft/world/phys/Vec3;"),
-        remap = false
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/phys/Vec3;atLowerCornerOf(Lnet/minecraft/core/Vec3i;)Lnet/minecraft/world/phys/Vec3;"
+        )
     )
-    private static Vec3 wrapAtCornerOf(Vec3i vec3i, Operation<Vec3> original) {
+    private Vec3 redirectAtLowerCornerOf(Vec3i pos) {
         Level level = Minecraft.getInstance().level;
-        if (level == null) return original.call(vec3i);
 
-        return VSGameUtilsKt.toWorldCoordinates(level, original.call(vec3i));
+        Vec3 vanilla = Vec3.atLowerCornerOf(pos);
+
+        if (level == null) {
+            return vanilla;
+        }
+
+        return VSGameUtilsKt.toWorldCoordinates(level, vanilla);
     }
 
     @WrapMethod(


### PR DESCRIPTION
## What this PR does:
- [x] Compat with another mod

**Explain what this PR is doing:**

This pull request adds some basic compat for the lights from the mod [theatrical](https://modrinth.com/mod/theatrical)

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [x] Out of dev singleplayer
- [ ] GameTest framework

---


## Additional Notes

Before:
<img width="1918" height="1047" alt="image" src="https://github.com/user-attachments/assets/5a25ab01-b09e-4e4c-9269-0ac8dee73b72" />

After:
<img width="838" height="468" alt="image" src="https://github.com/user-attachments/assets/faa640b7-c9a5-4690-9959-37f5472d80b7" />

(the beam being very wide on the right-most spotlight is intended behaviour)

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
