### PR TITLE
Fix game crash when a mod removes a dimension.

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/server/MixinMinecraftServer.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/server/MixinMinecraftServer.java
@@ -193,7 +193,7 @@ public abstract class MixinMinecraftServer implements IShipObjectWorldServerProv
             .map(VSGameUtilsKt::getPlayerWrapper).collect(Collectors.toSet());
         shipWorld.setPlayers(vsPlayers);
 
-        // region Tell the VS world to load new levels, and unload deleted ones
+        // region Tell the VS world to load new levels
         final Map<String, ServerLevel> newLoadedLevels = new HashMap<>();
         for (final ServerLevel level : getAllLevels()) {
             final String dimensionId = VSGameUtilsKt.getDimensionId(level);
@@ -209,6 +209,12 @@ public abstract class MixinMinecraftServer implements IShipObjectWorldServerProv
         }
         */
 
+        // endregion
+
+        vsPipeline.preTickGame();
+
+        // region Tell VS to unload deleted levels and update the loaded level set.
+        // VsiServerShipWorld::removeDimension must happen after the PRE_TICK stage, otherwise the game crashes.
         for (final String oldLoadedLevelId : loadedLevels) {
             if (!newLoadedLevels.containsKey(oldLoadedLevelId)) {
                 shipWorld.removeDimension(oldLoadedLevelId);
@@ -217,8 +223,6 @@ public abstract class MixinMinecraftServer implements IShipObjectWorldServerProv
         }
         loadedLevels = newLoadedLevels.keySet();
         // endregion
-
-        vsPipeline.preTickGame();
     }
 
     /**


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [x] Compat with another mod

**Explain what this PR is doing:**
Right now, if any mod tries to remove a dimension while the game is running, Valkyrien Skies will crash the game with the following exception:
```
org.valkyrienskies.core.impl.shadow.Gf: Constraints failed. Stages since last reset: [PRE_TICK, GET_LAST_TICK_CHANGES, UPDATE_CHUNKS, UPDATE_CHUNKS, UPDATE_CHUNKS, UPDATE_CHUNKS, UPDATE_CHUNKS, UPDATE_CHUNKS, UPDATE_CHUNKS, UPDATE_CHUNKS, UPDATE_CHUNKS, POST_TICK_START, POST_TICK_GENERATED, POST_TICK_FINISH, GET_CURRENT_TICK_CHANGES, CLEAR_FOR_RESET, UPDATE_PLAYERS, UPDATE_DIMENSIONS]
Required stages matching predicate in the following order: [PRE_TICK, oneOf[UPDATE_DIMENSIONS, UPDATE_BLOCKS, UPDATE_CHUNKS], POST_TICK_START, POST_TICK_GENERATED, POST_TICK_FINISH, CLEAR_FOR_RESET, UPDATE_PLAYERS]
```
As you can see, the UPDATE_DIMENSIONS stage is placed at the end of the previous state rather than after PRE_TICK in the next state where it is supposed to be.

This PR fixes that bug by making sure the dimension removal always happens after the PRE_TICK state rather than before it.

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [x] In-dev dedicated server
- [x] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [x] No

---


## Additional Notes
Anything else reviewers might need to know:
Performance concerns, edge cases, etc

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
