### PR TITLE
World border and void fixes

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/ValkyrienSkiesMod.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/ValkyrienSkiesMod.kt
@@ -33,11 +33,13 @@ import org.valkyrienskies.core.internal.VsiCoreClient
 import org.valkyrienskies.mod.api.BlockEntityPhysicsListener
 import org.valkyrienskies.mod.api.EntityPhysicsListener
 import org.valkyrienskies.mod.api.SeatedControllingPlayer
+import org.valkyrienskies.mod.api.dimensionId
 import org.valkyrienskies.mod.api.getShipManagingBlock
 import org.valkyrienskies.mod.api_impl.events.VsApiImpl
 import org.valkyrienskies.mod.common.blockentity.TestAntigravBlockEntity
 import org.valkyrienskies.mod.common.blockentity.TestHingeBlockEntity
 import org.valkyrienskies.mod.common.blockentity.TestThrusterBlockEntity
+import org.valkyrienskies.mod.common.config.DimensionParametersResolver
 import org.valkyrienskies.mod.common.entity.ShipMountingEntity
 import org.valkyrienskies.mod.common.entity.VSPhysicsEntity
 import org.valkyrienskies.mod.common.jackson.BlockPosDeserializer
@@ -50,6 +52,7 @@ import org.valkyrienskies.mod.common.util.GameToPhysicsAdapter
 import org.valkyrienskies.mod.common.util.ShipSettings
 import org.valkyrienskies.mod.common.util.SplitHandler
 import org.valkyrienskies.mod.common.util.SplittingDisablerAttachment
+import org.valkyrienskies.mod.common.util.VoidAttachment
 import org.valkyrienskies.mod.common.util.WorldBorderAttachment
 import org.valkyrienskies.mod.mixinducks.client.world.ClientChunkCacheDuck
 import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck
@@ -147,14 +150,22 @@ object ValkyrienSkiesMod {
         }
         core.registerAttachment(BuoyancyHandlerAttachment::class.java)
         core.registerAttachment(WorldBorderAttachment::class.java)
+        core.registerAttachment(VoidAttachment::class.java)
 
         core.shipLoadEvent.on { event ->
             event.ship.setAttachment(SplittingDisablerAttachment(true))
             event.ship.setAttachment(BuoyancyHandlerAttachment())
             event.ship.setAttachment(WorldBorderAttachment())
+            event.ship.setAttachment(VoidAttachment())
             val level = currentServer?.getLevelFromDimensionId(event.ship.chunkClaimDimension)
+            // Maybe we should perf test this?
             level?.let {
                 event.ship.getAttachment(WorldBorderAttachment::class.java)!!.border = it.worldBorder
+                if (!(DimensionParametersResolver.dimensionMap[level.dimensionId]?.disableVoidSaving ?: false)) {
+                    event.ship.getAttachment(VoidAttachment::class.java)!!.lowestHeight = it.yRange.minY - 64
+                } else {
+                    event.ship.getAttachment(VoidAttachment::class.java)!!.lowestHeight = null
+                }
             }
         }
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/ValkyrienSkiesMod.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/ValkyrienSkiesMod.kt
@@ -2,6 +2,7 @@ package org.valkyrienskies.mod.common
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
+import net.fabricmc.fabric.api.loot.v2.LootTableEvents
 import net.minecraft.client.Minecraft
 import net.minecraft.core.BlockPos
 import net.minecraft.core.registries.Registries
@@ -9,15 +10,20 @@ import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceKey
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.MinecraftServer
+import net.minecraft.server.level.ServerLevel
 import net.minecraft.tags.TagKey
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.EntityType
 import net.minecraft.world.item.CreativeModeTab
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.level.Level
 import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.entity.BlockEntity
 import net.minecraft.world.level.block.entity.BlockEntityType
+import net.minecraft.world.level.border.BorderChangeListener
+import net.minecraft.world.level.border.WorldBorder
+import org.valkyrienskies.core.api.ships.LoadedServerShip
 import org.valkyrienskies.core.api.ships.properties.ShipId
 import org.valkyrienskies.core.api.util.GameTickOnly
 import org.valkyrienskies.core.api.util.PhysTickOnly
@@ -44,6 +50,7 @@ import org.valkyrienskies.mod.common.util.GameToPhysicsAdapter
 import org.valkyrienskies.mod.common.util.ShipSettings
 import org.valkyrienskies.mod.common.util.SplitHandler
 import org.valkyrienskies.mod.common.util.SplittingDisablerAttachment
+import org.valkyrienskies.mod.common.util.WorldBorderAttachment
 import org.valkyrienskies.mod.mixinducks.client.world.ClientChunkCacheDuck
 import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck
 import java.util.ServiceLoader
@@ -139,10 +146,16 @@ object ValkyrienSkiesMod {
             useLegacySerializer()
         }
         core.registerAttachment(BuoyancyHandlerAttachment::class.java)
+        core.registerAttachment(WorldBorderAttachment::class.java)
 
         core.shipLoadEvent.on { event ->
             event.ship.setAttachment(SplittingDisablerAttachment(true))
             event.ship.setAttachment(BuoyancyHandlerAttachment())
+            event.ship.setAttachment(WorldBorderAttachment())
+            val level = currentServer?.getLevelFromDimensionId(event.ship.chunkClaimDimension)
+            level?.let {
+                event.ship.getAttachment(WorldBorderAttachment::class.java)!!.border = it.worldBorder
+            }
         }
 
         core.physTickEvent.on { event ->
@@ -175,6 +188,8 @@ object ValkyrienSkiesMod {
                 player.vs_removeKnownShip(event.ship.id)
             }
         }
+
+
     }
 
     @JvmStatic
@@ -220,6 +235,63 @@ object ValkyrienSkiesMod {
 
     fun getEntityPhysTicker(dimensionId: DimensionId, entity: Entity): EntityPhysicsListener? {
         return entityPhysListeners.getOrPut(dimensionId, { ConcurrentHashMap() })[entity.id]
+    }
+
+    fun onLevelLoaded(level: ServerLevel) {
+        level.worldBorder.addListener(ShipBorderChangeListener(level))
+    }
+
+    /**
+     * Our shipLoaded event handler takes care of ships which are loading in, they query the current world border.
+     *
+     * This listener is only to update the _already_ loaded ships with the new border.
+     */
+    private class ShipBorderChangeListener(val level: ServerLevel) : BorderChangeListener {
+        override fun onBorderSizeSet(worldBorder: WorldBorder, d: Double) {
+            updateAllLoadedShips(worldBorder)
+        }
+
+        override fun onBorderSizeLerping(
+            worldBorder: WorldBorder, d: Double, e: Double,
+            l: Long
+        ) {
+            updateAllLoadedShips(worldBorder)
+        }
+
+        override fun onBorderCenterSet(
+            worldBorder: WorldBorder, d: Double, e: Double
+        ) {
+            updateAllLoadedShips(worldBorder)
+        }
+
+        override fun onBorderSetWarningTime(worldBorder: WorldBorder, i: Int) {
+            updateAllLoadedShips(worldBorder)
+        }
+
+        override fun onBorderSetWarningBlocks(
+            worldBorder: WorldBorder, i: Int
+        ) {
+            updateAllLoadedShips(worldBorder)
+        }
+
+        override fun onBorderSetDamagePerBlock(
+            worldBorder: WorldBorder, d: Double
+        ) {
+            updateAllLoadedShips(worldBorder)
+        }
+
+        override fun onBorderSetDamageSafeZOne(
+            worldBorder: WorldBorder, d: Double
+        ) {
+            updateAllLoadedShips(worldBorder)
+        }
+
+        private fun updateAllLoadedShips(worldBorder: WorldBorder) {
+            val loadedShips = level.allShips.filter { ship -> ship is LoadedServerShip }
+            loadedShips.forEach { ship ->
+                (ship as LoadedServerShip).getAttachment(WorldBorderAttachment::class.java)!!.border = worldBorder
+            }
+        }
     }
 
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/DimensionParametersResolver.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/DimensionParametersResolver.kt
@@ -45,6 +45,7 @@ object DimensionParametersResolver: SimpleJsonResourceReloadListener(Gson(), "vs
         val seaLevel = element.asJsonObject["seaLevel"]?.asDouble ?: throw NoSuchElementException("Parameter \"seaLevel\" wasn't filled")
         val gravity = element.asJsonObject["gravity"]?.asJsonArray ?: throw NoSuchElementException("Parameter \"gravity\" wasn't filled")
         val dimensionId = element.asJsonObject["dimensionId"]?.asString ?: throw NoSuchElementException("Parameter \"dimensionId\" wasn't filled")
+        val disableVoidSaving = element.asJsonObject["disableVoidSaving"]?.asBoolean ?: false
         val priority = element.asJsonObject["priority"]?.asInt ?: 0
 
         fun JsonArray.toVector3d() : Vector3dc {
@@ -55,9 +56,9 @@ object DimensionParametersResolver: SimpleJsonResourceReloadListener(Gson(), "vs
             )
         }
 
-        map.getOrPut(dimensionId) { Parameters(maxYPos, seaLevel, gravity.toVector3d(), priority) }.also {
+        map.getOrPut(dimensionId) { Parameters(maxYPos, seaLevel, gravity.toVector3d(), disableVoidSaving, priority) }.also {
             if (it.priority < priority) {
-                map[dimensionId] = Parameters(maxYPos, seaLevel, gravity.toVector3d(), priority)
+                map[dimensionId] = Parameters(maxYPos, seaLevel, gravity.toVector3d(), disableVoidSaving, priority)
             }
         }
     }
@@ -69,6 +70,7 @@ object DimensionParametersResolver: SimpleJsonResourceReloadListener(Gson(), "vs
      * of the dimension's atmosphere, and determines the squash factor of the atmosphere's gradient
      * @param seaLevel The Y value representing sea level in the dimension. This is the Y value where the atmosphere is at its densest, and any Y levels below are equal to this value.
      * @param gravity The gravitational acceleration in the dimension, in m/s^2. Defaults to DEFAULT_WORLD_GRAVITY, or (0, -10, 0). Should be a negative value if downward.
+     * @param disableVoidSaving if true, ships will fall into the void indefinitely
      */
-    data class Parameters(val maxY: Double, val seaLevel: Double, var gravity: Vector3dc = DEFAULT_WORLD_GRAVITY, val priority: Int = -1)
+    data class Parameters(val maxY: Double, val seaLevel: Double, var gravity: Vector3dc = DEFAULT_WORLD_GRAVITY, val disableVoidSaving: Boolean = false, val priority: Int = -1)
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -268,6 +268,11 @@ object VSGameConfig {
         )
         var defaultSplitGraceTimer = 2
 
+        @ConfigEntry(
+            description = "The offset (in blocks) from the death-height ships will stop falling at. To disable saving ships from falling into the void, you need a dimension property datapack."
+        )
+        var voidShipOffset = -3
+
         @ConfigCategory(title = "Commands")
         val Commands = COMMANDS()
 

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/VoidAttachment.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/VoidAttachment.kt
@@ -1,0 +1,44 @@
+package org.valkyrienskies.mod.common.util
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import net.minecraft.world.level.border.WorldBorder
+import org.joml.Vector3d
+import org.valkyrienskies.core.api.ships.PhysShip
+import org.valkyrienskies.core.api.ships.ShipPhysicsListener
+import org.valkyrienskies.core.api.util.PhysTickOnly
+import org.valkyrienskies.core.api.world.PhysLevel
+import org.valkyrienskies.mod.common.config.VSGameConfig
+import kotlin.math.abs
+
+class VoidAttachment : ShipPhysicsListener {
+    @Volatile
+    var disableOverride = false
+
+    @Volatile
+    @JsonIgnore
+    var lowestHeight: Int? = null
+
+    @OptIn(PhysTickOnly::class)
+    override fun physTick(
+        physShip: PhysShip, physLevel: PhysLevel
+    ) {
+        if (disableOverride) return
+        if (lowestHeight == null) return
+
+        val yPos = physShip.transform.positionInWorld.y()
+
+        // If lowestHeight has somehow been concurrently modified
+        // to be null between the null check and here, we're cooked
+        var distance = yPos - (lowestHeight!! + VSGameConfig.SERVER.voidShipOffset)
+
+        if (distance > 0) return
+
+        distance = abs(distance)//.coerceAtMost(50.0)
+        var upVec = Vector3d(0.0, 10.0, 0.0)
+        upVec = upVec.add(Vector3d(0.0, distance, 0.0))
+
+        physShip.applyWorldForceToModelPos(physShip.velocity.negate(Vector3d()).mul(physShip.mass))
+        physShip.applyWorldForceToModelPos(upVec.mul(physShip.mass))
+
+    }
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/WorldBorderAttachment.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/WorldBorderAttachment.kt
@@ -1,0 +1,44 @@
+package org.valkyrienskies.mod.common.util
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import net.minecraft.world.level.border.WorldBorder
+import org.joml.Vector3d
+import org.valkyrienskies.core.api.ships.PhysShip
+import org.valkyrienskies.core.api.ships.ShipPhysicsListener
+import org.valkyrienskies.core.api.util.PhysTickOnly
+import org.valkyrienskies.core.api.world.PhysLevel
+import kotlin.math.abs
+
+class WorldBorderAttachment : ShipPhysicsListener {
+    @Volatile
+    @JsonIgnore
+    var border = WorldBorder()
+
+    @OptIn(PhysTickOnly::class)
+    override fun physTick(
+        physShip: PhysShip, physLevel: PhysLevel
+    ) {
+        val pos = physShip.transform.positionInWorld
+
+        if (!border.isWithinBounds(pos.x(), pos.z(), 0.0)) {
+            var distance = border.getDistanceToBorder(pos.x(), pos.z())
+
+            if (distance > 0) return
+            if (abs(distance) < border.damageSafeZone) return
+
+            distance = abs(distance) - border.damageSafeZone
+
+            // Prevent MASSIVE forces when really far from border
+            // Why are we reusing border.damagePerBlock? because it's roughly the same purpose
+            // default damagePerBlock is 0.2, making our max distance force happen at 10 blocks out
+            distance = distance.coerceAtMost(border.damagePerBlock * 50)
+
+            // Get a rough vector that will send the ship back inside the border
+            val centerVec = Vector3d(border.centerX, pos.y(), border.centerZ)
+            var toCenter = centerVec.sub(pos, Vector3d())
+
+            toCenter = toCenter.mul(distance).mul(physShip.mass)
+            physShip.applyWorldForceToModelPos(toCenter)
+        }
+    }
+}

--- a/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/common/ValkyrienSkiesModFabric.kt
+++ b/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/common/ValkyrienSkiesModFabric.kt
@@ -10,6 +10,7 @@ import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback
 import net.fabricmc.fabric.api.event.lifecycle.v1.CommonLifecycleEvents
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents
 import net.fabricmc.fabric.api.`object`.builder.v1.block.entity.FabricBlockEntityTypeBuilder
 import net.fabricmc.fabric.api.`object`.builder.v1.entity.FabricDefaultAttributeRegistry
@@ -31,7 +32,9 @@ import net.minecraft.world.item.BlockItem
 import net.minecraft.world.item.CreativeModeTabs
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.Item.Properties
+import net.minecraft.world.level.Level
 import net.minecraft.world.level.block.Block
+import net.minecraft.world.level.block.LevelEvent
 import net.minecraftforge.fml.config.ModConfig
 import org.valkyrienskies.mod.client.EmptyRenderer
 import org.valkyrienskies.mod.client.VSPhysicsEntityModel
@@ -264,6 +267,10 @@ class ValkyrienSkiesModFabric : ModInitializer {
 
         CommandRegistrationCallback.EVENT.register { dispatcher ,d, _ ->
             VSCommands.registerServerCommands(dispatcher)
+        }
+
+        ServerWorldEvents.LOAD.register { _, serverLevel ->
+            ValkyrienSkiesMod.onLevelLoaded(serverLevel)
         }
 
         // registering data loaders

--- a/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ValkyrienSkiesModForge.kt
+++ b/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ValkyrienSkiesModForge.kt
@@ -4,12 +4,14 @@ import dev.engine_room.flywheel.api.event.ReloadLevelRendererEvent
 import net.minecraft.commands.Commands.CommandSelection.ALL
 import net.minecraft.commands.Commands.CommandSelection.INTEGRATED
 import net.minecraft.resources.ResourceLocation
+import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.entity.EntityType
 import net.minecraft.world.entity.MobCategory
 import net.minecraft.world.item.BlockItem
 import net.minecraft.world.item.CreativeModeTabs
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.Item.Properties
+import net.minecraft.world.level.Level
 import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.entity.BlockEntityType
 import net.minecraftforge.client.event.EntityRenderersEvent
@@ -19,6 +21,7 @@ import net.minecraftforge.event.BuildCreativeModeTabContentsEvent
 import net.minecraftforge.event.RegisterCommandsEvent
 import net.minecraftforge.event.TagsUpdatedEvent
 import net.minecraftforge.event.entity.EntityAttributeCreationEvent
+import net.minecraftforge.event.level.LevelEvent
 import net.minecraftforge.fml.ModList
 import net.minecraftforge.fml.ModLoadingContext
 import net.minecraftforge.fml.common.Mod
@@ -147,6 +150,8 @@ class ValkyrienSkiesModForge {
             }
         }
         modBus.addListener(::loadComplete)
+
+        forgeBus.addListener(::onLevelLoaded)
 
         forgeBus.addListener(::registerCommands)
         forgeBus.addListener(::tagsUpdated)
@@ -280,6 +285,10 @@ class ValkyrienSkiesModForge {
             event.accept(CLASSIC_AREA_ASSEMBLER_ITEM)
             event.accept(PHYSICS_ENTITY_CREATOR_ITEM)
         }
+    }
+
+    private fun onLevelLoaded(event: LevelEvent.Load) {
+        if (event.level is ServerLevel) ValkyrienSkiesMod.onLevelLoaded(event.level as ServerLevel)
     }
 
     private fun onConfigLoad(event: ModConfigEvent.Loading) {


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix?
- [x] Feature

**Explain what this PR is doing:**

This PR makes ships bounce back from the world border, fixing https://github.com/ValkyrienSkies/Valkyrien-Skies-2/issues/520

https://github.com/user-attachments/assets/2c2c470e-b513-4c7e-b32e-a23948231383

It also makes ships stop falling into the void after a certain point. They will stabilize at 3 blocks below the death line, so you would need another ship to fish them out without dying. The offset from the death line is configurable (server config), and you can also add 
`"disableVoidSaving": true` to a datapacks dimension properties to restore the old behaviour (falling into the void forever) for a particular dimension.

https://github.com/user-attachments/assets/5134bb34-9715-4e36-9b8c-536448fe2747

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [x] Yes (describe)
- [ ] No

The constructor for `DimensionParametersResolver.Parameters` changed, although I doubt any addons were using it.

---


## Additional Notes

This has added some extra work to our default shipLoadEvent callback, namely getting some level info (like worldborder and void height) and giving it to the attachments. I think the performance cost is probably negligible, but its worth keeping an eye on.

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
