### PR TITLE
Make block data sync to clients and allow servers to disable syncing

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mass_tooltip/MixinBlockItem.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mass_tooltip/MixinBlockItem.java
@@ -25,7 +25,7 @@ public class MixinBlockItem {
     private void ValkyrienSkies$addMassToTooltip(final ItemStack itemStack, final Level level,
         final List<Component> list, final TooltipFlag tooltipFlag, final CallbackInfo ci) {
         final MassTooltipVisibility visibility = VSGameConfig.CLIENT.getTooltip().getMassTooltipVisibility();
-        if (visibility.isVisible(tooltipFlag) && ClientBlockStateInfo.INSTANCE.getEnabled()) {
+        if (visibility.isVisible(tooltipFlag) && ClientBlockStateInfo.INSTANCE.getShouldAddMassTooltip()) {
             try {
                 final BlockItem item = (BlockItem) itemStack.getItem();
                 final ClientBlockInfo info = ClientBlockStateInfo.INSTANCE.getBlockInfo(BuiltInRegistries.BLOCK.getKey(item.getBlock()));

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mass_tooltip/MixinBlockItem.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mass_tooltip/MixinBlockItem.java
@@ -1,8 +1,8 @@
 package org.valkyrienskies.mod.mixin.feature.mass_tooltip;
 
 import java.util.List;
-import java.util.Objects;
 import net.minecraft.ChatFormatting;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
@@ -13,7 +13,8 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.valkyrienskies.mod.common.BlockStateInfo;
+import org.valkyrienskies.mod.client.ClientBlockInfo;
+import org.valkyrienskies.mod.client.ClientBlockStateInfo;
 import org.valkyrienskies.mod.common.config.VSGameConfig;
 import org.valkyrienskies.mod.mixinducks.feature.mass_tooltip.MassTooltipVisibility;
 import oshi.util.tuples.Pair;
@@ -24,12 +25,11 @@ public class MixinBlockItem {
     private void ValkyrienSkies$addMassToTooltip(final ItemStack itemStack, final Level level,
         final List<Component> list, final TooltipFlag tooltipFlag, final CallbackInfo ci) {
         final MassTooltipVisibility visibility = VSGameConfig.CLIENT.getTooltip().getMassTooltipVisibility();
-        if (visibility.isVisible(tooltipFlag)) {
+        if (visibility.isVisible(tooltipFlag) && ClientBlockStateInfo.INSTANCE.getEnabled()) {
             try {
                 final BlockItem item = (BlockItem) itemStack.getItem();
-                final Double mass =
-                    Objects.requireNonNull(BlockStateInfo.INSTANCE.get(item.getBlock().defaultBlockState()))
-                        .getFirst();
+                final ClientBlockInfo info = ClientBlockStateInfo.INSTANCE.getBlockInfo(BuiltInRegistries.BLOCK.getKey(item.getBlock()));
+                final double mass = info != null ? info.getMass() : 1000;
                 list.add(Component.translatable("tooltip.valkyrienskies.mass")
                     .append(VSGameConfig.CLIENT.getTooltip().getUseImperialUnits() ?
                         getImperialText(mass) : ": " + mass + "kg").withStyle(ChatFormatting.DARK_GRAY));

--- a/common/src/main/kotlin/org/valkyrienskies/mod/client/ClientBlockStateInfo.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/client/ClientBlockStateInfo.kt
@@ -21,7 +21,7 @@ object ClientBlockStateInfo {
      * Set by server and used on client side, disables mass tooltip completely if false
      */
     @ApiStatus.Internal
-    var enabled = false
+    var shouldAddMassTooltip = false
 
     /**
      * Used to register clientside block data. For internal use only.
@@ -40,7 +40,7 @@ object ClientBlockStateInfo {
      */
     @ApiStatus.Internal
     fun disable() {
-        enabled = false
+        shouldAddMassTooltip = false
         idToBlockData.clear()
     }
 }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/client/ClientBlockStateInfo.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/client/ClientBlockStateInfo.kt
@@ -1,0 +1,46 @@
+package org.valkyrienskies.mod.client
+
+import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.block.state.BlockState
+import org.jetbrains.annotations.ApiStatus
+
+data class ClientBlockInfo(
+    val mass: Double,
+    val friction: Double,
+    val elasticity: Double,
+)
+
+/**
+ * For getting block mass, friction, and elasticity on the client side
+ */
+object ClientBlockStateInfo {
+    private val idToBlockData: MutableMap<ResourceLocation, ClientBlockInfo> = HashMap()
+
+    /**
+     * Set by server and used on client side, disables mass tooltip completely if false
+     */
+    @ApiStatus.Internal
+    var enabled = false
+
+    /**
+     * Used to register clientside block data. For internal use only.
+     */
+    @ApiStatus.Internal
+    fun registerBlockInfo(id: ResourceLocation, clientBlockInfo: ClientBlockInfo) {
+        idToBlockData[id] = clientBlockInfo
+    }
+
+    fun getBlockInfo(blockState: BlockState): ClientBlockInfo? = idToBlockData[BuiltInRegistries.BLOCK.getKey(blockState.block)]
+
+    fun getBlockInfo(id: ResourceLocation): ClientBlockInfo? = idToBlockData[id]
+
+    /**
+     * Clears data and disables mass tooltip
+     */
+    @ApiStatus.Internal
+    fun disable() {
+        enabled = false
+        idToBlockData.clear()
+    }
+}

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
@@ -35,7 +35,6 @@ import org.valkyrienskies.mod.api_impl.events.RegisterBlockStateEventImpl
 import org.valkyrienskies.mod.client.ClientBlockInfo
 import org.valkyrienskies.mod.common.BlockStateInfoProvider
 import org.valkyrienskies.mod.common.ValkyrienSkiesMod
-import org.valkyrienskies.mod.common.config.MassDatapackResolver.generateShapeFromVoxel
 import org.valkyrienskies.mod.common.hooks.VSGameEvents
 import org.valkyrienskies.mod.common.networking.PacketSyncBlockStateInfo
 import org.valkyrienskies.mod.common.util.MinecraftPlayer
@@ -460,7 +459,7 @@ object MassDatapackResolver : BlockStateInfoProvider {
     fun syncBlockStates(player: MinecraftPlayer) {
         logger.info("Syncing ${mcBlockStateToVs.size} blockstates to ${player.uuid}")
         with(vsCore.simplePacketNetworking) {
-            val blockstate2VS: Map<String, ClientBlockInfo> =
+            val resourceLoc2VS: Map<String, ClientBlockInfo> =
                 mcBlockStateToVs.entries.associate { (blockState, vsState) ->
                     val id = BuiltInRegistries.BLOCK.getKey(blockState.block)
                     val clientInfo = ClientBlockInfo(
@@ -469,13 +468,13 @@ object MassDatapackResolver : BlockStateInfoProvider {
                         vsState.solidState?.elasticity ?: VSGameConfig.SERVER.defaultBlockElasticity,
                     )
                     id.toString() to clientInfo
-                }
-                    .toMap()
+                }.toMap()
 
-            PacketSyncBlockStateInfo(blockstate2VS).sendToClient(player)
+            PacketSyncBlockStateInfo(resourceLoc2VS).sendToClient(player)
         }
     }
 
+    @ApiStatus.Internal
     fun clearBlockStates(player: MinecraftPlayer) {
         logger.info("Clearing synced blockstates from ${player.uuid}")
         with(vsCore.simplePacketNetworking) {

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/MassDatapackResolver.kt
@@ -16,11 +16,12 @@ import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.Blocks
 import net.minecraft.world.level.block.entity.BlockEntity
 import net.minecraft.world.level.block.state.BlockState
+import net.minecraft.world.level.material.FlowingFluid
 import net.minecraft.world.level.material.Fluid
 import net.minecraft.world.level.material.FluidState
 import net.minecraft.world.level.material.Fluids
-import net.minecraft.world.level.material.FlowingFluid
 import net.minecraft.world.phys.shapes.VoxelShape
+import org.jetbrains.annotations.ApiStatus
 import org.joml.Vector3d
 import org.joml.primitives.AABBi
 import org.joml.primitives.AABBic
@@ -31,9 +32,13 @@ import org.valkyrienskies.core.api.physics.blockstates.SolidBlockShape
 import org.valkyrienskies.core.internal.physics.blockstates.VsiBlockState
 import org.valkyrienskies.core.internal.world.chunks.VsiBlockType
 import org.valkyrienskies.mod.api_impl.events.RegisterBlockStateEventImpl
+import org.valkyrienskies.mod.client.ClientBlockInfo
 import org.valkyrienskies.mod.common.BlockStateInfoProvider
 import org.valkyrienskies.mod.common.ValkyrienSkiesMod
+import org.valkyrienskies.mod.common.config.MassDatapackResolver.generateShapeFromVoxel
 import org.valkyrienskies.mod.common.hooks.VSGameEvents
+import org.valkyrienskies.mod.common.networking.PacketSyncBlockStateInfo
+import org.valkyrienskies.mod.common.util.MinecraftPlayer
 import org.valkyrienskies.mod.common.vsCore
 import org.valkyrienskies.mod.mixin.accessors.world.level.block.SlabBlockAccessor
 import org.valkyrienskies.mod.mixin.accessors.world.level.block.StairBlockAccessor
@@ -48,7 +53,7 @@ private data class VSBlockStateInfo(
     val friction: Double,
     val elasticity: Double,
     val type: VsiBlockType?,
-    val noCollisionOverride: Boolean?,
+    val noCollision: Boolean?,
 )
 
 object MassDatapackResolver : BlockStateInfoProvider {
@@ -135,7 +140,7 @@ object MassDatapackResolver : BlockStateInfoProvider {
                             add(
                                 VSBlockStateInfo(
                                     BuiltInRegistries.BLOCK.getKey(it.value()), tagInfo.priority, tagInfo.mass, tagInfo.friction,
-                                    tagInfo.elasticity, tagInfo.type, tagInfo.noCollisionOverride
+                                    tagInfo.elasticity, tagInfo.type, tagInfo.noCollision
                                 )
                             )
                         }
@@ -162,22 +167,21 @@ object MassDatapackResolver : BlockStateInfoProvider {
 
         private fun parse(element: JsonElement, origin: ResourceLocation) {
             val tag = element.asJsonObject["tag"]?.asString
-            val weight = element.asJsonObject["mass"]?.asDouble
-                ?: throw IllegalArgumentException("No mass in file $origin")
+            val weight = element.asJsonObject["mass"]?.asDouble ?: VSGameConfig.SERVER.defaultBlockMass
             val friction = element.asJsonObject["friction"]?.asDouble ?: VSGameConfig.SERVER.defaultBlockFriction
             val elasticity = element.asJsonObject["elasticity"]?.asDouble ?: VSGameConfig.SERVER.defaultBlockElasticity
 
             val priority = element.asJsonObject["priority"]?.asInt ?: decideDefaultPriority(origin)
 
-            val overrideNoCollision = element.asJsonObject["no_collision"]?.asBoolean
+            val noCollision = element.asJsonObject["no_collision"]?.asBoolean ?: false
 
             if (tag != null) {
-                addToBeAddedTags(VSBlockStateInfo(ResourceLocation(tag), priority, weight, friction, elasticity, null, overrideNoCollision))
+                addToBeAddedTags(VSBlockStateInfo(ResourceLocation(tag), priority, weight, friction, elasticity, null, noCollision))
             } else {
                 val block = element.asJsonObject["block"]?.asString
                     ?: throw IllegalArgumentException("No block or tag in file $origin")
 
-                add(VSBlockStateInfo(ResourceLocation(block), priority, weight, friction, elasticity, null, overrideNoCollision))
+                add(VSBlockStateInfo(ResourceLocation(block), priority, weight, friction, elasticity, null, noCollision))
             }
         }
     }
@@ -418,8 +422,8 @@ object MassDatapackResolver : BlockStateInfoProvider {
 
                     val vsBlockStateInfo = map[BuiltInRegistries.BLOCK.getKey(blockState.block)]
 
-                    // If overrideNoCollision is set to true in datapack, force it to have no collision shape
-                    if (vsBlockStateInfo?.noCollisionOverride ?: false) {
+                    // If noCollision is set to true in datapack, force it to have no collision shape
+                    if (vsBlockStateInfo?.noCollision ?: false) {
                         // Won't ever be null with an empty list
                         collisionShape = vsCore.solidShapeUtils.generateShapeFromBoxes(mutableListOf())!!
                     }
@@ -447,6 +451,36 @@ object MassDatapackResolver : BlockStateInfoProvider {
 
         runRegisterBlockStateEvent()
         registeredBlocks = true
+    }
+
+    /**
+     * For internal use only, used to sync blockstate info from server to client and should not be called otherwise.
+     */
+    @ApiStatus.Internal
+    fun syncBlockStates(player: MinecraftPlayer) {
+        logger.info("Syncing ${mcBlockStateToVs.size} blockstates to ${player.uuid}")
+        with(vsCore.simplePacketNetworking) {
+            val blockstate2VS: Map<String, ClientBlockInfo> =
+                mcBlockStateToVs.entries.associate { (blockState, vsState) ->
+                    val id = BuiltInRegistries.BLOCK.getKey(blockState.block)
+                    val clientInfo = ClientBlockInfo(
+                        getBlockStateMass(blockState) ?: VSGameConfig.SERVER.defaultBlockMass,
+                        vsState.solidState?.friction ?: VSGameConfig.SERVER.defaultBlockFriction,
+                        vsState.solidState?.elasticity ?: VSGameConfig.SERVER.defaultBlockElasticity,
+                    )
+                    id.toString() to clientInfo
+                }
+                    .toMap()
+
+            PacketSyncBlockStateInfo(blockstate2VS).sendToClient(player)
+        }
+    }
+
+    fun clearBlockStates(player: MinecraftPlayer) {
+        logger.info("Clearing synced blockstates from ${player.uuid}")
+        with(vsCore.simplePacketNetworking) {
+            PacketSyncBlockStateInfo(HashMap()).sendToClient(player)
+        }
     }
 
     private fun runRegisterBlockStateEvent() {

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -395,6 +395,11 @@ object VSGameConfig {
         var minScaling = 0.25
 
         @ConfigEntry(
+            description = "If players can see block info (mass, friction, elasticity)"
+        )
+        var allowBlockInfo = true
+
+        @ConfigEntry(
             description = "Default mass for blocks that do not have it defined in data or code. Blocks with masses below 100 float in water"
         )
         var defaultBlockMass = 1000.0

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/config/VSGameConfig.kt
@@ -397,7 +397,7 @@ object VSGameConfig {
         @ConfigEntry(
             description = "If players can see block info (mass, friction, elasticity)"
         )
-        var allowBlockInfo = true
+        var allowBlockInfo = true // they call me jade because i be showin block info
 
         @ConfigEntry(
             description = "Default mass for blocks that do not have it defined in data or code. Blocks with masses below 100 float in water"

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/PacketSyncBlockStateInfo.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/PacketSyncBlockStateInfo.kt
@@ -1,0 +1,11 @@
+package org.valkyrienskies.mod.common.networking
+
+import org.valkyrienskies.core.impl.networking.simple.SimplePacket
+import org.valkyrienskies.mod.client.ClientBlockInfo
+
+/**
+ * Packet to sync datapack-defined blockstate info from server to client
+ */
+data class PacketSyncBlockStateInfo(
+    val blockState2VS: Map<String, ClientBlockInfo>
+) : SimplePacket

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/VSGamePackets.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/VSGamePackets.kt
@@ -72,12 +72,13 @@ object VSGamePackets {
             }
         }
 
+        // sync mass/friction/elasticity to the client
         PacketSyncBlockStateInfo::class.registerClientHandler { syncBsi ->
             if (syncBsi.blockState2VS.isEmpty()) {
                 ClientBlockStateInfo.disable()
             } else {
+                ClientBlockStateInfo.shouldAddMassTooltip = true
                 syncBsi.blockState2VS.forEach { (id, state) ->
-                    ClientBlockStateInfo.enabled = true
                     ClientBlockStateInfo.registerBlockInfo(ResourceLocation.of(id, ':'), state)
                 }
             }

--- a/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/VSGamePackets.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/mod/common/networking/VSGamePackets.kt
@@ -13,6 +13,7 @@ import org.valkyrienskies.core.api.attachment.getAttachment
 import org.valkyrienskies.core.api.ships.LoadedServerShip
 import org.valkyrienskies.mod.api.SeatedControllingPlayer
 import org.valkyrienskies.mod.api.shipWorld
+import org.valkyrienskies.mod.client.ClientBlockStateInfo
 import org.valkyrienskies.mod.common.entity.ShipMountingEntity
 import org.valkyrienskies.mod.common.entity.handling.VSEntityManager
 import org.valkyrienskies.mod.common.getLoadedShipManagingPos
@@ -33,6 +34,7 @@ object VSGamePackets {
         PacketStopChunkUpdates::class.register()
         PacketRestartChunkUpdates::class.register()
         PacketSyncVSEntityTypes::class.register()
+        PacketSyncBlockStateInfo::class.register()
         PacketEntityShipMotion::class.register()
         PacketMobShipRotation::class.register()
         PacketPlayerShipMotion::class.register()
@@ -67,6 +69,17 @@ object VSGamePackets {
                     ResourceLocation.tryParse(handler)?.let { VSEntityManager.getHandler(it) }
                         ?: throw IllegalStateException("No handler: $handler")
                 )
+            }
+        }
+
+        PacketSyncBlockStateInfo::class.registerClientHandler { syncBsi ->
+            if (syncBsi.blockState2VS.isEmpty()) {
+                ClientBlockStateInfo.disable()
+            } else {
+                syncBsi.blockState2VS.forEach { (id, state) ->
+                    ClientBlockStateInfo.enabled = true
+                    ClientBlockStateInfo.registerBlockInfo(ResourceLocation.of(id, ':'), state)
+                }
             }
         }
 
@@ -143,38 +156,40 @@ object VSGamePackets {
             }
         }
 
-        // PacketRequestEntityMotion::class.registerServerHandler { motion, player ->
-        //     val player = (player as MinecraftPlayer).player as ServerPlayer?
-        //         ?: return@registerServerHandler
-        //     val level = player.level() ?: return@registerServerHandler
-        //     val entity = level.getEntity(motion.entityId) ?: return@registerServerHandler
-        //
-        //     val dragInfo = (entity as? IEntityDraggingInformationProvider)?.draggingInformation
-        //         ?: return@registerServerHandler
-        //
-        //     val ship = if (dragInfo.lastShipStoodOn != null) {
-        //         (level as ServerLevel).shipObjectWorld.allShips.getById(dragInfo.lastShipStoodOn!!)
-        //     } else {
-        //         null
-        //     }
-        //
-        //     val position = ship.getWorldToShip().transformPosition(new Vector3d(entity.getX(), entity.getY(), entity.getZ()));
-        //     if (dragInfo.getServerRelativePlayerPosition() != null) {
-        //         position = new Vector3d(dragInfo.getServerRelativePlayerPosition());
-        //     }
-        //     Vector3d motion = ship.getTransform().getWorldToShip().transformDirection(new Vector3d(entity.getDeltaMovement().x(), entity.getDeltaMovement().y(), entity.getDeltaMovement().z()), new Vector3d());
-        //     double yaw;
-        //     if (!(t instanceof ClientboundRotateHeadPacket)) {
-        //         yaw = EntityLerper.INSTANCE.yawToShip(ship, entity.getYRot());
-        //     } else {
-        //         yaw = EntityLerper.INSTANCE.yawToShip(ship, entity.getYHeadRot());
-        //     }
-        //     double pitch = entity.getXRot();
-        //     val vsPacket = PacketEntityShipMotion(motion.entityId, ship?.id ?: -1L,
-        //         position.x, position.y, position.z,
-        //         motion.x, motion.y, motion.z,
-        //         yaw, pitch);
-        // }
+        /*
+        PacketRequestEntityMotion::class.registerServerHandler { motion, player ->
+            val player = (player as MinecraftPlayer).player as ServerPlayer?
+                ?: return@registerServerHandler
+            val level = player.level() ?: return@registerServerHandler
+            val entity = level.getEntity(motion.entityId) ?: return@registerServerHandler
+
+            val dragInfo = (entity as? IEntityDraggingInformationProvider)?.draggingInformation
+                ?: return@registerServerHandler
+
+            val ship = if (dragInfo.lastShipStoodOn != null) {
+                (level as ServerLevel).shipObjectWorld.allShips.getById(dragInfo.lastShipStoodOn!!)
+            } else {
+                null
+            }
+
+            val position = ship.getWorldToShip().transformPosition(new Vector3d(entity.getX(), entity.getY(), entity.getZ()));
+            if (dragInfo.getServerRelativePlayerPosition() != null) {
+                position = new Vector3d(dragInfo.getServerRelativePlayerPosition());
+            }
+            Vector3d motion = ship.getTransform().getWorldToShip().transformDirection(new Vector3d(entity.getDeltaMovement().x(), entity.getDeltaMovement().y(), entity.getDeltaMovement().z()), new Vector3d());
+            double yaw;
+            if (!(t instanceof ClientboundRotateHeadPacket)) {
+                yaw = EntityLerper.INSTANCE.yawToShip(ship, entity.getYRot());
+            } else {
+                yaw = EntityLerper.INSTANCE.yawToShip(ship, entity.getYHeadRot());
+            }
+            double pitch = entity.getXRot();
+            val vsPacket = PacketEntityShipMotion(motion.entityId, ship?.id ?: -1L,
+                position.x, position.y, position.z,
+                motion.x, motion.y, motion.z,
+                yaw, pitch);
+        }
+        */
 
         PacketPlayerShipMotion::class.registerServerHandler { motion, iPlayer ->
             val player = (iPlayer as MinecraftPlayer).player as ServerPlayer?

--- a/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/common/ValkyrienSkiesModFabric.kt
+++ b/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/common/ValkyrienSkiesModFabric.kt
@@ -282,13 +282,6 @@ class ValkyrienSkiesModFabric : ModInitializer {
             }
         }
 
-        ServerPlayConnectionEvents.DISCONNECT.register { handler, server ->
-            if (handler.player is ServerPlayer) {
-                val player: MinecraftPlayer = handler.player.playerWrapper
-                MassDatapackResolver.clearBlockStates(player)
-            }
-        }
-
         CommandRegistrationCallback.EVENT.register { dispatcher ,d, _ ->
             VSCommands.registerServerCommands(dispatcher)
         }

--- a/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/common/ValkyrienSkiesModFabric.kt
+++ b/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/common/ValkyrienSkiesModFabric.kt
@@ -13,25 +13,25 @@ import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback
 import net.fabricmc.fabric.api.event.lifecycle.v1.CommonLifecycleEvents
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents
 import net.fabricmc.fabric.api.`object`.builder.v1.block.entity.FabricBlockEntityTypeBuilder
 import net.fabricmc.fabric.api.`object`.builder.v1.entity.FabricDefaultAttributeRegistry
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper
 import net.fabricmc.loader.api.FabricLoader
-import net.minecraft.client.Minecraft
 import net.minecraft.client.multiplayer.ClientLevel
 import net.minecraft.client.renderer.ShaderInstance
 import net.minecraft.client.renderer.entity.EntityRendererProvider.Context
 import net.minecraft.core.Registry
 import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.resources.ResourceLocation
+import net.minecraft.server.level.ServerPlayer
 import net.minecraft.server.packs.PackType.SERVER_DATA
 import net.minecraft.server.packs.resources.PreparableReloadListener.PreparationBarrier
 import net.minecraft.server.packs.resources.ResourceManager
 import net.minecraft.util.profiling.ProfilerFiller
 import net.minecraft.world.entity.EntityType
 import net.minecraft.world.entity.MobCategory
-import net.minecraft.world.item.BlockItem
 import net.minecraft.world.item.CreativeModeTabs
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.Item.Properties
@@ -66,7 +66,6 @@ import org.valkyrienskies.mod.common.blockentity.TestAntigravBlockEntity
 import org.valkyrienskies.mod.common.blockentity.TestHingeBlockEntity
 import org.valkyrienskies.mod.common.blockentity.TestThrusterBlockEntity
 import org.valkyrienskies.mod.common.command.VSCommands
-import org.valkyrienskies.mod.common.config.ConfigType
 import org.valkyrienskies.mod.common.config.DimensionParametersResolver
 import org.valkyrienskies.mod.common.config.MassDatapackResolver
 import org.valkyrienskies.mod.common.config.SlugDatapackResolver
@@ -85,6 +84,8 @@ import org.valkyrienskies.mod.common.item.ShipAssemblerItem
 import org.valkyrienskies.mod.common.item.ShipCreatorItem
 import org.valkyrienskies.mod.common.item.ShipRemoverItem
 import org.valkyrienskies.mod.common.item.VSBlockItem
+import org.valkyrienskies.mod.common.playerWrapper
+import org.valkyrienskies.mod.common.util.MinecraftPlayer
 import org.valkyrienskies.mod.compat.LoadedMods
 import org.valkyrienskies.mod.compat.flywheel.FlywheelCompat
 import org.valkyrienskies.mod.compat.flywheel.ShipEmbeddingManager
@@ -268,6 +269,24 @@ class ValkyrienSkiesModFabric : ModInitializer {
             event.accept(AREA_ASSEMBLER_ITEM)
             event.accept(CLASSIC_AREA_ASSEMBLER_ITEM)
             event.accept(PHYSICS_ENTITY_CREATOR_ITEM)
+        }
+
+        ServerPlayConnectionEvents.JOIN.register { handler, sender, server ->
+            if (handler.player is ServerPlayer) {
+                val player: MinecraftPlayer = handler.player.playerWrapper
+                if (VSGameConfig.SERVER.allowBlockInfo) {
+                    MassDatapackResolver.syncBlockStates(player)
+                } else {
+                    MassDatapackResolver.clearBlockStates(player)
+                }
+            }
+        }
+
+        ServerPlayConnectionEvents.DISCONNECT.register { handler, server ->
+            if (handler.player is ServerPlayer) {
+                val player: MinecraftPlayer = handler.player.playerWrapper
+                MassDatapackResolver.clearBlockStates(player)
+            }
         }
 
         CommandRegistrationCallback.EVENT.register { dispatcher ,d, _ ->

--- a/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ValkyrienSkiesModForge.kt
+++ b/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ValkyrienSkiesModForge.kt
@@ -2,14 +2,13 @@ package org.valkyrienskies.mod.forge.common
 
 import com.mojang.blaze3d.vertex.DefaultVertexFormat
 import dev.engine_room.flywheel.api.event.ReloadLevelRendererEvent
-import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.ShaderInstance
 import net.minecraft.commands.Commands.CommandSelection.ALL
 import net.minecraft.commands.Commands.CommandSelection.INTEGRATED
 import net.minecraft.resources.ResourceLocation
+import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.entity.EntityType
 import net.minecraft.world.entity.MobCategory
-import net.minecraft.world.item.BlockItem
 import net.minecraft.world.item.CreativeModeTabs
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.Item.Properties
@@ -23,6 +22,7 @@ import net.minecraftforge.event.BuildCreativeModeTabContentsEvent
 import net.minecraftforge.event.RegisterCommandsEvent
 import net.minecraftforge.event.TagsUpdatedEvent
 import net.minecraftforge.event.entity.EntityAttributeCreationEvent
+import net.minecraftforge.event.entity.player.PlayerEvent
 import net.minecraftforge.fml.ModList
 import net.minecraftforge.fml.ModLoadingContext
 import net.minecraftforge.fml.common.Mod
@@ -64,7 +64,6 @@ import org.valkyrienskies.mod.common.blockentity.TestAntigravBlockEntity
 import org.valkyrienskies.mod.common.blockentity.TestHingeBlockEntity
 import org.valkyrienskies.mod.common.blockentity.TestThrusterBlockEntity
 import org.valkyrienskies.mod.common.command.VSCommands
-import org.valkyrienskies.mod.common.config.ConfigType
 import org.valkyrienskies.mod.common.config.DimensionParametersResolver
 import org.valkyrienskies.mod.common.config.MassDatapackResolver
 import org.valkyrienskies.mod.common.config.SlugDatapackResolver
@@ -83,6 +82,8 @@ import org.valkyrienskies.mod.common.item.ShipAssemblerItem
 import org.valkyrienskies.mod.common.item.ShipCreatorItem
 import org.valkyrienskies.mod.common.item.ShipRemoverItem
 import org.valkyrienskies.mod.common.item.VSBlockItem
+import org.valkyrienskies.mod.common.playerWrapper
+import org.valkyrienskies.mod.common.util.MinecraftPlayer
 import org.valkyrienskies.mod.compat.LoadedMods
 import org.valkyrienskies.mod.compat.flywheel.ShipEmbeddingManager
 import org.valkyrienskies.mod.forge.compat.dynmap.ForgeDynmapHandler
@@ -158,6 +159,8 @@ class ValkyrienSkiesModForge {
             }
         }
         modBus.addListener(::loadComplete)
+        forgeBus.addListener(::playerJoin)
+        forgeBus.addListener(::playerLeave)
 
         forgeBus.addListener(::registerCommands)
         forgeBus.addListener(::tagsUpdated)
@@ -381,6 +384,24 @@ class ValkyrienSkiesModForge {
 
     private fun tagsUpdated(event: TagsUpdatedEvent) {
         VSGameEvents.tagsAreLoaded.emit(Unit)
+    }
+
+    private fun playerJoin(event: PlayerEvent.PlayerLoggedInEvent) {
+        if (event.entity is ServerPlayer) {
+            val player: MinecraftPlayer = event.entity.playerWrapper
+            if (VSGameConfig.SERVER.allowBlockInfo) {
+                MassDatapackResolver.syncBlockStates(player)
+            } else {
+                MassDatapackResolver.clearBlockStates(player)
+            }
+        }
+    }
+
+    private fun playerLeave(event: PlayerEvent.PlayerLoggedOutEvent) {
+        if (event.entity is ServerPlayer) {
+            val player: MinecraftPlayer = event.entity.playerWrapper
+            MassDatapackResolver.clearBlockStates(player)
+        }
     }
 
     private fun loadComplete(event: FMLLoadCompleteEvent) {

--- a/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ValkyrienSkiesModForge.kt
+++ b/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ValkyrienSkiesModForge.kt
@@ -160,7 +160,6 @@ class ValkyrienSkiesModForge {
         }
         modBus.addListener(::loadComplete)
         forgeBus.addListener(::playerJoin)
-        forgeBus.addListener(::playerLeave)
 
         forgeBus.addListener(::registerCommands)
         forgeBus.addListener(::tagsUpdated)
@@ -394,13 +393,6 @@ class ValkyrienSkiesModForge {
             } else {
                 MassDatapackResolver.clearBlockStates(player)
             }
-        }
-    }
-
-    private fun playerLeave(event: PlayerEvent.PlayerLoggedOutEvent) {
-        if (event.entity is ServerPlayer) {
-            val player: MinecraftPlayer = event.entity.playerWrapper
-            MassDatapackResolver.clearBlockStates(player)
         }
     }
 


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix 
- [x] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**
this pr fixes (implements, since it didn't exist before) clients being able to see block mass on servers by using a packet to sync them on player join. It also allows servers to disable this syncing so that players cannot see block mass (as well as disabling the tooltip)

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [x] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [x] No

---


## Additional Notes
Anything else reviewers might need to know:
Performance concerns, edge cases, etc
Although this contains no breaking changes, #1934 should be updated to use ClientBlockStateInfo for getting block values

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
