### PR TITLE
fix player falling through ship on world load

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityShipCollisionUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityShipCollisionUtils.kt
@@ -104,6 +104,9 @@ object EntityShipCollisionUtils {
     }
 
     private fun getAllShipsIntersectingEvenIfNotYetFullyLoaded(level: Level, aabb: AABBd): Stream<Ship> {
+        // Includes both unloaded ships AND loaded ships, because a ship can be in `loadedShips`
+        // (metadata received from server) before its block chunks have arrived on the client.
+        // The downstream areAllChunksLoaded check distinguishes the two.
         // shipAABB and worldAABB are sometimes too small when ship was just loaded for the first time.
         // To circumvent this, we use activeChunksSet to find a rougher bounding box which should always contain the entire ship.
         return level.allShips.stream().filter { ship ->

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityShipCollisionUtils.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/util/EntityShipCollisionUtils.kt
@@ -21,10 +21,10 @@ import org.valkyrienskies.core.internal.collision.VsiConvexPolygonc
 import org.valkyrienskies.core.util.extend
 import org.valkyrienskies.core.util.toAABBd
 import org.valkyrienskies.core.api.ships.properties.ShipId
+import org.valkyrienskies.mod.common.allShips
 import org.valkyrienskies.mod.common.dimensionId
 import org.valkyrienskies.mod.common.getLoadedShipManagingPos
 import org.valkyrienskies.mod.common.shipObjectWorld
-import org.valkyrienskies.mod.common.unloadedShips
 import org.valkyrienskies.mod.common.vsCore
 import org.valkyrienskies.mod.mixinducks.feature.tickets.PlayerKnownShipsDuck
 import org.valkyrienskies.mod.util.BugFixUtil
@@ -106,7 +106,7 @@ object EntityShipCollisionUtils {
     private fun getAllShipsIntersectingEvenIfNotYetFullyLoaded(level: Level, aabb: AABBd): Stream<Ship> {
         // shipAABB and worldAABB are sometimes too small when ship was just loaded for the first time.
         // To circumvent this, we use activeChunksSet to find a rougher bounding box which should always contain the entire ship.
-        return level.unloadedShips.stream().filter { ship ->
+        return level.allShips.stream().filter { ship ->
             ship.chunkClaimDimension == level.dimensionId &&
             getShipyardChunkAABBAround(ship).toAABBd(AABBd()).transform(ship.shipToWorld).intersectsAABB(aabb)
         }
@@ -121,9 +121,6 @@ object EntityShipCollisionUtils {
                 return shouldBlockPlayerForClientShipSync(entity, level.gameTime)
             } else if (entity is Player) {
                 playerClientSyncBlockStartTicks.remove(entity.id)
-            }
-            if (level.unloadedShips.isEmpty()) {
-                return false
             }
 
             val aabb = entity.boundingBox.toJOML()


### PR DESCRIPTION
fix player falling through ship on world load

## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**

This PR fixes player falling through ships when loading in a world
---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [x] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [x] No

---


## Additional Notes
Anything else reviewers might need to know:
Performance concerns, edge cases, etc

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
