### PR TITLE
reduce isChunkInShipyardCompanion usage & fix sable compat

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/accessors/server/level/ChunkMapAccessor.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/accessors/server/level/ChunkMapAccessor.java
@@ -5,6 +5,7 @@ import java.util.function.BooleanSupplier;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ChunkMap.DistanceManager;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.ai.village.poi.PoiManager;
 import net.minecraft.world.level.ChunkPos;
@@ -47,4 +48,7 @@ public interface ChunkMapAccessor {
 
     @Invoker("getChunkQueueLevel")
     java.util.function.IntSupplier callGetChunkQueueLevel(long chunkPosLong);
+
+    @Accessor("level")
+    ServerLevel getLevel();
 }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/client/world/MixinClientChunkCache.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/client/world/MixinClientChunkCache.java
@@ -198,7 +198,7 @@ public abstract class MixinClientChunkCache implements ClientChunkCacheDuck {
         at = @At("HEAD"), cancellable = true)
     public void preGetChunk(final int chunkX, final int chunkZ, final ChunkStatus chunkStatus, final boolean bl,
         final CallbackInfoReturnable<LevelChunk> cir) {
-        if (!VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkX, chunkZ)) {
+        if (!VSGameUtilsKt.isChunkInShipyard(level, chunkX, chunkZ)) {
             return;
         }
         final LevelChunk shipChunk = vs$shipChunks.get(ChunkPos.asLong(chunkX, chunkZ));

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinChunkMapClose.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinChunkMapClose.java
@@ -4,6 +4,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ChunkTaskPriorityQueueSorter;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ThreadedLevelLightEngine;
 import net.minecraft.world.entity.ai.village.poi.PoiManager;
 import net.minecraft.world.level.ChunkPos;
@@ -16,6 +17,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.mod.common.VS2ChunkAllocator;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
 /**
  * Safety-net fix for the "Saving World" hang.
@@ -41,6 +43,7 @@ public class MixinChunkMapClose {
     @Shadow @Final private java.util.Queue<Runnable> unloadQueue;
     @Shadow @Final private ChunkTaskPriorityQueueSorter queueSorter;
     @Shadow @Final ChunkMap.DistanceManager distanceManager;
+    @Shadow @Final private ServerLevel level;
 
     @Inject(method = "hasWork", at = @At("HEAD"), cancellable = true)
     private void vs$hasWorkSkipShipyard(CallbackInfoReturnable<Boolean> cir) {
@@ -53,7 +56,7 @@ public class MixinChunkMapClose {
             long key = entry.getLongKey();
             int cx = ChunkPos.getX(key);
             int cz = ChunkPos.getZ(key);
-            if (!VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(cx, cz)) {
+            if (!VSGameUtilsKt.isChunkInShipyard(level, cx, cz)) {
                 hasNonShipyard = true;
                 break;
             }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinChunkMapScheduleUnload.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinChunkMapScheduleUnload.java
@@ -5,6 +5,7 @@ import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ChunkMap;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -13,6 +14,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.valkyrienskies.mod.common.VS2ChunkAllocator;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
 /**
  * Fast-paths shipyard chunk unloads. Two interventions; they work together.
@@ -53,12 +55,16 @@ public abstract class MixinChunkMapScheduleUnload {
     @Final
     private LongSet toDrop;
 
+    @Shadow
+    @Final
+    private ServerLevel level;
+
     @Inject(method = "scheduleUnload", at = @At("HEAD"), cancellable = true)
     private void vs$fastScheduleUnloadForShipyard(final long chunkPos, final ChunkHolder holder,
                                                   final CallbackInfo ci) {
         final int cx = ChunkPos.getX(chunkPos);
         final int cz = ChunkPos.getZ(chunkPos);
-        if (!VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(cx, cz)) return;
+        if (!VSGameUtilsKt.isChunkInShipyard(level, cx, cz)) return;
 
         // Shipyard chunks on their way out: skip the whole async save + cleanup
         // chain. The only bookkeeping we have to do before returning is the
@@ -88,7 +94,7 @@ public abstract class MixinChunkMapScheduleUnload {
             final long chunkPos = it.nextLong();
             final int cx = ChunkPos.getX(chunkPos);
             final int cz = ChunkPos.getZ(chunkPos);
-            if (!VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(cx, cz)) continue;
+            if (!VSGameUtilsKt.isChunkInShipyard(level, cx, cz)) continue;
             updatingChunkMap.remove(chunkPos);
             pendingUnloads.remove(chunkPos);
             it.remove();

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinChunkMapShipyard.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinChunkMapShipyard.java
@@ -6,14 +6,18 @@ import java.util.function.IntFunction;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ChunkResult;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.mod.common.VS2ChunkAllocator;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
 /**
  * Bypasses chunk pipeline neighbor requirements for shipyard chunks.
@@ -30,6 +34,10 @@ import org.valkyrienskies.mod.common.VS2ChunkAllocator;
 @Mixin(ChunkMap.class)
 public class MixinChunkMapShipyard {
 
+    @Shadow
+    @Final
+    private ServerLevel level;
+
     @Inject(
         method = "getChunkRangeFuture",
         at = @At("HEAD"),
@@ -42,7 +50,7 @@ public class MixinChunkMapShipyard {
         if (range <= 0) return; // No neighbors needed anyway
 
         ChunkPos center = centerHolder.getPos();
-        if (!VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(center.x, center.z)) return;
+        if (!VSGameUtilsKt.isChunkInShipyard(level, center.x, center.z)) return;
 
         // For shipyard chunks, skip neighbor gathering entirely.
         // Request only the center chunk at the status required for distance 0.

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/world/MixinServerLevel.java
@@ -24,6 +24,7 @@ import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.ai.village.poi.PoiManager;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -90,7 +91,7 @@ public abstract class MixinServerLevel implements IShipObjectWorldServerProvider
     private void vs$allowShipyardBlockTicking(long packedChunkPos, CallbackInfoReturnable<Boolean> cir) {
         int chunkX = ChunkPos.getX(packedChunkPos);
         int chunkZ = ChunkPos.getZ(packedChunkPos);
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkX, chunkZ)) {
+        if (VSGameUtilsKt.isChunkInShipyard(Level.class.cast(this), chunkX, chunkZ)) {
             cir.setReturnValue(true);
         }
     }
@@ -108,7 +109,7 @@ public abstract class MixinServerLevel implements IShipObjectWorldServerProvider
     private void vs$allowShipyardPositionTicking(long packedPos, CallbackInfoReturnable<Boolean> cir) {
         int chunkX = ChunkPos.getX(packedPos);
         int chunkZ = ChunkPos.getZ(packedPos);
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkX, chunkZ)) {
+        if (VSGameUtilsKt.isChunkInShipyard(Level.class.cast(this), chunkX, chunkZ)) {
             // Unconditional true for shipyard chunks. The getChunkNow() guard we used here
             // was returning null for chunks whose ChunkHolder hadn't promoted to visibleChunkMap
             // (common for level-33 FULL tickets), causing LevelTicks.sortContainersToTick's
@@ -240,7 +241,7 @@ public abstract class MixinServerLevel implements IShipObjectWorldServerProvider
             if (worldChunk instanceof LevelChunk levelChunk) {
                 final int cx = worldChunk.getPos().x;
                 final int cz = worldChunk.getPos().z;
-                if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(cx, cz)) {
+                if (VSGameUtilsKt.isChunkInShipyard(Level.class.cast(this), cx, cz)) {
                     final ServerLevel self = ServerLevel.class.cast(this);
                     levelChunk.registerTickContainerInLevel(self);
                     self.startTickingChunk(levelChunk);
@@ -328,7 +329,7 @@ public abstract class MixinServerLevel implements IShipObjectWorldServerProvider
     private void vs$keepActiveShipChunksLoaded(final net.minecraft.world.level.chunk.LevelChunk chunk,
                                                 final CallbackInfo ci) {
         final ChunkPos pos = chunk.getPos();
-        if (!VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(pos.x, pos.z)) return;
+        if (!VSGameUtilsKt.isChunkInShipyard(Level.class.cast(this), pos.x, pos.z)) return;
         final ServerLevel self = ServerLevel.class.cast(this);
         if (org.valkyrienskies.mod.common.VSGameUtilsKt.getShipManagingPos(self, pos.x, pos.z) != null) {
             ci.cancel();
@@ -364,7 +365,7 @@ public abstract class MixinServerLevel implements IShipObjectWorldServerProvider
 
             // Shipyard chunks use FULL tickets and may never produce a ticking future.
             final ChunkPos cp = chunkHolder.getPos();
-            if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(cp.x, cp.z)) {
+            if (VSGameUtilsKt.isChunkInShipyard(Level.class.cast(this), cp.x, cp.z)) {
                 final LevelChunk cachedChunk = chunkSource.getChunkNow(cp.x, cp.z);
                 if (cachedChunk != null) {
                     vs$loadChunk(cachedChunk, voxelShapeUpdates);

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/world/chunk/MixinLevelChunk.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/world/chunk/MixinLevelChunk.java
@@ -69,7 +69,7 @@ public abstract class MixinLevelChunk extends ChunkAccess implements VSLevelChun
      */
     @Inject(method = "isTicking", at = @At("HEAD"), cancellable = true)
     private void vs$allowShipyardBlockEntityTicking(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(
+        if (VSGameUtilsKt.isChunkInShipyard(level,
                 pos.getX() >> 4, pos.getZ() >> 4)) {
             cir.setReturnValue(true);
         }
@@ -85,7 +85,7 @@ public abstract class MixinLevelChunk extends ChunkAccess implements VSLevelChun
      */
     @Inject(method = "getFullStatus", at = @At("HEAD"), cancellable = true)
     private void vs$upgradeShipyardChunkStatus(CallbackInfoReturnable<FullChunkStatus> cir) {
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(
+        if (VSGameUtilsKt.isChunkInShipyard(level,
                 this.chunkPos.x, this.chunkPos.z)) {
             cir.setReturnValue(FullChunkStatus.BLOCK_TICKING);
         }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/world/chunk/MixinServerChunkCache.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/world/chunk/MixinServerChunkCache.java
@@ -1,18 +1,27 @@
 package org.valkyrienskies.mod.mixin.world.chunk;
 
 import net.minecraft.server.level.ServerChunkCache;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.TicketType;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.mod.common.VS2ChunkAllocator;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.world.VSTicketType;
 
 @Mixin(ServerChunkCache.class)
 public class MixinServerChunkCache {
+
+    @Shadow
+    @Final
+    private ServerLevel level;
 
     /**
      * Allow shipyard chunks to be treated as "position ticking" even at ticket level 33 (FULL).
@@ -29,7 +38,7 @@ public class MixinServerChunkCache {
     private void vs$allowShipyardTicking(long pos, CallbackInfoReturnable<Boolean> cir) {
         int chunkX = ChunkPos.getX(pos);
         int chunkZ = ChunkPos.getZ(pos);
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkX, chunkZ)) {
+        if (VSGameUtilsKt.isChunkInShipyard(level, chunkX, chunkZ)) {
             // Check if the chunk is actually loaded (FULL status)
             if (((ServerChunkCache) (Object) this).getChunkNow(chunkX, chunkZ) != null) {
                 cir.setReturnValue(true);

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/world/level/chunk/MixinChunkGenerator.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/world/level/chunk/MixinChunkGenerator.java
@@ -12,6 +12,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.mod.common.VS2ChunkAllocator;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
 @Mixin(ChunkGenerator.class)
 public class MixinChunkGenerator {
@@ -19,7 +20,7 @@ public class MixinChunkGenerator {
     // tfc in forge part of the mod has a bandaid solution, if this is fixed please remove that
     @Inject(method = "findNearestMapStructure", at = @At("HEAD"), cancellable = true)
     private void preFindNearestMapFeature(ServerLevel serverLevel, HolderSet<Structure> holderSet, BlockPos blockPos, int i, boolean bl, CallbackInfoReturnable<Pair<BlockPos, Holder<Structure>>> cir) {
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(blockPos.getX() >> 4, blockPos.getZ() >> 4)) {
+        if (VSGameUtilsKt.isChunkInShipyard(serverLevel, blockPos.getX() >> 4, blockPos.getZ() >> 4)) {
             cir.setReturnValue(null);
         }
     }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/world/level/levelgen/MixinChunkStatus.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/world/level/levelgen/MixinChunkStatus.java
@@ -13,6 +13,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.mod.common.VS2ChunkAllocator;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
 @Mixin(ChunkStatusTasks.class)
 public class MixinChunkStatus {
@@ -24,7 +25,7 @@ public class MixinChunkStatus {
         final CallbackInfoReturnable<CompletableFuture<ChunkAccess>> cir
     ) {
         final ChunkPos chunkPos = chunkAccess.getPos();
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)) {
+        if (VSGameUtilsKt.isChunkInShipyard(worldGenContext.level(), chunkPos.x, chunkPos.z)) {
             cir.setReturnValue(CompletableFuture.completedFuture(chunkAccess));
         }
     }
@@ -36,7 +37,7 @@ public class MixinChunkStatus {
         final CallbackInfoReturnable<CompletableFuture<ChunkAccess>> cir
     ) {
         final ChunkPos chunkPos = chunkAccess.getPos();
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)) {
+        if (VSGameUtilsKt.isChunkInShipyard(worldGenContext.level(), chunkPos.x, chunkPos.z)) {
             worldGenContext.level().onStructureStartsAvailable(chunkAccess);
             cir.setReturnValue(CompletableFuture.completedFuture(chunkAccess));
         }
@@ -59,7 +60,7 @@ public class MixinChunkStatus {
         final CallbackInfoReturnable<CompletableFuture<ChunkAccess>> cir
     ) {
         final ChunkPos chunkPos = chunkAccess.getPos();
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)) {
+        if (VSGameUtilsKt.isChunkInShipyard(worldGenContext.level(), chunkPos.x, chunkPos.z)) {
             cir.setReturnValue(CompletableFuture.completedFuture(chunkAccess));
         }
     }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/world/level/lighting/MixinThreadedLevelLightEngine.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/world/level/lighting/MixinThreadedLevelLightEngine.java
@@ -13,6 +13,8 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.valkyrienskies.mod.common.VS2ChunkAllocator;
 
 import java.util.function.IntSupplier;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.mixin.accessors.server.level.ChunkMapAccessor;
 
 /**
  * Forces the light engine to process light updates for shipyard chunks at high priority.
@@ -42,7 +44,7 @@ public abstract class MixinThreadedLevelLightEngine {
     private IntSupplier vs$forceShipyardPriority(ChunkMap instance, long chunkPosLong) {
         int x = ChunkPos.getX(chunkPosLong);
         int z = ChunkPos.getZ(chunkPosLong);
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(x, z)) {
+        if (VSGameUtilsKt.isChunkInShipyard(((ChunkMapAccessor)instance).getLevel(), x, z)) {
             return () -> VS$FULL_CHUNK_LEVEL;
         }
         return ((org.valkyrienskies.mod.mixin.accessors.server.level.ChunkMapAccessor) instance)

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/VSGameUtils.kt
@@ -138,7 +138,7 @@ fun Level.isTickingChunk(chunkX: Int, chunkZ: Int) =
  */
 fun Level.isChunkLoadedForVS(pos: ChunkPos): Boolean {
     // For shipyard chunks, accept FULL status (level 33) — no need for ticking
-    if (VS2ChunkAllocator.isChunkInShipyardCompanion(pos.x, pos.z)) {
+    if (this.isChunkInShipyard(pos.x, pos.z)) {
         return (chunkSource as ServerChunkCache).getChunkNow(pos.x, pos.z) != null
     }
     // For world chunks, require ticking status

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/world/ChunkManagement.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/world/ChunkManagement.kt
@@ -11,6 +11,7 @@ import org.valkyrienskies.mod.common.VS2ChunkAllocator
 import org.valkyrienskies.mod.common.executeIf
 import org.valkyrienskies.mod.common.getLevelFromDimensionId
 import org.valkyrienskies.mod.common.getShipManagingPos
+import org.valkyrienskies.mod.common.isChunkInShipyard
 import org.valkyrienskies.mod.common.isChunkLoadedForVS
 import org.valkyrienskies.mod.common.isTickingChunk
 import org.valkyrienskies.mod.common.mcPlayer
@@ -34,7 +35,7 @@ object ChunkManagement {
             val chunkPos = ChunkPos(chunkWatchTask.chunkX, chunkWatchTask.chunkZ)
 
             val level = server.getLevelFromDimensionId(chunkWatchTask.dimensionId)!!
-            if (VS2ChunkAllocator.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)) {
+            if (level.isChunkInShipyard(chunkPos.x, chunkPos.z)) {
                 // Shipyard chunks use radius-0 tickets (level 33 = FULL status) to avoid
                 // loading ~25 neighbor chunks per ship chunk. The chunk pipeline's neighbor
                 // requirements are bypassed by MixinChunkMapShipyard.
@@ -43,7 +44,7 @@ object ChunkManagement {
                 level.chunkSource.updateChunkForced(chunkPos, true)
             }
 
-            val isShipyard = VS2ChunkAllocator.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)
+            val isShipyard = level.isChunkInShipyard(chunkPos.x, chunkPos.z)
             // Shipyard chunks use FULL status (level 33), so isTickingChunk never returns true.
             // Use isChunkLoadedForVS which accepts FULL status for shipyard chunks.
             val condition = if (isShipyard) {
@@ -90,7 +91,7 @@ object ChunkManagement {
 
             if (chunkUnwatchTask.shouldUnload) {
                 val level = server.getLevelFromDimensionId(chunkUnwatchTask.dimensionId)!!
-                if (VS2ChunkAllocator.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)) {
+                if (level.isChunkInShipyard(chunkPos.x, chunkPos.z)) {
                     // Only release the SHIP_CHUNK ticket if the ship that owns this chunk
                     // is actually gone. If the ship still exists (just no player watcher),
                     // keep the chunk loaded — otherwise scheduled ticks, block entities,

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/twilightforest/ChunkGeneratorTwilightMixin.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/twilightforest/ChunkGeneratorTwilightMixin.java
@@ -30,6 +30,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.mod.common.VS2ChunkAllocator;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
 @Pseudo
 @Mixin(targets = "twilightforest.world.components.chunkgenerators.ChunkGeneratorTwilight")
@@ -50,7 +51,10 @@ public class ChunkGeneratorTwilightMixin {
     @Inject(method = "buildSurface", at = @At("HEAD"), cancellable = true)
     private void preBuildSurface(WorldGenRegion world, StructureManager manager, RandomState random, ChunkAccess chunk, CallbackInfo ci) {
         final ChunkPos chunkPos = chunk.getPos();
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)) {
+        if (chunk.getLevel() == null?
+            VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z):
+            VSGameUtilsKt.isChunkInShipyard(chunk.getLevel(), chunkPos.x, chunkPos.z)
+        ) {
             ci.cancel();
         }
     }
@@ -58,7 +62,9 @@ public class ChunkGeneratorTwilightMixin {
     @Inject(method = "fillFromNoise", at = @At("HEAD"), cancellable = true)
     private void preFillFromNoise(Executor executor, Blender blender, RandomState random, StructureManager structureManager, ChunkAccess chunk, CallbackInfoReturnable<CompletableFuture<ChunkAccess>> cir) {
         final ChunkPos chunkPos = chunk.getPos();
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)) {
+        if (chunk.getLevel() == null?
+            VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z):
+            VSGameUtilsKt.isChunkInShipyard(chunk.getLevel(), chunkPos.x, chunkPos.z)) {
             cir.setReturnValue(CompletableFuture.completedFuture(chunk));
         }
     }
@@ -66,14 +72,16 @@ public class ChunkGeneratorTwilightMixin {
     @Inject(method = "createStructures", at = @At("HEAD"), cancellable = true)
     private void preCreateStructures(RegistryAccess access, ChunkGeneratorStructureState state, StructureManager manager, ChunkAccess chunk, StructureTemplateManager templateManager, CallbackInfo ci) {
         final ChunkPos chunkPos = chunk.getPos();
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z)) {
+        if (chunk.getLevel() == null?
+            VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(chunkPos.x, chunkPos.z):
+            VSGameUtilsKt.isChunkInShipyard(chunk.getLevel(), chunkPos.x, chunkPos.z)) {
             ci.cancel();
         }
     }
 
     @Inject(method = "findNearestMapStructure", at = @At("HEAD"), cancellable = true)
     private void preFindNearestMapStructure(ServerLevel level, HolderSet<Structure> targetStructures, BlockPos pos, int searchRadius, boolean skipKnownStructures, CallbackInfoReturnable cir) {
-        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(pos.getX() >> 4, pos.getZ() >> 4)) {
+        if (VSGameUtilsKt.isChunkInShipyard(level, pos.getX() >> 4, pos.getZ() >> 4)) {
             cir.setReturnValue(null);
         }
     }


### PR DESCRIPTION
## What this PR does:
- [X] Bug fix 
- [ ] Feature
- [X] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**

replace some isChunkInShipyardCompanion usage by VSGameUtilsKt.isChunkInShipyard
fix sable subLevel not showing after reloading due to MixinClientChunkCache using isChunkInShipyardCompanion

---

## Modloaders this PR affects:
- [X] Forge
- [X] Fabric

## Where this PR was tested:
- [X] In-dev singleplayer
- [X] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [X] No

---


## Additional Notes
Anything else reviewers might need to know:
Performance concerns, edge cases, etc

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
