### PR TITLE
Make get-ship work without an entity

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/command/commands/GetShipCommand.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/command/commands/GetShipCommand.kt
@@ -12,13 +12,11 @@ import org.valkyrienskies.mod.common.getShipManagingPos
 object GetShipCommand {
     private const val GET_SHIP_SUCCESS_MESSAGE = "command.valkyrienskies.get_ship.success"
     private const val GET_SHIP_FAIL_MESSAGE = "command.valkyrienskies.get_ship.fail"
-    private const val GET_SHIP_ONLY_USABLE_BY_ENTITIES_MESSAGE = "command.valkyrienskies.get_ship.only_usable_by_entities"
 
     fun register(vs: LiteralArgumentBuilder<CommandSourceStack>) {
         vs.then(literal("get-ship")
         .requires{ it.hasPermission(VSGameConfig.SERVER.Commands.getShipCommandPerms)}
         .executes {
-            var success = false
             val sourceEntity: Entity? = it.source.entity
             if (sourceEntity != null) {
                 val rayTrace = sourceEntity.pick(25.0, 1.0.toFloat(), false)
@@ -30,19 +28,24 @@ object GetShipCommand {
                                 translatable(GET_SHIP_SUCCESS_MESSAGE, ship.slug, ship.id)
                             }, true
                         )
-                        success = true
+                        return@executes ship.id.toInt()
                     }
                 }
-                if (success) {
-                    1
-                } else {
-                    it.source.sendFailure(translatable(GET_SHIP_FAIL_MESSAGE))
-                    0
-                }
-            } else {
-                it.source.sendFailure(translatable(GET_SHIP_ONLY_USABLE_BY_ENTITIES_MESSAGE))
-                0
+
             }
+
+            val ship = it.source.level.getShipManagingPos(it.source.position)
+            if (ship != null) {
+                it.source.sendSuccess(
+                    {
+                        translatable(GET_SHIP_SUCCESS_MESSAGE, ship.slug, ship.id)
+                    }, true
+                )
+                return@executes ship.id.toInt()
+            }
+
+            it.source.sendFailure(translatable(GET_SHIP_FAIL_MESSAGE))
+            0
 
         })
     }

--- a/common/src/main/resources/assets/valkyrienskies/lang/ar_sa.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/ar_sa.json
@@ -31,7 +31,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "يمكنك الانتقال إلى سفينة واحدة فقط",
   "command.valkyrienskies.get_ship.success": "تم العثور على سفينة بالمعرّف %s",
   "command.valkyrienskies.get_ship.fail": "لم يتم العثور على سفينة",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship يمكن استخدامه فقط بواسطة الكيانات!",
   "command.valkyrienskies.scale.success": "تم تغيير حجم %d سفن!",
 
   "misc.valkyrienskies.create.deployer_working_mode": "سلوك السفينة",

--- a/common/src/main/resources/assets/valkyrienskies/lang/en_pt.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/en_pt.json
@@ -31,7 +31,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "Ye can only blink-jump to one ship, ye scallywag!",
   "command.valkyrienskies.get_ship.success": "Found a vessel flyin’ the slug %s!",
   "command.valkyrienskies.get_ship.fail": "Nary a ship be found!",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship can only be run by livin’ creatures, lad!",
   "command.valkyrienskies.scale.success": "Sized up %d ships, aye!",
 
   "misc.valkyrienskies.create.deployer_working_mode": "Ship Manner o’ Workin’",

--- a/common/src/main/resources/assets/valkyrienskies/lang/en_us.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/en_us.json
@@ -61,7 +61,6 @@
   "command.valkyrienskies.mc_teleport.ship_to_pos": "Teleported %d ships to %s %s %s",
   "command.valkyrienskies.get_ship.success": "Found ship with slug %s, id %s",
   "command.valkyrienskies.get_ship.fail": "No ship found",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship can only be run by entities!",
   "command.valkyrienskies.scale.success_one": "Scaled %s",
   "command.valkyrienskies.scale.success": "Scaled %d ships!",
   "command.valkyrienskies.backend.current": "Backend is currently %s",

--- a/common/src/main/resources/assets/valkyrienskies/lang/es_es.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/es_es.json
@@ -18,7 +18,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "Solo se puede teletransportar exactamente 1 nave",
   "command.valkyrienskies.get_ship.success": "Nave encontrada con el slug %s",
   "command.valkyrienskies.get_ship.fail": "Ninguna nave encontrada",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship solo puede ser ejecutado por entidades",
   "tooltip.valkyrienskies.mass": "Masa",
   "command.valkyrienskies.scale.success": "¡Escalado %d naves!",
   "itemGroup.valkyrienSkies": "Valkyrien Skies"

--- a/common/src/main/resources/assets/valkyrienskies/lang/fi_fi.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/fi_fi.json
@@ -31,7 +31,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "Voi teleportata vain tarkalleen yhteen alukseen",
   "command.valkyrienskies.get_ship.success": "Löydettiin alus tunnisteella %s",
   "command.valkyrienskies.get_ship.fail": "Alusta ei löytynyt",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship voidaan suorittaa vain entiteeteiltä!",
   "command.valkyrienskies.scale.success": "Skaalattiin %d alusta!",
 
   "misc.valkyrienskies.create.deployer_working_mode": "Aluksen Käyttäytyminen",

--- a/common/src/main/resources/assets/valkyrienskies/lang/fr_fr.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/fr_fr.json
@@ -18,7 +18,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "Peut seulement téléporter exactement 1 vaisseau",
   "command.valkyrienskies.get_ship.success": "Vaisseau trouvé avec le slug %s",
   "command.valkyrienskies.get_ship.fail": "Aucun vaisseau trouvé",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship ne peut être exécuté que par des entités !",
   "tooltip.valkyrienskies.mass": "Masse",
   "command.valkyrienskies.scale.success": "%d navires mis à l'échelle !"
 }

--- a/common/src/main/resources/assets/valkyrienskies/lang/hi_in.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/hi_in.json
@@ -31,7 +31,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "सिर्फ ठीक 1 जहाज़ पर ही टेलीपोर्ट किया जा सकता है",
   "command.valkyrienskies.get_ship.success": "स्लग %s वाला जहाज़ मिला",
   "command.valkyrienskies.get_ship.fail": "कोई जहाज़ नहीं मिला",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship केवल इकाइयों द्वारा ही चलाया जा सकता है!",
   "command.valkyrienskies.scale.success": "%d जहाज़ स्केल किए गए!",
 
   "misc.valkyrienskies.create.deployer_working_mode": "जहाज़ व्यवहार",

--- a/common/src/main/resources/assets/valkyrienskies/lang/ja_jp.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/ja_jp.json
@@ -34,7 +34,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "テレポートできる船は 1 隻のみです",
   "command.valkyrienskies.get_ship.success": "スラグ %s の船が見つかりました",
   "command.valkyrienskies.get_ship.fail": "船が見つかりません",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship はエンティティのみが実行できます！",
   "command.valkyrienskies.scale.success": "%d 隻の船をスケールしました！",
 
   "misc.valkyrienskies.create.deployer_working_mode": "船の動作モード",

--- a/common/src/main/resources/assets/valkyrienskies/lang/ko_kr.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/ko_kr.json
@@ -32,7 +32,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "정확히 1척의 선박으로만 이동할 수 있습니다",
   "command.valkyrienskies.get_ship.success": "슬러그가 %s인 선박을 찾았습니다",
   "command.valkyrienskies.get_ship.fail": "선박을 찾을 수 없습니다",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship은 엔티티에 의해서만 실행될 수 있습니다!",
   "command.valkyrienskies.scale.success": "%d척의 선박을 크기를 조절했습니다!",
 
   "misc.valkyrienskies.create.deployer_working_mode": "선박 동작 방식",

--- a/common/src/main/resources/assets/valkyrienskies/lang/pl_pl.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/pl_pl.json
@@ -31,7 +31,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "Można teleportować się tylko do dokładnie 1 statku",
   "command.valkyrienskies.get_ship.success": "Znaleziono statek o nazwie %s",
   "command.valkyrienskies.get_ship.fail": "Nie znaleziono statku",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship może być uruchomione tylko przez byty!",
   "command.valkyrienskies.scale.success": "Zmieniono skalę %d statków!",
 
   "misc.valkyrienskies.create.deployer_working_mode": "Zachowanie Statku",

--- a/common/src/main/resources/assets/valkyrienskies/lang/pt_br.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/pt_br.json
@@ -34,7 +34,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "Só é possível teleportar para exatamente 1 navio",
   "command.valkyrienskies.get_ship.success": "Navio encontrado com slug %s",
   "command.valkyrienskies.get_ship.fail": "Nenhum navio encontrado",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship só pode ser executado por entidades!",
   "command.valkyrienskies.scale.success": "%d navios escalados!",
 
   "misc.valkyrienskies.create.deployer_working_mode": "Comportamento do Navio",

--- a/common/src/main/resources/assets/valkyrienskies/lang/ru_ru.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/ru_ru.json
@@ -32,7 +32,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "Можно телепортироваться только к одному кораблю",
   "command.valkyrienskies.get_ship.success": "Найден корабль со слагом %s",
   "command.valkyrienskies.get_ship.fail": "Корабль не найден",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship можно выполнять только сущностям!",
   "command.valkyrienskies.scale.success": "Масштабировано кораблей: %d!",
 
   "misc.valkyrienskies.create.deployer_working_mode": "Поведение корабля",

--- a/common/src/main/resources/assets/valkyrienskies/lang/sv_se.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/sv_se.json
@@ -31,7 +31,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "Kan bara teleportera till exakt 1 skepp",
   "command.valkyrienskies.get_ship.success": "Hittade skepp med slug %s",
   "command.valkyrienskies.get_ship.fail": "Inget skepp hittades",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship kan endast köras av entiteter!",
   "command.valkyrienskies.scale.success": "Skalade %d skepp!",
 
   "misc.valkyrienskies.create.deployer_working_mode": "Skeppsbeteende",

--- a/common/src/main/resources/assets/valkyrienskies/lang/tr_tr.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/tr_tr.json
@@ -31,7 +31,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "Yalnızca tam olarak 1 gemiye ışınlanabilirsiniz",
   "command.valkyrienskies.get_ship.success": "%s slug'ına sahip gemi bulundu",
   "command.valkyrienskies.get_ship.fail": "Gemi bulunamadı",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "/vs get-ship yalnızca varlıklar tarafından çalıştırılabilir!",
   "command.valkyrienskies.scale.success": "%d gemi ölçeklendirildi!",
 
   "misc.valkyrienskies.create.deployer_working_mode": "Gemi Davranışı",

--- a/common/src/main/resources/assets/valkyrienskies/lang/zh_cn.json
+++ b/common/src/main/resources/assets/valkyrienskies/lang/zh_cn.json
@@ -40,7 +40,6 @@
   "command.valkyrienskies.mc_teleport.can_only_teleport_to_one_ship": "只能传送到一个物理结构",
   "command.valkyrienskies.get_ship.success": "已找到名为 %s 的物理结构",
   "command.valkyrienskies.get_ship.fail": "未找到物理结构",
-  "command.valkyrienskies.get_ship.only_usable_by_entities": "指令 /vs get-ship 只能被实体执行！",
   "command.valkyrienskies.scale.success_one": "调整了 %s 的尺寸！",
   "command.valkyrienskies.scale.success": "调整了 %d 个物理结构的尺寸！",
   "command.valkyrienskies.backend.current": "后端引擎目前为 %s",


### PR DESCRIPTION
## What this PR does:
- [x] Feature

**Explain what this PR is doing:**

Allows the get-ship command to get a ship without being executed from an entity.
Now, if the entity raycast fails, or there is no source entity, it will attempt to get the ship from the position of the command before failing.

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
