### PR TITLE
fix tfc crash

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -169,6 +169,9 @@ dependencies {
     modCompileOnly("curse.maven:connectible-chains-forge-418514:6142294")
     //modRuntimeOnly("curse.maven:connectible-chains-forge-418514:6142294")
 
+    // TerraFirmaCraft
+    modCompileOnly("maven.modrinth:terrafirmacraft:3.2.23")
+
 
     // Add Kotlin for Forge (3.12.0)
     forgeRuntimeLibrary("maven.modrinth:kotlin-for-forge:${kotlin_version}")

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/tfc/MixinChunkData.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/tfc/MixinChunkData.java
@@ -1,0 +1,35 @@
+package org.valkyrienskies.mod.forge.mixin.compat.tfc;
+
+import net.dries007.tfc.world.chunkdata.ChunkData;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.valkyrienskies.mod.common.VS2ChunkAllocator;
+
+// Shipyard chunks skip worldgen (see MixinChunkStatus), so TFC never generates chunk data for them and its capability
+// holds null. Every ChunkData.get overload funnels through this one, so anything that asks TFC about a shipyard chunk
+// - onChunkWatch when a client starts tracking a ship, TFC block ticks on ship blocks - NPEs without this.
+// The priority is above the default 1000 so we can still inject when another mod @Overwrites this method, as
+// TerraFirmaGreg-Core does.
+@Mixin(value = ChunkData.class, remap = false, priority = 1500)
+public class MixinChunkData {
+
+    @Inject(
+        method = "get(Lnet/minecraft/world/level/chunk/LevelChunk;)Lnet/dries007/tfc/world/chunkdata/ChunkData;",
+        at = @At("HEAD"),
+        cancellable = true,
+        require = 0
+    )
+    private static void vs$noChunkDataInShipyard(final LevelChunk chunk, final CallbackInfoReturnable<ChunkData> cir) {
+        if (chunk == null) {
+            return;
+        }
+        final ChunkPos pos = chunk.getPos();
+        if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(pos.x, pos.z)) {
+            cir.setReturnValue(ChunkData.EMPTY);
+        }
+    }
+}

--- a/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/tfc/MixinChunkData.java
+++ b/forge/src/main/java/org/valkyrienskies/mod/forge/mixin/compat/tfc/MixinChunkData.java
@@ -6,6 +6,7 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.valkyrienskies.mod.common.VS2ChunkAllocator;
 
@@ -30,6 +31,24 @@ public class MixinChunkData {
         final ChunkPos pos = chunk.getPos();
         if (VS2ChunkAllocator.INSTANCE.isChunkInShipyardCompanion(pos.x, pos.z)) {
             cir.setReturnValue(ChunkData.EMPTY);
+        }
+    }
+
+    // ChunkData.update is called from ChunkDataProvider#promotePartial with whatever partial ChunkData was tracked
+    // for the ProtoChunk being promoted to a LevelChunk, looked up by removing it from a weak map keyed on the
+    // ProtoChunk instance. Since shipyard chunks skip the worldgen stages that populate that map (see
+    // MixinChunkStatus), the lookup misses and returns null. ChunkDataCapability#setData stores that null with no
+    // check, so the next chunk save NPEs in ChunkDataCapability.serializeNBT. Cancelling here leaves the capability
+    // holding the non-null ChunkData it was attached with instead of being nulled out.
+    @Inject(
+        method = "update(Lnet/minecraft/world/level/chunk/LevelChunk;Lnet/dries007/tfc/world/chunkdata/ChunkData;)V",
+        at = @At("HEAD"),
+        cancellable = true,
+        require = 0
+    )
+    private static void vs$noNullChunkDataUpdate(final LevelChunk chunk, final ChunkData data, final CallbackInfo ci) {
+        if (data == null) {
+            ci.cancel();
         }
     }
 }

--- a/forge/src/main/resources/valkyrienskies-forge.mixins.json
+++ b/forge/src/main/resources/valkyrienskies-forge.mixins.json
@@ -20,6 +20,7 @@
     "compat.mffs.MixinClientPacketHandler",
     "compat.mffs.MixinFrequencyGrid",
     "compat.modular_routers.MixinRouterMenu",
+    "compat.tfc.MixinChunkData",
     "compat.thermalexpansion.MixinTileCoFH",
     "compat.twilightforest.ChunkGeneratorTwilightMixin",
     "entity.MixinBoat",


### PR DESCRIPTION
## What this PR does:
- [x] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [x] Compat with another mod

**Explain what this PR is doing:**
returns tfc's empty chunk data if trying to load in a ship chunk
---

## Modloaders this PR affects:
- [x] Forge
- [ ] Fabric

## Where this PR was tested:
- [ ] In-dev singleplayer
- [ ] In-dev dedicated server
- [x] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [x] No

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
