### PR TITLE
Add `/vs apply [force/torque]` command

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/VSCommands.kt
@@ -4,7 +4,6 @@ import com.mojang.brigadier.CommandDispatcher
 import net.minecraft.commands.CommandSourceStack
 import net.minecraft.commands.Commands.literal
 import net.minecraft.commands.SharedSuggestionProvider
-import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.Component.translatable
 import org.joml.Quaterniond
 import org.joml.Quaterniondc
@@ -17,6 +16,7 @@ import org.valkyrienskies.mod.common.command.arguments.ContraptionSelectorOption
 import org.valkyrienskies.mod.common.command.commands.BackendCommand
 import org.valkyrienskies.mod.common.command.commands.DeleteCommand
 import org.valkyrienskies.mod.common.command.commands.DryCommand
+import org.valkyrienskies.mod.common.command.commands.ApplyCommand
 import org.valkyrienskies.mod.common.command.commands.GetAirCommand
 import org.valkyrienskies.mod.common.command.commands.GetGravityCommand
 import org.valkyrienskies.mod.common.command.commands.GetShipCommand
@@ -43,6 +43,7 @@ object VSCommands {
         BackendCommand.register(vs)
         DeleteCommand.register(vs)
         DryCommand.register(vs)
+        ApplyCommand.register(vs)
         GetAirCommand.register(vs)
         GetGravityCommand.register(vs)
         GetShipCommand.register(vs)

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/arguments/RelativeVector3.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/arguments/RelativeVector3.kt
@@ -20,7 +20,7 @@ data class RelativeVector3(val x: RelativeValue, val y: RelativeValue, val z: Re
     )
 }
 
-data class RelativeValue(private val angleDegrees: Double, private val isRelative: Boolean) {
+data class RelativeValue(val angleDegrees: Double, val isRelative: Boolean) {
     fun getRelativeValue(sourceAngleDegrees: Double): Double {
         return if (isRelative) sourceAngleDegrees + angleDegrees else angleDegrees
     }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/arguments/RelativeVector3Argument.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/arguments/RelativeVector3Argument.kt
@@ -53,7 +53,7 @@ open class RelativeVector3Argument : ArgumentType<RelativeVector3> {
         fun relativeVector3() = RelativeVector3Argument()
 
         @JvmStatic
-        fun getRelativeVector3(commandContext: CommandContext<CommandSourceStack?>, string: String?): RelativeVector3 {
+        fun getRelativeVector3(commandContext: CommandContext<CommandSourceStack>, string: String?): RelativeVector3 {
             return commandContext.getArgument(
                 string,
                 RelativeVector3::class.java

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/arguments/ShipSelector.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/arguments/ShipSelector.kt
@@ -10,6 +10,7 @@ import org.valkyrienskies.core.api.ships.ServerShip
 import org.valkyrienskies.core.api.ships.Ship
 import org.valkyrienskies.mod.api.dimensionId
 import org.valkyrienskies.mod.api.toMinecraft
+import org.valkyrienskies.mod.common.toWorldCoordinates
 import java.util.function.Function
 import java.util.function.Predicate
 import kotlin.math.min
@@ -51,7 +52,7 @@ class ShipSelector(
                 predicate.and(Predicate { ship: ServerShip -> this.mass.matches(ship.inertiaData.mass) })
         }
 
-        if (!this.size.isAny()) {
+        if (!this.size.isAny) {
             predicate =
                 predicate.and(Predicate { ship: ServerShip -> this.size.matches(ship.worldAABB.toMinecraft().size) })
         }
@@ -74,7 +75,7 @@ class ShipSelector(
             found = found.filter { it.chunkClaimDimension == source.level.dimensionId }
         }
 
-        val position = this.position.apply(source.position)
+        val position = this.position.apply(source.level.toWorldCoordinates(source.position))
         val predicate = this.addPositionalPredicates(position)
 
         // Do all the other selectors

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/commands/ApplyCommand.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/commands/ApplyCommand.kt
@@ -1,0 +1,199 @@
+package org.valkyrienskies.mod.common.command.commands
+
+import com.mojang.brigadier.Command
+import com.mojang.brigadier.arguments.StringArgumentType
+import com.mojang.brigadier.builder.ArgumentBuilder
+import com.mojang.brigadier.builder.LiteralArgumentBuilder
+import com.mojang.brigadier.builder.RequiredArgumentBuilder
+import com.mojang.brigadier.context.CommandContext
+import net.minecraft.commands.CommandSourceStack
+import net.minecraft.commands.Commands.argument
+import net.minecraft.commands.Commands.literal
+import net.minecraft.commands.arguments.coordinates.Vec3Argument
+import net.minecraft.network.chat.Component
+import net.minecraft.world.phys.Vec3
+import org.joml.Vector3d
+import org.valkyrienskies.core.api.ships.ServerShip
+import org.valkyrienskies.mod.api.toJOML
+import org.valkyrienskies.mod.common.ValkyrienSkiesMod
+import org.valkyrienskies.mod.common.command.arguments.RelativeValue
+import org.valkyrienskies.mod.common.command.arguments.RelativeVector3
+import org.valkyrienskies.mod.common.command.arguments.RelativeVector3Argument
+import org.valkyrienskies.mod.common.command.arguments.ShipArgument
+import org.valkyrienskies.mod.common.config.VSGameConfig
+
+object ApplyCommand {
+    fun register(vs: LiteralArgumentBuilder<CommandSourceStack>) {
+        vs.then(literal("apply")
+            .requires { it.hasPermission(VSGameConfig.SERVER.Commands.applyCommandPerms) }
+            .then(
+                literal("force")
+                    .then(
+                        sharedArguments {
+
+                            executes { ctx ->
+                                return@executes applyForce(ctx, Mode.WORLD)
+                            }
+
+                            then(
+                                argument("mode", StringArgumentType.word())
+                                    .suggests { _, builder ->
+                                        Mode.entries.forEach {
+                                            builder.suggest(it.name.lowercase())
+                                        }
+                                        builder.buildFuture()
+                                    }
+                                    .executes { ctx ->
+                                        val modeName = StringArgumentType.getString(ctx, "mode")
+                                        var mode: Mode?
+                                        try {
+                                            mode = Mode.valueOf(
+                                                modeName.uppercase()
+                                            )
+                                        } catch (_: IllegalArgumentException) {
+                                            ctx.source.sendFailure(Component.translatable("argument.valkyrienskies.ship.unknown_option", modeName))
+                                            return@executes 0
+                                        }
+
+                                        return@executes applyForce(ctx, mode)
+                                    }
+                                    .then(argument("pos", RelativeVector3Argument.relativeVector3()).executes { ctx ->
+                                        val modeName = StringArgumentType.getString(ctx, "mode")
+                                        var mode: Mode?
+                                        try {
+                                            mode = Mode.valueOf(
+                                                modeName.uppercase()
+                                            )
+                                        } catch (_: IllegalArgumentException) {
+                                            ctx.source.sendFailure(Component.translatable("argument.valkyrienskies.ship.unknown_option", modeName))
+                                            return@executes 0
+                                        }
+
+                                        val pos = RelativeVector3Argument.getRelativeVector3(ctx, "pos").toVector3d(0.0, 0.0, 0.0)
+
+                                        return@executes applyForce(ctx, mode, pos)
+                                    })
+                            )
+                        }
+                    )
+            )
+            .then(
+                literal("torque")
+                    .then(
+                        sharedArguments {
+                            executes { ctx ->
+                                return@executes applyTorque(ctx, Mode.WORLD)
+                            }
+
+                            then(
+                                argument("mode", StringArgumentType.word())
+                                    .suggests { _, builder ->
+                                        Mode.entries.forEach {
+                                            builder.suggest(it.name.lowercase())
+                                        }
+                                        builder.buildFuture()
+                                    }
+                                    .executes { ctx ->
+                                        val modeName = StringArgumentType.getString(ctx, "mode")
+                                        var mode: Mode?
+                                        try {
+                                            mode = Mode.valueOf(
+                                                modeName.uppercase()
+                                            )
+                                        } catch (_: IllegalArgumentException) {
+                                            ctx.source.sendFailure(
+                                                Component.translatable(
+                                                    "argument.valkyrienskies.ship.unknown_option", modeName
+                                                )
+                                            )
+                                            return@executes 0
+                                        }
+
+                                        return@executes applyTorque(ctx, mode)
+                                    }
+                            )
+                        }
+                    )
+            )
+        )
+
+    }
+
+    private fun applyTorque(ctx: CommandContext<CommandSourceStack>, mode: Mode): Int {
+        val ships = ShipArgument.getShips(ctx, "ships")
+        if (ships.isEmpty()) {
+            ctx.source.sendFailure(
+                Component.translatable("command.valkyrienskies.get_ship.fail")
+            )
+            return 0
+        }
+
+        val vec = RelativeVector3Argument.getRelativeVector3(ctx, "vec")
+
+        ships.forEach {
+            applyTorque(it as ServerShip, vec, mode)
+        }
+
+        return 1
+    }
+
+    private fun applyTorque(ship: ServerShip, force: RelativeVector3, mode: Mode) {
+        val gtpa = ValkyrienSkiesMod.getOrCreateGTPA(ship.chunkClaimDimension)
+        val force = force.toVector3dMul(ship.inertiaData.mass,ship.inertiaData.mass,ship.inertiaData.mass)
+        when (mode) {
+            Mode.WORLD -> gtpa.applyWorldTorque(ship.id, force)
+            Mode.BODY -> gtpa.applyBodyTorque(ship.id, force)
+            Mode.MODEL -> gtpa.applyModelTorque(ship.id, force)
+        }
+    }
+
+    private fun applyForce(ctx: CommandContext<CommandSourceStack>, mode: Mode, position: Vector3d? = null): Int {
+        val ships = ShipArgument.getShips(ctx, "ships")
+        if (ships.isEmpty()) {
+            ctx.source.sendFailure(
+                Component.translatable("command.valkyrienskies.get_ship.fail")
+            )
+            return 0
+        }
+
+        val vec = RelativeVector3Argument.getRelativeVector3(ctx, "vec")
+
+        ships.forEach {
+            applyForce(it as ServerShip, vec, mode, position)
+        }
+
+        return 1
+    }
+
+    private fun applyForce(ship: ServerShip, force: RelativeVector3, mode: Mode, position: Vector3d?) {
+        val gtpa = ValkyrienSkiesMod.getOrCreateGTPA(ship.chunkClaimDimension)
+        val force = force.toVector3dMul(ship.inertiaData.mass,ship.inertiaData.mass,ship.inertiaData.mass)
+        when (mode) {
+            Mode.WORLD -> gtpa.applyWorldForce(ship.id, force, position)
+            Mode.BODY -> gtpa.applyBodyForce(ship.id, force, position ?: Vector3d())
+            Mode.MODEL -> gtpa.applyModelForce(ship.id, force, position)
+        }
+    }
+
+    private fun sharedArguments(
+        build: RequiredArgumentBuilder<CommandSourceStack, RelativeVector3>.() -> Unit
+    ): ArgumentBuilder<CommandSourceStack, *> {
+        return argument("ships", ShipArgument.ships()).then(
+            argument("vec", RelativeVector3Argument.relativeVector3()).apply(build)
+        )
+    }
+
+    private enum class Mode {
+        WORLD,
+        BODY,
+        MODEL
+    }
+
+    // These are so that we can use ~ syntax but with * instead of +
+    private fun RelativeVector3.toVector3dMul(sourceX: Double, sourceY: Double, sourceZ: Double): Vector3d = Vector3d(
+        this.x.getRelativeValueMul(sourceX), this.y.getRelativeValueMul(sourceY), this.z.getRelativeValueMul(sourceZ)
+    )
+    private fun RelativeValue.getRelativeValueMul(sourceAngleDegrees: Double): Double {
+        return if (this.isRelative) sourceAngleDegrees * angleDegrees else angleDegrees
+    }
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -432,6 +432,11 @@ object VSGameConfig {
                 description = "The permission level required to use the /vs dry command. Must be 0 <= x <= 4"
             )
             var dryShipCommandPerms = 2
+
+            @ConfigEntry(
+                description = "The permission level required to use the /vs apply (force/torque) command. Must be 0 <= x <= 4"
+            )
+            var applyCommandPerms = 2
         }
     }
 


### PR DESCRIPTION
## What this PR does:
- [x] Feature

**Explain what this PR is doing:**

Adds a `/vs apply` command which can be used to apply forces or torques to ships.

Syntax:
`vs apply force <ships> <vec> [<mode>] [<pos>]`
`vs apply torque <ships> <vec> [<mode>]`

Where `mode` is one of: `world`, `body` and `model`

This covers pretty much every use of GTPA api, aside from those with mixed position and force spaces. (such as `applyWorldForceToBodyPos`), but those are simply helpful and not required for handling ships.

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
