### PR TITLE
fix(fabric): skip Fabric ModifyArg on processUnloads when C2ME chunk-system rewrite is present

### DIFF
--- a/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/ValkyrienSkiesFabricMixinPlugin.java
+++ b/fabric/src/main/java/org/valkyrienskies/mod/fabric/mixin/ValkyrienSkiesFabricMixinPlugin.java
@@ -8,6 +8,10 @@ import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import org.valkyrienskies.mod.compat.LoadedMods;
 
 public class ValkyrienSkiesFabricMixinPlugin implements IMixinConfigPlugin {
+    private static final String FABRIC_SHIPYARD_ENTITY_MANAGER_MIXIN =
+        "org.valkyrienskies.mod.fabric.mixin.feature.shipyard_entities.MixinPersistentEntitySectionManager";
+    private static final String C2ME_CHUNK_SYSTEM_ENTITY_MANAGER_MIXIN =
+        "com.ishland.c2me.rewrites.chunksystem.mixin.fixes.MixinServerEntityManager";
 
     private static boolean classExists(final String className) {
         try {
@@ -31,6 +35,14 @@ public class ValkyrienSkiesFabricMixinPlugin implements IMixinConfigPlugin {
     @Override
     public boolean shouldApplyMixin(final String s, final String mixinClassName) {
         final boolean isMixinBoosterLoaded = classExists("io.github.steelwoolmc.mixintransmog.MixinModlauncherRemapper");
+
+        // C2ME rewrites PersistentEntitySectionManager.processUnloads() and removes the vanilla LongSet.removeIf
+        // call that the Fabric-only VS patch targets. The common VS mixin already replaces processUnloads()
+        // safely, so skip only this redundant Fabric patch when C2ME's chunk-system rewrite is present.
+        if (FABRIC_SHIPYARD_ENTITY_MANAGER_MIXIN.equals(mixinClassName)
+            && classExists(C2ME_CHUNK_SYSTEM_ENTITY_MANAGER_MIXIN)) {
+            return false;
+        }
 
         if (mixinClassName.contains("org.valkyrienskies.mod.fabric.mixin.compat.old_create")) {
             return LoadedMods.getOldCreate();


### PR DESCRIPTION
### What kind of change is this?

- [x] Bug fix
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [x] Compat with another mod

---

### Description

`MixinPersistentEntitySectionManager` (Fabric-only) contains a `@ModifyArg` that wraps the `LongSet.removeIf` call inside `PersistentEntitySectionManager.processUnloads()` in a try-catch to prevent random crashes.

When [C2ME](https://github.com/RelativityMC/C2ME-fabric) is installed with its chunk-system rewrite enabled, `processUnloads()` is entirely replaced by `com.ishland.c2me.rewrites.chunksystem.mixin.fixes.MixinServerEntityManager`. The vanilla `LongSet.removeIf` invocation no longer exists in the rewritten method body, so the `@ModifyArg` injection target is missing — causing a hard mixin conflict and crash at startup:

```
Required @ModifyArg injection in processUnloads was not found
```

The common VS mixin already replaces `processUnloads()` safely for the same purpose, so the Fabric-specific patch is redundant when C2ME's chunk-system rewrite is active.

**Fix:** In `ValkyrienSkiesFabricMixinPlugin.shouldApplyMixin()`, detect C2ME's chunk-system entity manager mixin by class existence check and return `false` for `MixinPersistentEntitySectionManager` when C2ME is loaded, avoiding the injection conflict while preserving full functionality via the common mixin path.

---

### Modloaders affected

- [ ] Forge / NeoForge
- [x] Fabric

---

### Testing

- [x] In-dev dedicated server

Tested on Arclight-Fabric 1.21.1 with C2ME `0.3.0+alpha.0.5` — previously crashed at startup with the missing `@ModifyArg` error; no longer crashes after this change and ships load/unload correctly.

---

### Breaking Changes

No.

---

### Additional Notes

The class-existence check targets `com.ishland.c2me.rewrites.chunksystem.mixin.fixes.MixinServerEntityManager` — the specific C2ME mixin that replaces `processUnloads()` — so the Fabric patch continues to apply normally in all other configurations (vanilla, OptiFine, Sodium, etc.).