### PR TITLE
fix issue #1848

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityShipCollisionUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityShipCollisionUtils.kt
@@ -26,7 +26,6 @@ import org.valkyrienskies.mod.common.getLoadedShipManagingPos
 import org.valkyrienskies.mod.common.shipObjectWorld
 import org.valkyrienskies.mod.common.unloadedShips
 import org.valkyrienskies.mod.common.vsCore
-import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck
 import org.valkyrienskies.mod.util.BugFixUtil
 import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Stream
@@ -44,6 +43,8 @@ object EntityShipCollisionUtils {
     private val playerUnloadedShipBlockStartTicks = ConcurrentHashMap<Long, Long>()
     private val playerClientSyncBlockStartTicks = ConcurrentHashMap<Int, Long>()
     private const val PLAYER_UNLOADED_SHIP_BLOCK_TIMEOUT_TICKS = 200L // ~10 seconds
+
+    private const val PLAYER_JOIN_GRACE_TICKS = 200L // ~10 seconds
 
     @JvmStatic
     fun markShipAsRecentlySpawned(shipId: ShipId, currentTick: Long) {
@@ -117,6 +118,9 @@ object EntityShipCollisionUtils {
         val level = entity.level()
 
         if (level is ServerLevel || (level.isClientSide && level is ClientLevel)) {
+            if (entity is Player && entity.tickCount < PLAYER_JOIN_GRACE_TICKS) {
+                return false
+            }
             if (level.isClientSide && level is ClientLevel && !level.shipObjectWorld.isSyncedWithServer) {
                 return shouldBlockPlayerForClientShipSync(entity, level.gameTime)
             } else if (entity is Player) {
@@ -134,8 +138,6 @@ object EntityShipCollisionUtils {
                     // loading. Without this, spawning a new ship near a player would freeze
                     // them because isCollidingWithUnloadedShips returns true (the new ship's
                     // chunks haven't loaded yet), which cancels all entity movement.
-                    // This must be checked BEFORE vs_isKnownShip, because the player won't
-                    // know about a brand-new ship yet either.
                     if (isInSpawnGracePeriod(ship.id)) {
                         return@allMatch true // pretend it's loaded → don't block movement
                     }
@@ -144,9 +146,6 @@ object EntityShipCollisionUtils {
                     if (chunksLoaded) {
                         playerUnloadedShipBlockStartTicks.remove(playerShipBlockKey(entity, ship.id))
                         return@allMatch true
-                    }
-                    if (entity is PlayerKnownShipsDuck && !entity.vs_isKnownShip(ship.id)) {
-                        return@allMatch !shouldBlockPlayerForUnloadedShip(entity, ship, currentTick)
                     }
                     !shouldBlockPlayerForUnloadedShip(entity, ship, currentTick)
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,8 @@ minecraft_version=1.20.1
 enabled_platforms=quilt,fabric,forge
 archives_base_name=valkyrienskies-120
 
+org.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64
+
 mod_version=2.4.13
 maven_group=org.valkyrienskies.mod
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,6 @@ minecraft_version=1.20.1
 enabled_platforms=quilt,fabric,forge
 archives_base_name=valkyrienskies-120
 
-org.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64
-
 mod_version=2.4.13
 maven_group=org.valkyrienskies.mod
 


### PR DESCRIPTION
fix issue #1848 player unable to move upon world reload if ship entity is present

## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**

This PR fixes issue #1848 player unable to move upon world reload if physics entity is present.
---

## Modloaders this PR affects:
- [x] Forge
- [ ] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [x] No

---


## Additional Notes
Anything else reviewers might need to know:
Performance concerns, edge cases, etc

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
