### PR TITLE
1.20.1/fix riding view vector

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/client/MixinCamera.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/client/MixinCamera.java
@@ -2,6 +2,7 @@ package org.valkyrienskies.mod.mixin.client;
 
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
@@ -160,28 +161,33 @@ public abstract class MixinCamera implements IVSCamera {
         return original.call();
     }
 
+    /**
+     * @author Bunting_chj
+     * @reason This Injection will modify the Camera position to transform the eye offset with the ship player is mounted on.
+     *  Funny thing that original code doesn't utilize getEyePosition().
+     */
+    @WrapOperation(
+        method = "setup",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Camera;setPosition(DDD)V")
+    )
+    private void setPosition(Camera camera, double d, double e, double f, Operation<Void> original){
+        if(VSGameUtilsKt.getShipMountedTo(this.entity) instanceof ClientShip ship) {
+            double eyeHeight = Mth.lerp(f, this.eyeHeightOld, this.eyeHeight);
+            Vector3d eyeOffset = ship.getRenderTransform().getRotation().transform(new Vector3d(0, eyeHeight, 0));
+            original.call(camera, d + eyeOffset.x, e - eyeHeight + eyeOffset.y, f + eyeOffset.z);
+        }
+        else original.call(camera, d, e, f);
+    }
+
     @Override
     public void setupWithShipMounted(final @NotNull BlockGetter level, final @NotNull Entity renderViewEntity,
         final boolean thirdPerson, final boolean thirdPersonReverse, final float partialTicks,
         final @NotNull ClientShip shipMountedTo, final @NotNull Vector3dc inShipPlayerPosition) {
-        final ShipTransform renderTransform = shipMountedTo.getRenderTransform();
-        final Vector3dc playerBasePos =
-            renderTransform.getShipToWorldMatrix().transformPosition(inShipPlayerPosition, new Vector3d());
-        final Vector3dc playerEyePos = renderTransform.getShipCoordinatesToWorldCoordinatesRotation()
-            .transform(new Vector3d(0.0, Mth.lerp(partialTicks, this.eyeHeightOld, this.eyeHeight), 0.0))
-            .add(playerBasePos);
-
         this.initialized = true;
         this.level = level;
         this.entity = renderViewEntity;
         this.detached = thirdPerson;
-        this.setRotationWithShipTransform(renderViewEntity.getViewYRot(partialTicks),
-            renderViewEntity.getViewXRot(partialTicks), renderTransform);
-        this.setPosition(playerEyePos.x(), playerEyePos.y(), playerEyePos.z());
         if (thirdPerson) {
-            if (thirdPersonReverse) {
-                this.setRotationWithShipTransform(this.yRot + 180.0F, -this.xRot, renderTransform);
-            }
 
             final AABBi boundingBox = (AABBi) shipMountedTo.getShipVoxelAABB();
 

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/client/player/MixinLocalPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/client/player/MixinLocalPlayer.java
@@ -1,32 +1,21 @@
 package org.valkyrienskies.mod.mixin.client.player;
 
-import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.util.Mth;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.valkyrienskies.core.api.ships.Ship;
-import org.valkyrienskies.mod.common.VSGameUtilsKt;
-import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 import org.valkyrienskies.mod.mixinducks.client.player.LocalPlayerDuck;
 
 @Mixin(LocalPlayer.class)
 public abstract class MixinLocalPlayer extends LivingEntity implements LocalPlayerDuck {
-    @Shadow
-    private float yRotLast;
-    @Shadow
-    private float xRotLast;
     @Unique
     private Vec3 lastPosition = null;
     @Unique
@@ -62,30 +51,5 @@ public abstract class MixinLocalPlayer extends LivingEntity implements LocalPlay
             this.velocity = new Vector3d(pos.x - this.lastPosition.x, pos.y - this.lastPosition.y, pos.z - this.lastPosition.z);
         }
         this.lastPosition = pos;
-    }
-
-    @WrapMethod(
-        method = "startRiding(Lnet/minecraft/world/entity/Entity;Z)Z"
-    )
-    private boolean adjustLookOnMount(Entity entity, boolean bl, Operation<Boolean> original) {
-        Vector3d lookVector = VectorConversionsMCKt.toJOML(this.getLookAngle());
-        if(original.call(entity, bl)) {
-            Ship ship = VSGameUtilsKt.getShipMountedTo(Entity.class.cast(this));
-            if (ship != null) {
-                final Vector3d transformedLook = ship.getTransform().getWorldToShip().transformDirection(lookVector);
-                final double yaw = Math.atan2(-transformedLook.x, transformedLook.z) * 180.0 / Math.PI;
-                final double pitch = Math.atan2(-transformedLook.y, Math.sqrt((transformedLook.x * transformedLook.x) + (transformedLook.z * transformedLook.z))) * 180.0 / Math.PI;
-                this.setYRot((float) yaw);
-                this.setXRot((float) pitch);
-                this.yRotO = this.getYRot();
-                this.yRotLast = this.getYRot();
-                this.yHeadRot = this.getYRot();
-                this.yHeadRotO = this.getYRot();
-                this.xRotO = this.getXRot();
-                this.xRotLast = this.getXRot();
-            }
-            return true;
-        }
-        return false;
     }
 }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/client/renderer/MixinGameRenderer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/client/renderer/MixinGameRenderer.java
@@ -12,6 +12,7 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix3f;
@@ -96,10 +97,18 @@ public abstract class MixinGameRenderer {
     public HitResult modifyCrosshairTargetBlocks(final Entity receiver, final double maxDistance, final float tickDelta,
         final boolean includeFluids, final Operation<HitResult> pick) {
 
-        final HitResult original = entityRaycastNoTransform(receiver, maxDistance, tickDelta, includeFluids);
-        ((MinecraftDuck) this.minecraft).vs$setOriginalCrosshairTarget(original);
-
-        return pick.call(receiver, maxDistance, tickDelta, includeFluids);
+        HitResult result = pick.call(receiver, maxDistance, tickDelta, includeFluids);
+        HitResult noTransform;
+        if(result instanceof BlockHitResult blockHitResult) {
+            noTransform = new BlockHitResult(
+                VSGameUtilsKt.toShipRenderCoordinates(Minecraft.getInstance().level, blockHitResult.getBlockPos().getCenter(), blockHitResult.location),
+                blockHitResult.getDirection(),
+                blockHitResult.getBlockPos(),
+                blockHitResult.isInside()
+            );
+        } else noTransform = result;
+        ((MinecraftDuck) this.minecraft).vs$setOriginalCrosshairTarget(noTransform);
+        return result;
     }
 
     @WrapOperation(

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/client/renderer/MixinGameRenderer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/client/renderer/MixinGameRenderer.java
@@ -3,7 +3,6 @@ package org.valkyrienskies.mod.mixin.client.renderer;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
@@ -15,10 +14,7 @@ import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
-import org.joml.Matrix3f;
 import org.joml.Matrix4f;
-import org.joml.Quaterniond;
-import org.joml.Quaternionf;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.joml.primitives.AABBdc;
@@ -298,19 +294,6 @@ public abstract class MixinGameRenderer {
             clientShip,
             shipMountedToData.getMountPosInShip()
         );
-
-        // Apply the ship render transform to [matrixStack]
-        final Quaternionf invShipRenderRotation = new Quaternionf(
-            clientShip.getRenderTransform().getShipToWorldRotation().conjugate(new Quaterniond())
-        );
-        matrixStack.mulPose(invShipRenderRotation);
-
-        // We also need to recompute [inverseViewRotationMatrix] after updating [matrixStack]
-        {
-            final Matrix3f matrix3f = new Matrix3f(matrixStack.last().normal());
-            matrix3f.invert();
-            RenderSystem.setInverseViewRotationMatrix(matrix3f);
-        }
 
         // Camera FOV changes based on the position of the camera, so recompute FOV to account for the change of camera
         // position.

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/entity/MixinEntity.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/entity/MixinEntity.java
@@ -10,7 +10,6 @@ import net.minecraft.CrashReportCategory;
 import net.minecraft.ReportedException;
 import net.minecraft.core.BlockPos;
 import net.minecraft.tags.TagKey;
-import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
@@ -275,62 +274,6 @@ public abstract class MixinEntity implements IEntityDraggingInformationProvider 
         );
         final Vec3 newEyePos = VectorConversionsMCKt.toMinecraft(basePos.add(eyeRelativePos, new Vector3d()));
         cir.setReturnValue(newEyePos);
-    }
-
-    /**
-     * @reason Used to be needed for players to pick blocks correctly when mounted to a ship
-     *
-     * Additionally, this has to have dragging information included or it breaks. This is because of reasons that I literally
-     * do not know or understand, but minecraft's rendering pipeline is like that.
-     */
-    @Inject(method = "calculateViewVector", at = @At("HEAD"), cancellable = true)
-    private void preCalculateViewVector(final float xRot, final float yRot, final CallbackInfoReturnable<Vec3> cir) {
-        final LoadedShip shipMountedTo = VSGameUtilsKt.getShipMountedTo(Entity.class.cast(this));
-        if (shipMountedTo == null) {
-//            if (Entity.class.cast(this) instanceof final ServerPlayer sPlayer && sPlayer instanceof final IEntityDraggingInformationProvider dragProvider) {
-//                if (dragProvider.getDraggingInformation().isEntityBeingDraggedByAShip() && dragProvider.getDraggingInformation().getServerRelativePlayerYaw() != null) {
-//                    final Ship shipDraggedBy = VSGameUtilsKt.getAllShips(level).getById(dragProvider.getDraggingInformation().getLastShipStoodOn());
-//                    if (shipDraggedBy != null) {
-//                        final float realYRot = (float) EntityDragger.INSTANCE.serversideWorldEyeRotationOrDefault(sPlayer, shipDraggedBy, yRot);
-//                        final float f = xRot * (float) (Math.PI / 180.0);
-//                        final float g = -realYRot * (float) (Math.PI / 180.0);
-//                        final float h = Mth.cos(g);
-//                        final float i = Mth.sin(g);
-//                        final float j = Mth.cos(f);
-//                        final float k = Mth.sin(f);
-//                        final Vector3dc originalViewVector = new Vector3d(i * j, -k, h * j);
-//
-//                        final ShipTransform shipTransform;
-//                        if (shipDraggedBy instanceof ClientShip) {
-//                            shipTransform = ((ClientShip) shipDraggedBy).getRenderTransform();
-//                        } else {
-//                            shipTransform = shipDraggedBy.getShipTransform();
-//                        }
-//                        final Vec3 newViewVector = VectorConversionsMCKt.toMinecraft(
-//                            shipTransform.getShipCoordinatesToWorldCoordinatesRotation().transform(originalViewVector, new Vector3d()));
-//                        cir.setReturnValue(newViewVector);
-//                    }
-//                }
-//            }
-            return;
-        }
-        final float f = xRot * (float) (Math.PI / 180.0);
-        final float g = -yRot * (float) (Math.PI / 180.0);
-        final float h = Mth.cos(g);
-        final float i = Mth.sin(g);
-        final float j = Mth.cos(f);
-        final float k = Mth.sin(f);
-        final Vector3dc originalViewVector = new Vector3d(i * j, -k, h * j);
-
-        final ShipTransform shipTransform;
-        if (shipMountedTo instanceof ClientShip) {
-            shipTransform = ((ClientShip) shipMountedTo).getRenderTransform();
-        } else {
-            shipTransform = shipMountedTo.getTransform();
-        }
-        final Vec3 newViewVector = VectorConversionsMCKt.toMinecraft(
-            shipTransform.getShipToWorldRotation().transform(originalViewVector, new Vector3d()));
-        cir.setReturnValue(newViewVector);
     }
 
     /**

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinLivingEntityRenderer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/shipyard_entities/MixinLivingEntityRenderer.java
@@ -1,0 +1,122 @@
+package org.valkyrienskies.mod.mixin.feature.shipyard_entities;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.LivingEntityRenderer;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.LivingEntity;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.valkyrienskies.core.api.ships.ClientShip;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+/**
+ * Because {@link MixinEntityRenderDispatcher} transforms the Entity according to Ship Transform,
+ *  living Entities are rendered to be looking at different direction than they are supposed to.
+ *  to correct that, this mixin will modify the rendered rotation of the living entities
+ *  by recalculating the angles from the look vector.
+ * @author Bunting_chj
+ */
+@Mixin(LivingEntityRenderer.class)
+public class MixinLivingEntityRenderer {
+    @Inject(
+        method = "render(Lnet/minecraft/world/entity/LivingEntity;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
+        at = @At("HEAD")
+    )
+    private void calcBodyRotation(LivingEntity livingEntity, float f, float g, PoseStack poseStack,
+        MultiBufferSource multiBufferSource, int i, CallbackInfo ci, @Share("eulerDegrees")
+        LocalRef<Vector3f> eulerDegrees, @Share("eulerDegreesOld")
+        LocalRef<Vector3f> eulerDegreesOld) {
+        if (VSGameUtilsKt.getShipMountedTo(livingEntity) instanceof ClientShip ship) {
+            Quaternionf rotation = new Quaternionf(ship.getRenderTransform().getRotation()).invert();
+            Vector3f lookVector = livingEntity.getViewVector(1.0f).toVector3f();
+            Vector3f lookVectorOld = livingEntity.getViewVector(0.0f).toVector3f();
+            lookVector.rotate(rotation);
+            lookVectorOld.rotate(rotation);
+            Vector3f zero = new Vector3f(0, 0, 1);
+            eulerDegrees.set(zero.rotationTo(lookVector, new Quaternionf()).getEulerAnglesYXZ(new Vector3f()).mul(Mth.RAD_TO_DEG));
+            eulerDegreesOld.set(zero.rotationTo(lookVectorOld, new Quaternionf()).getEulerAnglesYXZ(new Vector3f()).mul(Mth.RAD_TO_DEG));
+        }
+    }
+
+    @WrapOperation(
+        method = "render(Lnet/minecraft/world/entity/LivingEntity;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
+        at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/LivingEntity;yHeadRot:F", opcode = Opcodes.GETFIELD)
+    )
+    private float modifyYHeadRot(LivingEntity livingEntity, Operation<Float> original, @Share("eulerDegrees")
+    LocalRef<Vector3f> eulerDegrees){
+        if(eulerDegrees.get() != null) {
+            return -eulerDegrees.get().y;
+        }
+        else return original.call(livingEntity);
+    }
+
+    @WrapOperation(
+        method = "render(Lnet/minecraft/world/entity/LivingEntity;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
+        at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/LivingEntity;yHeadRotO:F", opcode = Opcodes.GETFIELD)
+    )
+    private float modifyYHeadRotOld(LivingEntity livingEntity, Operation<Float> original, @Share("eulerDegreesOld")
+    LocalRef<Vector3f> eulerDegreesOld){
+        if(eulerDegreesOld.get() != null) {
+            return -eulerDegreesOld.get().y;
+        }
+        else return original.call(livingEntity);
+    }
+
+    @WrapOperation(
+        method = "render(Lnet/minecraft/world/entity/LivingEntity;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
+        at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/LivingEntity;yBodyRot:F", opcode = Opcodes.GETFIELD)
+    )
+    private float modifyYBodyRot(LivingEntity livingEntity, Operation<Float> original, @Share("eulerDegrees")
+    LocalRef<Vector3f> eulerDegrees){
+        if(eulerDegrees.get() != null) {
+            return original.call(livingEntity) - livingEntity.yHeadRot - eulerDegrees.get().y;
+        }
+        else return original.call(livingEntity);
+    }
+
+    @WrapOperation(
+        method = "render(Lnet/minecraft/world/entity/LivingEntity;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
+        at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/LivingEntity;yBodyRotO:F", opcode = Opcodes.GETFIELD)
+    )
+    private float modifyYBodyRotOld(LivingEntity livingEntity, Operation<Float> original, @Share("eulerDegreesOld")
+    LocalRef<Vector3f> eulerDegreesOld){
+        if(eulerDegreesOld.get() != null) {
+            return original.call(livingEntity) - livingEntity.yHeadRotO - eulerDegreesOld.get().y;
+        }
+        else return original.call(livingEntity);
+    }
+
+    @WrapOperation(
+        method = "render(Lnet/minecraft/world/entity/LivingEntity;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;getXRot()F")
+    )
+    private float modifyXRot(LivingEntity livingEntity, Operation<Float> original, @Share("eulerDegrees")
+    LocalRef<Vector3f> eulerDegrees){
+        if(eulerDegrees.get() != null) {
+            return eulerDegrees.get().x;
+        }
+        else return original.call(livingEntity);
+    }
+
+    @WrapOperation(
+        method = "render(Lnet/minecraft/world/entity/LivingEntity;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
+        at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/LivingEntity;xRotO:F", opcode = Opcodes.GETFIELD)
+    )
+    private float modifyXRotOld(LivingEntity livingEntity, Operation<Float> original, @Share("eulerDegreesOld")
+    LocalRef<Vector3f> eulerDegreesOld){
+        if(eulerDegreesOld.get() != null) {
+            return eulerDegreesOld.get().x;
+        }
+        else return original.call(livingEntity);
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/command/level/MixinServerPlayer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/command/level/MixinServerPlayer.java
@@ -17,7 +17,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider;
-import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 
 @Mixin(ServerPlayer.class)
 public abstract class MixinServerPlayer extends Player {
@@ -58,13 +57,6 @@ public abstract class MixinServerPlayer extends Player {
         final Ship ship = VSGameUtilsKt.getShipManagingPos(level, x, y, z);
         if (ship != null) {
             ci.cancel();
-
-            Vector3d lookVector = VectorConversionsMCKt.toJOML(this.getLookAngle());
-            final Vector3d transformedLook = ship.getTransform().getShipToWorld().transformDirection(lookVector);
-            final double yaw = Math.atan2(-transformedLook.x, transformedLook.z) * 180.0 / Math.PI;
-            final double pitch = Math.atan2(-transformedLook.y, Math.sqrt((transformedLook.x * transformedLook.x) + (transformedLook.z * transformedLook.z))) * 180.0 / Math.PI;
-            this.setYRot((float) yaw);
-            this.setXRot((float) pitch);
 
             //Predict the position 2 ticks ahead for dismount
             final Vector3d inWorld = ship.getTransform().getShipToWorld().transformPosition(x, y, z, new Vector3d());

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -281,6 +281,7 @@
     "feature.shipyard_entities.MixinClientLevel",
     "feature.shipyard_entities.MixinEntityRenderDispatcher",
     "feature.shipyard_entities.MixinEntityRenderer",
+    "feature.shipyard_entities.MixinLivingEntityRenderer",
     "feature.sound.client.MixinAbstractTickableSoundInstance",
     "feature.sound.client.MixinChannel",
     "feature.sound.client.MixinListener",


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix 
- [x] Code refactor / improvement
- [x] Compat with another mod

**Explain what this PR is doing:**
1. Misalignment of looking direction
When VS renders mounted(seated on ship) entities, it will transform the entities with rotation of the ship.
This caused look vector and rendered looking direction of entities to misalign, so previously this was fixed by also rotating the view vector (and camera rotation of players) of said entities. Although this was fine for many cases, some mechanics and other mods, e.g. compass direction and minimap markers, uses raw values stored for yaw and pitch of entities. Following image is one of such occasions, nameTags and other sprites being misaligned.<img width="1920" height="1111" alt="2026-04-30_21 09 23" src="https://github.com/user-attachments/assets/2333851a-6d23-41db-8b0a-3976c0b01291" />To resolve this, this PR will preserve the original view vector and instead change the rendered rotation of living entities, by calculating the yaw and pitch from the ship transform and entities' view vector. By this way, other codes can safely refer to consistent view vector and rotation angles, while also getting the rendered rotation right.

2. Order of Entity.pick() in MixinGameRenderer
This is mainly done for Shoulder Surfing reloaded compatibility. Previous code has separately executed raycast operation to get untransformed(in shipyard) location of hit result to use on interactions. But when the Entity.pick() was modified by other mods to be using different raycast trace, rendered target of crosshair and actual position used for interactions didn't match.
This PR will remove the separate raycasting, and use the result of Entity.pick() by creating a copy of block hit result that has untransformed location instead. 
---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] Out of dev singleplayer


## Breaking Changes
- [x] Yes (describe)
---
This PR will change the view vector and rendered rotation of entities mounted to a ship. This will fix many occasions of misalignment in player/entity direction. Also, this can possibly affect other codes that rotates the entities on a ship, causing another bug, although none was found during testing.
Compatible with Shoulder surfing reloaded(modified to remove the incompatibility notation).

## Additional Notes
Anything else reviewers might need to know:
Performance concerns, edge cases, etc
---
Might break other codes that separately dealt with entity rotation.
Might have priority issue with other mixins to the Entity.pick() method.

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
