### PR TITLE
Fix Immersive Portals Compat Bounds Check

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/immersive_portals/MixinIpNewChunkTrackingGraph.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/mod_compat/immersive_portals/MixinIpNewChunkTrackingGraph.java
@@ -40,10 +40,10 @@ public class MixinIpNewChunkTrackingGraph {
         // region inject ships
         final AABBd box = new AABBd(
             (instance.center.x - instance.radius) << 4,
-            world.getMinBuildHeight(),
+            -Double.MAX_VALUE,
             (instance.center.z - instance.radius) << 4,
             (instance.center.x + instance.radius) << 4,
-            world.getMaxBuildHeight(),
+            Double.MAX_VALUE,
             (instance.center.z + instance.radius) << 4
         );
         for (final Ship ship : VSGameUtilsKt.getShipsIntersecting(world, box)) {


### PR DESCRIPTION
Include ships that are outside the build limit.

## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**
Changes the bounds of the AABB check for ships to include ranges above max build limit and below min build limit by changing them to the double max value instead of world height values.

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [ ] In-dev singleplayer
- [ ] In-dev dedicated server
- [x] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [x] No

---


## Additional Notes
Anything else reviewers might need to know:
Performance concerns, edge cases, etc

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
