### PR TITLE
Ships delete when they have no blocks now

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/BlockStateInfoProvider.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/BlockStateInfoProvider.kt
@@ -20,6 +20,7 @@ import org.valkyrienskies.core.api.ships.Wing
 import org.valkyrienskies.core.api.world.connectivity.ConnectionStatus
 import org.valkyrienskies.core.api.world.connectivity.SparseVoxelPosition
 import org.valkyrienskies.core.internal.world.chunks.VsiBlockType
+import org.valkyrienskies.mod.common.assembly.ShipAssembler
 import org.valkyrienskies.mod.common.block.WingBlock
 import org.valkyrienskies.mod.common.config.ConfigType
 import org.valkyrienskies.mod.common.config.MassDatapackResolver
@@ -162,6 +163,14 @@ object BlockStateInfo {
             x, y, z, level.dimensionId, prevBlockType, newBlockType, prevBlockMass,
             newBlockMass
         )
+
+        //when there are no blocks on the ship delete it | Tiger was here:)
+        if (level is ServerLevel) {
+            val shipJustModified = level.getLoadedShipManagingPos(x shr 4, z shr 4)
+            if (shipJustModified != null && shipJustModified.shipAABB == null) {
+                ShipAssembler.deleteShip(level, shipJustModified, deleteBlocks = false, dropBlocks = false)
+            }
+        }
 
         fun Set<SparseVoxelPosition>.centerFromVoxelSet() : Vector3dc {
             val center = Vector3d(0.0, 0.0, 0.0)


### PR DESCRIPTION
## What this PR does:
- [ ] Bug fix 

**Explain what this PR is doing:**
Fixes issue #1917 so ships actually delete themselves when they have no blocks

---

## Modloaders this PR affects:
- [ ] Forge
- [ ] Fabric

## Where this PR was tested:
- [ ] In-dev singleplayer


## Breaking Changes
- [ ] No

---


## Additional Notes
Anything else reviewers might need to know:
Performance concerns, edge cases, etc

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
