### PR TITLE
Add dev wiki to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Valkyrien Skies
 <a href="https://discord.gg/rG3QNDV"><img src="https://img.shields.io/badge/Discord-white?style=for-the-badge&logo=discord" alt="Discord"></a>
 </p>
 
+<h2 align="center">
+<a href="https://docs.valkyrienskies.org"><b>Developer Wiki</b></a>
+</h2>
+
 *The physics mod to end all other physics mods. Better compatibility,
 performance, collisions, interactions and physics than anything prior!*
 


### PR DESCRIPTION
Adds the developer wiki link to the README so that people can find it.

The link is big and ugly, but I _really_ don't want people to skip past it by accident and not find the wiki. I'm open to suggestions on how to keep it obvious but prettier.

What it looks like:
<img width="1020" height="472" alt="image" src="https://github.com/user-attachments/assets/357978f3-2042-4a87-924c-b53482b57063" />
