### PR TITLE
Don't crash when another mod @Overwrites a vanilla spawn rule

### DIFF
--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinBatShipSpawn.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinBatShipSpawn.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
-@Mixin(Bat.class)
+@Mixin(value = Bat.class, priority = 1500)
 public abstract class MixinBatShipSpawn {
 
     @WrapOperation(
@@ -22,7 +22,8 @@ public abstract class MixinBatShipSpawn {
             value = "INVOKE",
             target = "Lnet/minecraft/core/BlockPos;getY()I",
             ordinal = 0
-        )
+        ),
+        require = 0
     )
     private static int vs$shipBatY(
         final BlockPos pos, final Operation<Integer> original,
@@ -37,7 +38,8 @@ public abstract class MixinBatShipSpawn {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/LevelAccessor;getMaxLocalRawBrightness(Lnet/minecraft/core/BlockPos;)I"
-        )
+        ),
+        require = 0
     )
     private static int vs$shipBatMaxRawBrightness(
         final LevelAccessor level, final BlockPos pos, final Operation<Integer> original

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinDrownedShipSpawn.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinDrownedShipSpawn.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
-@Mixin(Drowned.class)
+@Mixin(value = Drowned.class, priority = 1500)
 public abstract class MixinDrownedShipSpawn {
 
     @WrapOperation(
@@ -17,7 +17,8 @@ public abstract class MixinDrownedShipSpawn {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/core/BlockPos;getY()I"
-        )
+        ),
+        require = 0
     )
     private static int vs$shipDeepEnoughY(
         final BlockPos receiver, final Operation<Integer> original,

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinGlowSquidShipSpawn.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinGlowSquidShipSpawn.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
-@Mixin(GlowSquid.class)
+@Mixin(value = GlowSquid.class, priority = 1500)
 public abstract class MixinGlowSquidShipSpawn {
 
     @WrapOperation(
@@ -21,7 +21,8 @@ public abstract class MixinGlowSquidShipSpawn {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/core/BlockPos;getY()I"
-        )
+        ),
+        require = 0
     )
     private static int vs$shipGlowSquidY(
         final BlockPos pos, final Operation<Integer> original,
@@ -36,7 +37,8 @@ public abstract class MixinGlowSquidShipSpawn {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/ServerLevelAccessor;getRawBrightness(Lnet/minecraft/core/BlockPos;I)I"
-        )
+        ),
+        require = 0
     )
     private static int vs$shipGlowSquidBrightness(
         final ServerLevelAccessor accessor, final BlockPos pos, final int skyDarken,

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinHuskShipSpawn.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinHuskShipSpawn.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
-@Mixin(Husk.class)
+@Mixin(value = Husk.class, priority = 1500)
 public abstract class MixinHuskShipSpawn {
 
     @WrapOperation(
@@ -18,7 +18,8 @@ public abstract class MixinHuskShipSpawn {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/ServerLevelAccessor;canSeeSky(Lnet/minecraft/core/BlockPos;)Z"
-        )
+        ),
+        require = 0
     )
     private static boolean vs$shipAwareCanSeeSky(
         final ServerLevelAccessor instance, final BlockPos pos, final Operation<Boolean> original

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinOcelotShipSpawn.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinOcelotShipSpawn.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
-@Mixin(Ocelot.class)
+@Mixin(value = Ocelot.class, priority = 1500)
 public abstract class MixinOcelotShipSpawn {
 
     @WrapOperation(
@@ -16,7 +16,8 @@ public abstract class MixinOcelotShipSpawn {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/core/BlockPos;getY()I"
-        )
+        ),
+        require = 0
     )
     private int vs$shipOcelotY(final BlockPos pos, final Operation<Integer> original) {
         return VSGameUtilsKt.shipProjectedWorldY(

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinSlimeShipSpawn.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinSlimeShipSpawn.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.valkyrienskies.core.api.ships.Ship;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
-@Mixin(Slime.class)
+@Mixin(value = Slime.class, priority = 1500)
 public abstract class MixinSlimeShipSpawn {
 
     @WrapOperation(
@@ -22,7 +22,8 @@ public abstract class MixinSlimeShipSpawn {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/core/BlockPos;getY()I"
-        )
+        ),
+        require = 0
     )
     private static int vs$shipProjectedY(
         final BlockPos pos, final Operation<Integer> original,
@@ -36,7 +37,8 @@ public abstract class MixinSlimeShipSpawn {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/LevelAccessor;getMaxLocalRawBrightness(Lnet/minecraft/core/BlockPos;)I"
-        )
+        ),
+        require = 0
     )
     private static int vs$shipAwareBrightness(
         final LevelAccessor level, final BlockPos pos, final Operation<Integer> original
@@ -51,7 +53,8 @@ public abstract class MixinSlimeShipSpawn {
         at = @At(
             value = "NEW",
             target = "(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/ChunkPos;"
-        )
+        ),
+        require = 0
     )
     private static ChunkPos vs$slimeChunkUsingWorldFrame(
         final BlockPos pos, final Operation<ChunkPos> original,

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinStrayShipSpawn.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinStrayShipSpawn.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
-@Mixin(Stray.class)
+@Mixin(value = Stray.class, priority = 1500)
 public abstract class MixinStrayShipSpawn {
 
     @WrapOperation(
@@ -18,7 +18,8 @@ public abstract class MixinStrayShipSpawn {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/ServerLevelAccessor;canSeeSky(Lnet/minecraft/core/BlockPos;)Z"
-        )
+        ),
+        require = 0
     )
     private static boolean vs$shipAwareCanSeeSky(
         final ServerLevelAccessor instance, final BlockPos pos, final Operation<Boolean> original

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinTurtleShipSpawn.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinTurtleShipSpawn.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
 
-@Mixin(Turtle.class)
+@Mixin(value = Turtle.class, priority = 1500)
 public abstract class MixinTurtleShipSpawn {
 
     @WrapOperation(
@@ -20,7 +20,8 @@ public abstract class MixinTurtleShipSpawn {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/core/BlockPos;getY()I"
-        )
+        ),
+        require = 0
     )
     private static int vs$shipTurtleY(
         final BlockPos pos, final Operation<Integer> original,

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinWardenSpawn.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinWardenSpawn.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.valkyrienskies.mod.common.util.ShipAwareCollisionUtil;
 
 // Warden.checkSpawnObstruction validates the candidate spawn AABB with level.noCollision, which only checks world chunks; without this wrap a warden could spawn inside ship geometry.
-@Mixin(Warden.class)
+@Mixin(value = Warden.class, priority = 1500)
 public abstract class MixinWardenSpawn {
 
     @WrapOperation(
@@ -20,7 +20,8 @@ public abstract class MixinWardenSpawn {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/LevelReader;noCollision(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Z"
-        )
+        ),
+        require = 0
     )
     private boolean vs$noCollisionIncludingShips(
         final LevelReader levelReader, final Entity entity, final AABB aabb,

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinZombieReinforcementSpawn.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/MixinZombieReinforcementSpawn.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.valkyrienskies.mod.common.util.ShipAwareCollisionUtil;
 
 // Zombie.hurt spawns reinforcement zombies on hard difficulty; each candidate is validated with level.noCollision which only checks world chunks, so reinforcements spawn inside ship geometry at the apparent ship location.
-@Mixin(Zombie.class)
+@Mixin(value = Zombie.class, priority = 1500)
 public abstract class MixinZombieReinforcementSpawn {
 
     @WrapOperation(
@@ -18,7 +18,8 @@ public abstract class MixinZombieReinforcementSpawn {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/Level;noCollision(Lnet/minecraft/world/entity/Entity;)Z"
-        )
+        ),
+        require = 0
     )
     private boolean vs$noCollisionIncludingShips(
         final Level level, final Entity entity, final Operation<Boolean> original

--- a/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/package-info.java
+++ b/common/src/main/java/org/valkyrienskies/mod/mixin/feature/mob_spawning/per_mob/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Per-mob spawn hooks that make vanilla's spawn predicates ship-aware.
+ *
+ * <p>These all wrap vanilla static spawn-rule helpers, which mods love to {@code @Overwrite}. Mixin
+ * refuses to inject into a method merged by another mixin unless our priority is strictly higher, so
+ * at the default 1000 an unrelated overwrite is a hard {@code InvalidInjectionException} at load
+ * time; and once that overwrite wins, the instruction we wrap is usually gone anyway.
+ *
+ * <p>Hence {@code priority = 1500} on every mixin here and {@code require = 0} on every injector: we
+ * apply after a default-priority overwrite and wrap it if the vanilla call survived, and step aside
+ * silently if it did not. The default {@code expect = 1} still warns, so a real mapping regression
+ * stays visible. Stepping aside is correct rather than a compromise — a mod that overwrote the spawn
+ * rule deliberately replaced the very check we were making ship-aware.
+ */
+package org.valkyrienskies.mod.mixin.feature.mob_spawning.per_mob;


### PR DESCRIPTION
## Problem

TerraFirmaGreg's Core mod `@Overwrite`s two of the vanilla spawn-rule helpers we hook, which takes the game down at class-load time:

```
InvalidInjectionException: @At("INVOKE") on Husk::vs$shipAwareCanSeeSky with priority 1000
cannot inject into Husk::m_218996_(...) merged by su.terrafirmagreg.core.mixins.common.minecraft.entities.HuskMixin with priority 1000

InvalidInjectionException: @At("INVOKE") on Slime::vs$shipProjectedY with priority 1000
cannot inject into Slime::m_219112_(...) merged by su.terrafirmagreg.core.mixins.common.minecraft.entities.SlimeMixin with priority 1000
```

Two separate things go wrong:

1. `Injector#findTargetNodes` refuses to inject into a method merged by another mixin unless the injecting mixin's priority is *strictly* greater (`InjectionPoint#checkPriority` is `targetPriority < mixinPriority`). At our default 1000 vs their default 1000, that's a hard failure, and it is thrown during prepare — `require` does not soften it.
2. Even past that check, the instruction we wrap is gone. [TFG's overwrites](https://github.com/TerraFirmaGreg-Team/Core-Modern/blob/main/src/main/java/su/terrafirmagreg/core/mixins/common/minecraft/entities/HuskMixin.java) replace the bodies wholesale — their husk rule is just `checkMonsterSpawnRules(...)` (no `canSeeSky`) and their slime rule is just `checkMobSpawnRules(...)` (no `getY`, no `getMaxLocalRawBrightness`, no `new ChunkPos`).

## Fix

Every mixin in `feature.mob_spawning.per_mob` now declares `priority = 1500`, and every injector in it declares `require = 0`:

- the priority lets us apply *after* a default-priority overwrite and wrap it if the vanilla call is still there;
- `require = 0` lets us quietly step aside when it isn't, instead of trading one crash for `Injection validation failed`.

The default `expect = 1` is untouched, so a wrap that finds nothing still logs a warning — a genuine mapping or version regression stays visible.

Stepping aside is the right behaviour rather than a compromise: a mod that overwrote the vanilla spawn rule has deliberately replaced the very check we were making ship-aware, so mobs just spawn by that mod's rules.

Applied to the whole package rather than only `Husk`/`Slime` — all ten mixins there wrap vanilla static spawn-rule helpers, which are a popular `@Overwrite` target, so they share the failure mode. The rationale is written up once in a new `package-info.java`.

## Testing

`:common:compileJava` passes. Change is annotation-only; no behaviour change when no other mod touches these methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
