### PR TITLE
Better explosion interactions with ships

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/explosions/MixinExplosion.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/explosions/MixinExplosion.java
@@ -2,6 +2,7 @@ package org.valkyrienskies.mod.mixin.feature.explosions;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import net.minecraft.core.BlockPos;
@@ -10,12 +11,12 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult.Type;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
+import org.joml.primitives.AABBd;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -26,6 +27,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.valkyrienskies.core.api.ships.LoadedServerShip;
 import org.valkyrienskies.core.api.ships.ServerShip;
+import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.core.impl.config.VSCoreConfig;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.ValkyrienSkiesMod;
@@ -56,14 +58,69 @@ public abstract class MixinExplosion {
     @Final
     @Mutable
     private float radius;
+
     @Unique
-    private boolean isModifyingExplosion = false;
+    private List<Ship> vs2$intersectingShips = Collections.emptyList();
+    @Unique
+    private final Vector3d vs2$tmpShipPos = new Vector3d();
 
     @Shadow
     public abstract void explode();
 
+    @Inject(method = "explode", at = @At("HEAD"))
+    private void vs2$cacheIntersectingShips(final CallbackInfo ci) {
+        if (this.level == null || this.radius <= 0.0F) {
+            this.vs2$intersectingShips = Collections.emptyList();
+            return;
+        }
+        final AABBd aabb = new AABBd(
+            this.x - this.radius, this.y - this.radius, this.z - this.radius,
+            this.x + this.radius, this.y + this.radius, this.z + this.radius
+        );
+        final List<Ship> ships = new ArrayList<>();
+        for (final Ship ship : VSGameUtilsKt.getShipsIntersecting(this.level, aabb)) {
+            ships.add(ship);
+        }
+        this.vs2$intersectingShips = ships;
+    }
+
+    @WrapOperation(
+        method = "explode",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/core/BlockPos;containing(DDD)Lnet/minecraft/core/BlockPos;"
+        )
+    )
+    private BlockPos vs2$frameAwareBlockPos(final double wx, final double wy, final double wz,
+                                            final Operation<BlockPos> operation) {
+        for (int i = 0, n = this.vs2$intersectingShips.size(); i < n; i++) {
+            final Ship ship = this.vs2$intersectingShips.get(i);
+            if (!ship.getWorldAABB().containsPoint(wx, wy, wz)) {
+                continue;
+            }
+            this.vs2$tmpShipPos.set(wx, wy, wz);
+            ship.getWorldToShip().transformPosition(this.vs2$tmpShipPos);
+            final BlockPos shipBlockPos = BlockPos.containing(
+                this.vs2$tmpShipPos.x, this.vs2$tmpShipPos.y, this.vs2$tmpShipPos.z
+            );
+            if (!this.level.getBlockState(shipBlockPos).isAir()) {
+                return shipBlockPos;
+            }
+        }
+        return operation.call(wx, wy, wz);
+    }
+
+    @Inject(method = "explode", at = @At("TAIL"))
+    private void vs2$afterExplode(final CallbackInfo ci) {
+        try {
+            vs2$doExplodeForce();
+        } finally {
+            this.vs2$intersectingShips = Collections.emptyList();
+        }
+    }
+
     @Unique
-    private void doExplodeForce() {
+    private void vs2$doExplodeForce() {
         if (this.level.isClientSide) {
             return;
         }
@@ -119,33 +176,6 @@ public abstract class MixinExplosion {
         }
     }
 
-    @Inject(at = @At("TAIL"), method = "explode")
-    private void afterExplode(final CallbackInfo ci) {
-        if (isModifyingExplosion) {
-            doExplodeForce();
-            return;
-        }
-
-        isModifyingExplosion = true;
-
-        final double origX = this.x;
-        final double origY = this.y;
-        final double origZ = this.z;
-
-        VSGameUtilsKt.transformToNearbyShipsAndWorld(this.level, this.x, this.y, this.z, this.radius, (x, y, z) -> {
-            this.x = x;
-            this.y = y;
-            this.z = z;
-            this.explode();
-        });
-
-        this.x = origX;
-        this.y = origY;
-        this.z = origZ;
-
-        isModifyingExplosion = false;
-    }
-
     @WrapOperation(
         method = "getSeenPercent",
         at = @At(
@@ -168,23 +198,4 @@ public abstract class MixinExplosion {
         }
         return operation.call(from, to, blockClip, fluidClip, source);
     }
-
-    // Don't raytrace the shipyard
-    // getEntities already gives shipyard entities
-    @WrapOperation(
-        method = "explode",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/Level;getEntities(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Ljava/util/List;"
-        )
-    )
-    private List<Entity> noRayTrace(final Level instance, final Entity entity, final AABB aabb,
-        final Operation<List<Entity>> getEntities) {
-        if (isModifyingExplosion) {
-            return Collections.emptyList();
-        } else {
-            return getEntities.call(instance, entity, aabb);
-        }
-    }
-
 }

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/explosions/MixinExplosion.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/explosions/MixinExplosion.java
@@ -15,7 +15,6 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult.Type;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3d;
-import org.joml.Vector3dc;
 import org.joml.primitives.AABBd;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -33,7 +32,6 @@ import org.valkyrienskies.mod.common.VSGameUtilsKt;
 import org.valkyrienskies.mod.common.ValkyrienSkiesMod;
 import org.valkyrienskies.mod.common.config.VSGameConfig;
 import org.valkyrienskies.mod.common.util.GameToPhysicsAdapter;
-import org.valkyrienskies.mod.common.util.VectorConversionsMCKt;
 
 @Mixin(Explosion.class)
 public abstract class MixinExplosion {
@@ -124,52 +122,57 @@ public abstract class MixinExplosion {
         if (this.level.isClientSide) {
             return;
         }
-        // Custom forces
-        final Vector3d originPos = new Vector3d(this.x, this.y, this.z);
-        final BlockPos explodePos = BlockPos.containing(originPos.x(), originPos.y(), originPos.z());
+        final Vec3 origin = new Vec3(this.x, this.y, this.z);
         final int radius = (int) Math.ceil(this.radius);
-        for (int x = radius; x >= -radius; x--) {
-            for (int y = radius; y >= -radius; y--) {
-                for (int z = radius; z >= -radius; z--) {
-                    final BlockHitResult result = level.clip(
-                        new ClipContext(Vec3.atCenterOf(explodePos),
-                            Vec3.atCenterOf(explodePos.offset(x, y, z)),
-                            ClipContext.Block.COLLIDER,
-                            ClipContext.Fluid.NONE, null));
-                    if (result.getType() == Type.BLOCK) {
-                        final BlockPos blockPos = result.getBlockPos();
-                        final LoadedServerShip ship = VSGameUtilsKt.getLoadedShipManagingPos((ServerLevel) this.level, blockPos);
-                        if (ship != null) {
-                            final Vector3d forceVector =
-                                VectorConversionsMCKt.toJOML(
-                                    Vec3.atCenterOf(explodePos)); //Start at center position
-                            final Double distanceMult = Math.max(0.5, 1.0 - (this.radius /
-                                forceVector.distance(VectorConversionsMCKt.toJOML(Vec3.atCenterOf(blockPos)))));
-                            final Double powerMult = Math.max(0.1, this.radius / 4); //TNT blast radius = 4
+        final double blastForce = VSGameConfig.SERVER.getExplosionBlastForce();
+        final double powerMult = Math.max(0.1, this.radius / 4.0); // TNT blast radius = 4
+        for (int x = -radius; x <= radius; x++) {
+            for (int y = -radius; y <= radius; y++) {
+                for (int z = -radius; z <= radius; z++) {
+                    if (x == 0 && y == 0 && z == 0) {
+                        continue;
+                    }
+                    final BlockHitResult result = this.level.clip(new ClipContext(
+                        origin,
+                        new Vec3(this.x + x, this.y + y, this.z + z),
+                        ClipContext.Block.COLLIDER,
+                        ClipContext.Fluid.NONE,
+                        null));
+                    if (result.getType() != Type.BLOCK) {
+                        continue;
+                    }
+                    final LoadedServerShip ship =
+                        VSGameUtilsKt.getLoadedShipManagingPos((ServerLevel) this.level, result.getBlockPos());
+                    if (ship == null) {
+                        continue;
+                    }
 
-                            forceVector.sub(VectorConversionsMCKt.toJOML(
-                                Vec3.atCenterOf(blockPos))); //Subtract hit block pos to get direction
-                            forceVector.normalize();
-                            forceVector.mul(-1 *
-                                VSGameConfig.SERVER.getExplosionBlastForce()); //Multiply by blast force at center position. Negative because of how we got the direction.
-                            forceVector.mul(distanceMult); //Multiply by distance falloff
-                            forceVector.mul(powerMult); //Multiply by radius, roughly equivalent to power
+                    // clipIncludeShips back-projects ship hits to world coordinates here.
+                    final Vec3 hitWorld = result.getLocation();
+                    final double dx = hitWorld.x - this.x;
+                    final double dy = hitWorld.y - this.y;
+                    final double dz = hitWorld.z - this.z;
+                    final double distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+                    if (distance < 1.0e-9 || distance >= this.radius * 2.0) {
+                        continue;
+                    }
+                    // Vanilla's entity knockback falloff: linear from 1.0 at center to 0.0 at 2*radius.
+                    final double distanceMult = 1.0 - distance / (this.radius * 2.0);
+                    final double scale = blastForce * powerMult * distanceMult / distance;
+                    final Vector3d forceInWorld = new Vector3d(dx * scale, dy * scale, dz * scale);
+                    if (!forceInWorld.isFinite()) {
+                        continue;
+                    }
+                    final Vector3d posInWorld = new Vector3d(hitWorld.x, hitWorld.y, hitWorld.z);
 
-                            Vector3dc modelPos = VectorConversionsMCKt.toJOML(Vec3.atCenterOf(blockPos));
+                    final GameToPhysicsAdapter forceApplier =
+                        ValkyrienSkiesMod.getOrCreateGTPA(ship.getChunkClaimDimension());
+                    forceApplier.applyWorldForce(ship.getId(), forceInWorld, posInWorld);
 
-                            if (VSCoreConfig.SERVER.getSp().getEnableSplitting()) {
-                                //custom split logic for TNT specifically
-                                ValkyrienSkiesMod.splitHandler.split(level, ship.getId(), (ServerShip ship1) -> ValkyrienSkiesMod.getOrCreateGTPA(ship.getChunkClaimDimension()).applyWorldForceToModelPos(
-                                        ship1.getId(), forceVector, ship1.getTransform().getWorldToShip().transformPosition(ship.getTransform().getShipToWorld().transformPosition(modelPos, new Vector3d())
-                                    )));
-                            }
-
-                            final GameToPhysicsAdapter forceApplier = ValkyrienSkiesMod.getOrCreateGTPA(ship.getChunkClaimDimension());
-                            if (forceVector.isFinite()) {
-                                forceApplier.applyWorldForceToModelPos(ship.getId(), forceVector,
-                                    VectorConversionsMCKt.toJOML(Vec3.atCenterOf(blockPos)));
-                            }
-                        }
+                    if (VSCoreConfig.SERVER.getSp().getEnableSplitting()) {
+                        // custom split logic for TNT specifically
+                        ValkyrienSkiesMod.splitHandler.split(this.level, ship.getId(), (ServerShip split) ->
+                            forceApplier.applyWorldForce(split.getId(), forceInWorld, posInWorld));
                     }
                 }
             }


### PR DESCRIPTION
## What this PR does:
- [X] Bug fix 
- [X] Feature
- [X] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

This restructures explosions so that they can be obstructed by ships and vice versa
Also refactors explosion blast force so that it actually works the way it should, with proper falloff. May need re-tuning of default blast force config?
Theoretically has performance improvements as well since it doesn't duplicate the *whole* explosion per ship.


---

## Modloaders this PR affects:
- [X] Forge
- [X] Fabric

## Where this PR was tested:
- [X] In-dev singleplayer
- [ ] In-dev dedicated server
- [X] Out of dev singleplayer
- [ ] GameTest framework

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
