### PR TITLE
Lightning and lightning effects on ships

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/world_weather/MixinLightningBolt.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/world_weather/MixinLightningBolt.java
@@ -1,0 +1,44 @@
+package org.valkyrienskies.mod.mixin.feature.world_weather;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.LightningBolt;
+import org.joml.Vector3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.valkyrienskies.core.api.ships.Ship;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider;
+
+@Mixin(LightningBolt.class)
+public abstract class MixinLightningBolt {
+
+    private Ship vs2$draggedShip() {
+        final LightningBolt self = (LightningBolt) (Object) this;
+        final var info = ((IEntityDraggingInformationProvider) (Object) self).getDraggingInformation();
+        final Long shipId = info.getLastShipStoodOn();
+        if (!info.isEntityBeingDraggedByAShip() || shipId == null) return null;
+        return VSGameUtilsKt.getAllShips(self.level()).getById(shipId);
+    }
+
+    private BlockPos vs2$worldBlockToShipyard(BlockPos world, Ship ship) {
+        final Vector3d s = ship.getWorldToShip().transformPosition(
+            new Vector3d(world.getX() + 0.5, world.getY() + 0.5, world.getZ() + 0.5));
+        return BlockPos.containing(s.x, s.y, s.z);
+    }
+
+    @ModifyReturnValue(method = "getStrikePosition", at = @At("RETURN"))
+    private BlockPos vs2$strikePosInShipyard(BlockPos original) {
+        final Ship ship = vs2$draggedShip();
+        return ship == null ? original : vs2$worldBlockToShipyard(original, ship);
+    }
+
+    @WrapOperation(method = "spawnFire", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LightningBolt;blockPosition()Lnet/minecraft/core/BlockPos;"))
+    private BlockPos vs2$firePosInShipyard(LightningBolt self, Operation<BlockPos> original) {
+        final BlockPos world = original.call(self);
+        final Ship ship = vs2$draggedShip();
+        return ship == null ? world : vs2$worldBlockToShipyard(world, ship);
+    }
+}

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/world_weather/MixinLightningBolt.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/world_weather/MixinLightningBolt.java
@@ -32,7 +32,8 @@ public abstract class MixinLightningBolt {
     @ModifyReturnValue(method = "getStrikePosition", at = @At("RETURN"))
     private BlockPos vs2$strikePosInShipyard(BlockPos original) {
         final Ship ship = vs2$draggedShip();
-        return ship == null ? original : vs2$worldBlockToShipyard(original, ship);
+        if (ship == null) return original;
+        return vs2$worldBlockToShipyard(((LightningBolt) (Object) this).blockPosition().below(), ship);
     }
 
     @WrapOperation(method = "spawnFire", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LightningBolt;blockPosition()Lnet/minecraft/core/BlockPos;"))

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/world_weather/MixinServerLevel.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/world_weather/MixinServerLevel.java
@@ -9,17 +9,44 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.entity.LightningBolt;
 import net.minecraft.world.level.biome.Biome.Precipitation;
 import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.Heightmap.Types;
+import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.CompatUtil;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
+import org.valkyrienskies.mod.common.util.IEntityDraggingInformationProvider;
 
 @Mixin(ServerLevel.class)
 public abstract class MixinServerLevel {
+
+    @WrapOperation(method = "tickChunk", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;findLightningTargetAround(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/BlockPos;"))
+    private BlockPos vs2$lightningTargetIncludingShips(
+        ServerLevel level, BlockPos pos, Operation<BlockPos> original,
+        @Local(argsOnly = true) LevelChunk chunk
+    ) {
+        if (VSGameUtilsKt.getShipManagingPos(level, chunk.getPos()) == null) {
+            return original.call(level, pos);
+        }
+        return CompatUtil.INSTANCE.getWorldHeightmapPosIncludingShips(level, Heightmap.Types.MOTION_BLOCKING, pos);
+    }
+
+    @WrapOperation(method = "tickChunk", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LightningBolt;moveTo(Lnet/minecraft/world/phys/Vec3;)V"))
+    private void vs2$attachLightningBoltToShip(
+        LightningBolt bolt, Vec3 pos, Operation<Void> original,
+        @Local(argsOnly = true) LevelChunk chunk
+    ) {
+        original.call(bolt, pos);
+        Ship ship = VSGameUtilsKt.getShipManagingPos(bolt.level(), chunk.getPos());
+        if (ship != null) {
+            ((IEntityDraggingInformationProvider) (Object) bolt).vs$dragImmediately(ship);
+        }
+    }
 
     @WrapOperation(method = "tickChunk", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;getHeightmapPos(Lnet/minecraft/world/level/levelgen/Heightmap$Types;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/BlockPos;"))
     private BlockPos occlude(

--- a/common/src/main/resources/valkyrienskies-common.mixins.json
+++ b/common/src/main/resources/valkyrienskies-common.mixins.json
@@ -100,6 +100,7 @@
     "feature.world_border.MixinLevel",
     "feature.world_border.MixinWorldBorder",
     "feature.world_weather.MixinBiome",
+    "feature.world_weather.MixinLightningBolt",
     "feature.world_weather.MixinMeltingBlocks",
     "feature.world_weather.MixinServerLevel",
     "mod_compat.alex_caves.MixinNuclearExplosion",


### PR DESCRIPTION
## What this PR does:
- [X] Bug fix 
- [X] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

Allows lightning to spawn on ships and allows lightning effects (fire, copper stripping) on ships.
Uses ship inclusive heightmap to spawn only on the top sides of ships regardless of rotation


---

## Modloaders this PR affects:
- [X] Forge
- [X] Fabric

## Where this PR was tested:
- [X] In-dev singleplayer
- [ ] In-dev dedicated server
- [X] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [X] No

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
