### PR TITLE
Pass contraptionWorld to contraption block getWing call

### DIFF
--- a/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/common/ContraptionShipyardEntityHandlerFabric.kt
+++ b/fabric/src/main/kotlin/org/valkyrienskies/mod/fabric/common/ContraptionShipyardEntityHandlerFabric.kt
@@ -20,7 +20,7 @@ object ContraptionShipyardEntityHandlerFabric: AbstractShipyardEntityHandler() {
             entity.contraption.blocks.forEach { (pos: BlockPos, blockInfo: StructureTemplate.StructureBlockInfo) ->
                 val block = blockInfo.state.block
                 if (block is WingBlock) {
-                    val wing = block.getWing(null, null, blockInfo.state)
+                    val wing = block.getWing(entity.contraption.contraptionWorld, pos, blockInfo.state)
                     attachment.setWing(entity.wingGroupId, pos.x, pos.y, pos.z, wing)
                 }
             }

--- a/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ContraptionShipyardEntityHandlerForge.kt
+++ b/forge/src/main/kotlin/org/valkyrienskies/mod/forge/common/ContraptionShipyardEntityHandlerForge.kt
@@ -20,7 +20,7 @@ object ContraptionShipyardEntityHandlerForge: AbstractShipyardEntityHandler() {
             entity.contraption.blocks.forEach { (pos: BlockPos, blockInfo: StructureTemplate.StructureBlockInfo) ->
                 val block = blockInfo.state.block
                 if (block is WingBlock) {
-                    val wing = block.getWing(null, null, blockInfo.state)
+                    val wing = block.getWing(entity.contraption.contraptionWorld, pos, blockInfo.state)
                     attachment.setWing(entity.wingGroupId, pos.x, pos.y, pos.z, wing)
                 }
             }


### PR DESCRIPTION
## What this PR does:
- [ ] Bug fix 
- [ ] Feature
- [ ] Code refactor / improvement
- [ ] API addition / improvement
- [ ] Compat with another mod

**Explain what this PR is doing:**
Passed the contraption world inside getWing method, so addons depending implementing WingBlock can create wings using block entity data.

---

## Modloaders this PR affects:
- [x] Forge
- [x] Fabric

## Where this PR was tested:
- [x] In-dev singleplayer
- [ ] In-dev dedicated server
- [ ] Out of dev singleplayer
- [ ] GameTest framework


## Breaking Changes
- [ ] Yes (describe)
- [x] No

---


## Additional Notes
Anything else reviewers might need to know:
Performance concerns, edge cases, etc

---

## Declaration
By submitting this PR, I affirm:  
- Code/data compiles and loads  
- Tests _(if any)_ pass  
- This PR will not brick worlds
