### PR TITLE
Embeddium crash with Vista compat fixed

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/ValkyrienCommonMixinConfigPlugin.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/ValkyrienCommonMixinConfigPlugin.java
@@ -141,6 +141,10 @@ public class ValkyrienCommonMixinConfigPlugin implements IMixinConfigPlugin {
             return LoadedMods.getAlexCaves();
         }
 
+        if (mixinClassName.equals("org.valkyrienskies.mod.mixin.mod_compat.vista.LevelRendererCameraStateMixin")) {
+            return renderer == VSRenderer.VANILLA;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
LevelRendererMixin is not applied when renderer is Sodium, so no need to cache the chunks on there.

## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**


---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [x] No

---


## Additional Notes
Anything else reviewers might need to know:
Performance concerns, edge cases, etc

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
