### PR TITLE
Add sodium options menu

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/compat/SodiumDummyOptionsStorage.java
+++ b/common/src/main/java/org/valkyrienskies/mod/compat/SodiumDummyOptionsStorage.java
@@ -1,0 +1,20 @@
+package org.valkyrienskies.mod.compat;
+
+import me.jellysquid.mods.sodium.client.gui.options.storage.OptionStorage;
+
+/**
+ * Sodium requires an options storage, but we don't actually use it (we set config values instead)
+ * So we use this as a dummy.
+ */
+public class SodiumDummyOptionsStorage implements OptionStorage<String> {
+
+    @Override
+    public String getData() {
+        return "";
+    }
+
+    @Override
+    public void save() {
+
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/sodium/MixinSodiumOptionsGUI.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/sodium/MixinSodiumOptionsGUI.java
@@ -1,0 +1,33 @@
+package org.valkyrienskies.mod.mixin.mod_compat.sodium;
+
+
+import java.util.List;
+import me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.mod.compat.SodiumOptionsMenu;
+
+@Mixin(SodiumOptionsGUI.class)
+public class MixinSodiumOptionsGUI extends Screen {
+    @Shadow(remap = false)
+    @Final
+    private List<Object> pages;
+
+    protected MixinSodiumOptionsGUI(Component component) {
+        super(component);
+    }
+
+    @Dynamic
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void lambdynlights$onInit(Screen prevScreen, CallbackInfo ci) {
+        this.pages.add(SodiumOptionsMenu.INSTANCE.makeSodiumOptionPage());
+    }
+
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/compat/SodiumOptionsMenu.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/compat/SodiumOptionsMenu.kt
@@ -1,0 +1,113 @@
+package org.valkyrienskies.mod.compat
+
+import com.google.common.collect.ImmutableList
+import me.jellysquid.mods.sodium.client.gui.options.OptionGroup
+import me.jellysquid.mods.sodium.client.gui.options.OptionImpl
+import me.jellysquid.mods.sodium.client.gui.options.OptionPage
+import me.jellysquid.mods.sodium.client.gui.options.control.ControlValueFormatter
+import me.jellysquid.mods.sodium.client.gui.options.control.CyclingControl
+import me.jellysquid.mods.sodium.client.gui.options.control.SliderControl
+import me.jellysquid.mods.sodium.client.gui.options.control.TickBoxControl
+import net.minecraft.network.chat.Component
+import net.minecraftforge.common.ForgeConfigSpec
+import org.valkyrienskies.core.internal.config.VsiConfigModelCategory
+import org.valkyrienskies.core.internal.config.VsiConfigModelEntry
+import org.valkyrienskies.mod.api.config.VSConfigApi
+import org.valkyrienskies.mod.common.config.VSConfigUpdater
+import org.valkyrienskies.mod.common.config.VSGameConfig
+
+object SodiumOptionsMenu {
+    // We ignore this storage, but we have to pass _something_
+    val ops = SodiumDummyOptionsStorage()
+
+    fun makeSodiumOptionPage(): OptionPage {
+        val groups = mutableListOf<OptionGroup>()
+
+        val clientConfig = VSConfigApi.buildVSConfigModel(VSGameConfig.CLIENT)
+
+        buildSodiumConfigSpec(clientConfig.root, groups)
+
+        return OptionPage(Component.translatable("itemGroup.valkyrienSkies"), ImmutableList.copyOf(groups))
+    }
+
+    fun buildSodiumConfigSpec(configCategory: VsiConfigModelCategory, groups: MutableList<OptionGroup>) {
+        val currentBuilder = OptionGroup.createBuilder()
+
+        for (node in configCategory.children) {
+            val entry = node.value
+            if (entry is VsiConfigModelCategory) {
+                buildSodiumConfigSpec(entry, groups)
+            } else if (entry is VsiConfigModelEntry<*>) {
+                val definedNode = defineNode(entry)
+                definedNode?.let {
+                    currentBuilder.add(it.build())
+                }
+            }
+        }
+        groups.add(currentBuilder.build())
+    }
+
+    private fun defineNode(
+        entry: VsiConfigModelEntry<*>
+    ): OptionImpl.Builder<*, *>? {
+
+        @Suppress("UNCHECKED_CAST")
+        fun <T : Enum<T>> defineEnum(): OptionImpl.Builder<String, T> {
+            val enumClass = entry.default!!::class.java as Class<T>
+
+            return OptionImpl.createBuilder(enumClass, ops)
+                .setName(Component.literal(entry.name))
+                .setTooltip(Component.literal(entry.description ?: ""))
+                .setBinding(
+                    { _, value -> setConfigOption(entry.name, value) },
+                    { entry.getValue.invoke() as T? }
+                ).setControl { option ->
+                    CyclingControl(option, enumClass)
+                }
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        fun defineBoolean(): OptionImpl.Builder<String, Boolean> {
+            return OptionImpl.createBuilder(Boolean::class.java, ops)
+                .setName(Component.literal(entry.name))
+                .setTooltip(Component.literal(entry.description ?: ""))
+                .setBinding(
+                    { _, value -> setConfigOption(entry.name, value) },
+                    { entry.getValue.invoke() as Boolean }
+                )
+                .setControl(::TickBoxControl)
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        fun defineInt(min: Int, max: Int): OptionImpl.Builder<String, Int> {
+            return OptionImpl.createBuilder(Int::class.java, ops)
+                .setName(Component.literal(entry.name))
+                .setTooltip(Component.literal(entry.description ?: ""))
+                .setBinding(
+                    { _, value -> setConfigOption(entry.name, value) },
+                    { entry.getValue.invoke() as Int }
+                )
+                .setControl { option ->
+                    SliderControl(option, min, max, 1, ControlValueFormatter.number())
+                }
+        }
+
+        return when (entry.getValue()) {
+
+            is Int -> {
+                val e = entry as VsiConfigModelEntry<Int>
+                defineInt(e.min ?: 0, e.max ?: 10)
+            }
+
+            is Boolean -> defineBoolean() as OptionImpl.Builder<*, *>
+
+            is Enum<*> -> defineEnum() as OptionImpl.Builder<*, *>
+
+            else -> null
+        }
+    }
+
+    fun <T> setConfigOption(key: String, value: T) {
+        (VSConfigUpdater.forgeConfigValuesMap.get(key) as ForgeConfigSpec.ConfigValue<T>).set(value)
+    }
+}

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -330,6 +330,7 @@
     "mod_compat.sodium.MixinChunkTracker",
     "mod_compat.sodium.MixinRenderSection",
     "mod_compat.sodium.MixinRenderSectionManager",
+    "mod_compat.sodium.MixinSodiumOptionsGUI",
     "mod_compat.sodium.MixinSodiumWorldRenderer",
     "mod_compat.sodium.RenderSectionManagerAccessor",
     "mod_compat.sound_physics_remastered.MixinSoundPhysics",


### PR DESCRIPTION
Our entire client config (not counting the core client config) is now parsed and loaded as an extra page on the sodium/embeddium visual settings menu.

## What this PR does:
- [x] Compat with another mod

**Explain what this PR is doing:**

This PR adds compat for sodium/embeddium so that all our client config options show up as a settings page in visual settings.

---

<img width="1447" height="787" alt="image" src="https://github.com/user-attachments/assets/62258a9c-9506-4c18-93c6-1769bcad025d" />

**Sodium** (GUI scale auto)

Some options are cut off, but this is a sodium bug

<img width="1398" height="787" alt="image" src="https://github.com/user-attachments/assets/a63c1ab7-a441-403c-bae1-7dca36165658" />

**Sodium** (GUI scale 1)
All options can be seen on GUI scale 1 or 2. Only auto is broken.

<img width="1444" height="787" alt="image" src="https://github.com/user-attachments/assets/490e133f-98ee-499f-bd5d-67d4e3f0a0b5" />

**Sodium + Reeses Sodium Options**
All options can be seen using the scrollbar

<img width="1443" height="787" alt="image" src="https://github.com/user-attachments/assets/abec17ad-a869-4934-a8b6-1d463337269c" />

**Sodium + Reeses Sodium Options + Sodium Options API**
All options can be seen using the scrollbar, and the VS logo is shown

<img width="853" height="479" alt="image" src="https://github.com/user-attachments/assets/f72f4fc8-0223-46e0-bbe1-7423ab31ff5d" />

**Embeddium**
Same as reeses + options api, but without those installed.

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [x] Out of dev singleplayer
- [ ] GameTest framework

---


## Additional Notes

It will only add client config options which are int, bool, or enum to the options screen. Sodium doesn't have a built in way to configure floats, doubles, longs or strings.

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
